### PR TITLE
Avoid browser cache problem by adding a version token to each asset filename

### DIFF
--- a/src/fontra/__main__.py
+++ b/src/fontra/__main__.py
@@ -1,6 +1,7 @@
 import argparse
 from importlib.metadata import entry_points
 import logging
+import secrets
 from .core.server import FontraServer
 from . import __version__ as fontraVersion
 
@@ -46,6 +47,7 @@ def main():
         httpPort=httpPort,
         projectManager=manager,
         launchWebBrowser=args.launch,
+        versionToken=secrets.token_hex(4),
     )
     server.setup()
     server.run()

--- a/src/fontra/client/core/utils.js
+++ b/src/fontra/client/core/utils.js
@@ -100,24 +100,6 @@ export function hyphenatedToCamelCase(s) {
 }
 
 
-export const VERSION_TOKEN_KEY = "fontra-version-token";
-
-
-export function autoReload() {
-  const savedVersionToken = localStorage.getItem(VERSION_TOKEN_KEY);
-  const cookies = parseCookies(document.cookie);
-  const cookieVersionToken = cookies[VERSION_TOKEN_KEY];
-  if (cookieVersionToken) {
-    localStorage.setItem(VERSION_TOKEN_KEY, cookieVersionToken);
-  }
-  if (savedVersionToken && cookieVersionToken && savedVersionToken !== cookieVersionToken) {
-    window.location.reload();
-    return true;
-  }
-  return false;
-}
-
-
 export const THEME_KEY = "fontra-theme";
 
 

--- a/src/fontra/client/settings.html
+++ b/src/fontra/client/settings.html
@@ -53,10 +53,6 @@ h2 {
 <script type="module">
 
 import { THEME_KEY, themeSwitch } from "./core/utils.js";
-import { autoReload, } from "./core/utils.js";
-
-
-autoReload();
 
 
 function themeSwitchCallback() {

--- a/src/fontra/filesystem/landing.js
+++ b/src/fontra/filesystem/landing.js
@@ -1,13 +1,9 @@
 import { loaderSpinner } from "/core/loader-spinner.js";
 import { getRemoteProxy } from "/core/remote.js";
-import { autoReload, themeSwitchFromLocalStorage } from "/core/utils.js";
+import { themeSwitchFromLocalStorage } from "/core/utils.js";
 
 
 export async function startupLandingPage(authenticateFunc) {
-  if (autoReload()) {
-    // Will reload
-    return;
-  }
   themeSwitchFromLocalStorage();
 
   if (authenticateFunc) {

--- a/src/fontra/filesystem/projectmanager.py
+++ b/src/fontra/filesystem/projectmanager.py
@@ -73,8 +73,10 @@ class FileSystemProjectManager:
     async def authorize(self, request):
         return "yes"  # arbitrary non-false string token
 
-    async def projectPageHandler(self, request):
+    async def projectPageHandler(self, request, filterContent=None):
         html = resources.read_text("fontra.filesystem", "landing.html")
+        if filterContent is not None:
+            html = filterContent(html, "text/html")
         response = web.Response(text=html, content_type="text/html")
         response.set_cookie("fontra-require-login", "false")
         return response

--- a/src/fontra/filesystem/projectmanager.py
+++ b/src/fontra/filesystem/projectmanager.py
@@ -1,5 +1,4 @@
 import argparse
-from contextlib import contextmanager
 from importlib import resources
 from importlib.metadata import entry_points
 import logging

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -24,7 +24,6 @@ import { ValueController } from "../core/value-controller.js";
 import { addItemwise, subItemwise, mulScalar } from "../core/var-funcs.js"
 import {
   THEME_KEY,
-  autoReload,
   makeUPlusStringFromCodePoint,
   hasShortcutModifierKey,
   hyphenatedToCamelCase,
@@ -106,10 +105,6 @@ const drawingParametersDark = {
 export class EditorController {
 
   static async fromWebSocket() {
-    if (autoReload()) {
-      // Will reload
-      return;
-    }
     const pathItems = window.location.pathname.split("/");
     // assert pathItems[0] === ""
     // assert pathItems[1] === "editor"


### PR DESCRIPTION
This fixes #229.

- All outgoing HTML, CSS, and JS can get their links filtered so that a version token gets added
- All incoming static content requests will be checked for the version token, and will return 404 if it doesn't match
- Upon each launch of the Fontra server, use a random string for the version token

TODO:
- [x] rip out not-working autoReload stuff