### PR TITLE
[glyph list] Require double-click to switch glyphs

### DIFF
--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -244,7 +244,7 @@ export class EditorController {
     ];
     this.glyphNamesList = new List("glyphs-list", columnDescriptions);
     this.glyphNamesList.itemEqualFunc = (itemA, itemB) => itemA.glyphName === itemB.glyphName;
-    this.glyphNamesList.addEventListener("listSelectionChanged", async event => {
+    this.glyphNamesList.addEventListener("rowDoubleClicked", async event => {
       const list = event.detail;
       const item = list.items[list.selectedItemIndex];
       await this.glyphNameChangedCallback(item.glyphName);


### PR DESCRIPTION
With this change, you have to double-click in the glyph list, or type enter, for the glyph to be inserted into the scene.

The main drive for this change is the desire to implement drag and drop from the list to a glyph-in-edit-mode to insert components.