### PR TITLE
Migration to Prettier formatting

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+src/fontra/views/editor/edit-behavior.js

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,9 @@
+{
+  "bracketSpacing": true,
+  "printWidth": 88,
+  "semi": true,
+  "quoteProps": "consistent",
+  "singleQuote": false,
+  "tabWidth": 2,
+  "useTabs": false
+}

--- a/src/fontra/client/core/canvas-controller.js
+++ b/src/fontra/client/core/canvas-controller.js
@@ -2,38 +2,41 @@ import { rectCenter, normalizeRect } from "./rectangle.js";
 import { withSavedState } from "./utils.js";
 import { mulScalar } from "./var-funcs.js";
 
-
 const MIN_MAGNIFICATION = 0.005;
 const MAX_MAGNIFICATION = 200;
 
-
 export class CanvasController {
-
   constructor(canvas, drawingParameters) {
-    this.canvas = canvas;  // The HTML5 Canvas object
+    this.canvas = canvas; // The HTML5 Canvas object
     this.context = canvas.getContext("2d");
-    this.sceneView = undefined;  // will be set later
+    this.sceneView = undefined; // will be set later
 
     this.magnification = 1;
-    this.origin = {x: this.canvasWidth / 2, y: 0.85 * this.canvasHeight};  // TODO choose y based on initial canvas height
+    this.origin = { x: this.canvasWidth / 2, y: 0.85 * this.canvasHeight }; // TODO choose y based on initial canvas height
     this.needsUpdate = false;
 
     this.setDrawingParameters(drawingParameters);
 
-    const resizeObserver = new ResizeObserver(entries => {
+    const resizeObserver = new ResizeObserver((entries) => {
       this.setupSize();
       this.draw();
       // console.log('Size changed');
     });
     resizeObserver.observe(this.canvas.parentElement);
 
-    window.addEventListener("resize", event => this.handleResize(event));
-    canvas.addEventListener("wheel", event => this.handleWheel(event));
+    window.addEventListener("resize", (event) => this.handleResize(event));
+    canvas.addEventListener("wheel", (event) => this.handleWheel(event));
 
     // Safari pinch zoom:
-    canvas.addEventListener("gesturestart", event => this.handleSafariGestureStart(event));
-    canvas.addEventListener("gesturechange", event => this.handleSafariGestureChange(event));
-    canvas.addEventListener("gestureend", event => this.handleSafariGestureEnd(event));
+    canvas.addEventListener("gesturestart", (event) =>
+      this.handleSafariGestureStart(event)
+    );
+    canvas.addEventListener("gesturechange", (event) =>
+      this.handleSafariGestureChange(event)
+    );
+    canvas.addEventListener("gestureend", (event) =>
+      this.handleSafariGestureEnd(event)
+    );
 
     // canvas.addEventListener("mousedown", async (e) => this.testing(e));
     // canvas.addEventListener("scroll", this.onEvent.bind(this));
@@ -81,7 +84,7 @@ export class CanvasController {
       this.origin.x += dx;
       this.origin.y += dy;
     }
-    this.previousOffsets = {parentOffsetX, parentOffsetY};
+    this.previousOffsets = { parentOffsetX, parentOffsetY };
   }
 
   setNeedsUpdate() {
@@ -99,7 +102,8 @@ export class CanvasController {
 
   _updateDrawingParameters() {
     this.drawingParameters = mulScalar(
-      this._unscaledDrawingParameters, 1 / this.magnification
+      this._unscaledDrawingParameters,
+      1 / this.magnification
     );
   }
 
@@ -149,7 +153,7 @@ export class CanvasController {
 
   handleSafariGestureChange(event) {
     event.preventDefault();
-    const zoomFactor = this._initialMagnification * event.scale / this.magnification;
+    const zoomFactor = (this._initialMagnification * event.scale) / this.magnification;
     this._doPinchMagnify(event, zoomFactor);
   }
 
@@ -159,11 +163,14 @@ export class CanvasController {
   }
 
   _doPinchMagnify(event, zoomFactor) {
-    const center = this.localPoint({x: event.pageX, y: event.pageY});
+    const center = this.localPoint({ x: event.pageX, y: event.pageY });
     const prevMagnification = this.magnification;
 
     this.magnification = this.magnification * zoomFactor;
-    this.magnification = Math.min(Math.max(this.magnification, MIN_MAGNIFICATION), MAX_MAGNIFICATION);
+    this.magnification = Math.min(
+      Math.max(this.magnification, MIN_MAGNIFICATION),
+      MAX_MAGNIFICATION
+    );
     zoomFactor = this.magnification / prevMagnification;
 
     // adjust origin
@@ -181,7 +188,7 @@ export class CanvasController {
 
   async testing(event) {
     console.log("testing async 1");
-    await new Promise(r => setTimeout(r, 500));
+    await new Promise((r) => setTimeout(r, 500));
     console.log("testing async 2");
   }
 
@@ -189,17 +196,21 @@ export class CanvasController {
 
   localPoint(event) {
     if (event.x === undefined) {
-      event = {"x": event.pageX, "y": event.pageY};
+      event = { x: event.pageX, y: event.pageY };
     }
-    const x = (event.x - this.canvas.parentElement.offsetLeft - this.origin.x) / this.magnification;
-    const y = -(event.y - this.canvas.parentElement.offsetTop - this.origin.y) / this.magnification;
-    return {x: x, y: y}
+    const x =
+      (event.x - this.canvas.parentElement.offsetLeft - this.origin.x) /
+      this.magnification;
+    const y =
+      -(event.y - this.canvas.parentElement.offsetTop - this.origin.y) /
+      this.magnification;
+    return { x: x, y: y };
   }
 
   canvasPoint(point) {
     const x = point.x * this.magnification + this.origin.x;
     const y = -point.y * this.magnification + this.origin.y;
-    return {x: x, y: y}
+    return { x: x, y: y };
   }
 
   get onePixelUnit() {
@@ -211,11 +222,14 @@ export class CanvasController {
     const height = this.canvasHeight;
     const left = this.canvas.parentElement.offsetLeft;
     const top = this.canvas.parentElement.offsetTop;
-    const bottomLeft = this.localPoint({x: 0 + left, y: 0 + top});
-    const topRight = this.localPoint({x: width + left, y: height + top});
-    return normalizeRect(
-      {xMin: bottomLeft.x, yMin: bottomLeft.y, xMax: topRight.x, yMax: topRight.y}
-    );
+    const bottomLeft = this.localPoint({ x: 0 + left, y: 0 + top });
+    const topRight = this.localPoint({ x: width + left, y: height + top });
+    return normalizeRect({
+      xMin: bottomLeft.x,
+      yMin: bottomLeft.y,
+      xMax: topRight.x,
+      yMax: topRight.y,
+    });
   }
 
   setViewBox(viewBox) {
@@ -247,10 +261,9 @@ export class CanvasController {
 
   _dispatchEvent(eventName, detail) {
     const event = new CustomEvent(eventName, {
-      "bubbles": false,
-      "detail": detail,
+      bubbles: false,
+      detail: detail,
     });
     this.canvas.dispatchEvent(event);
   }
-
 }

--- a/src/fontra/client/core/changes.js
+++ b/src/fontra/client/core/changes.js
@@ -1,5 +1,4 @@
 export class ChangeCollector {
-
   constructor(parentCollector, path) {
     this._parentCollector = parentCollector;
     this._path = path;
@@ -30,7 +29,10 @@ export class ChangeCollector {
       if (equalPath(this._path, lastItem(this._parentCollector._forwardChanges)?.p)) {
         this._forwardChanges = lastItem(this._parentCollector._forwardChanges).c;
       } else {
-        this._parentCollector._forwardChanges.push({p: this._path, c: this._forwardChanges});
+        this._parentCollector._forwardChanges.push({
+          p: this._path,
+          c: this._forwardChanges,
+        });
       }
     }
   }
@@ -45,7 +47,10 @@ export class ChangeCollector {
       if (equalPath(this._path, this._parentCollector._rollbackChanges[0]?.p)) {
         this._rollbackChanges = this._parentCollector._rollbackChanges[0].c;
       } else {
-        this._parentCollector._rollbackChanges.splice(0, 0, {p: this._path, c: this._rollbackChanges});
+        this._parentCollector._rollbackChanges.splice(0, 0, {
+          p: this._path,
+          c: this._rollbackChanges,
+        });
       }
     }
   }
@@ -68,12 +73,12 @@ export class ChangeCollector {
 
   addChange(func, ...args) {
     this._ensureForwardChanges();
-    this._forwardChanges.push({f: func, a: args});
+    this._forwardChanges.push({ f: func, a: args });
   }
 
   addRollbackChange(func, ...args) {
     this._ensureRollbackChanges();
-    this._rollbackChanges.splice(0, 0, {f: func, a: args});
+    this._rollbackChanges.splice(0, 0, { f: func, a: args });
   }
 
   subCollector(...path) {
@@ -99,9 +104,7 @@ export class ChangeCollector {
     }
     return ChangeCollector.fromChanges(forwardChanges, rollbackChanges);
   }
-
 }
-
 
 export function consolidateChanges(changes, prefixPath) {
   let change;
@@ -110,14 +113,14 @@ export function consolidateChanges(changes, prefixPath) {
     changes = [changes];
   }
   if (changes.length === 1) {
-    change = {...changes[0]};
+    change = { ...changes[0] };
     path = change.p;
   } else {
     const commonPrefix = findCommonPrefix(changes);
     const numCommonElements = commonPrefix.length;
     if (numCommonElements) {
-      changes = changes.map(change => {
-        const newChange = {...change};
+      changes = changes.map((change) => {
+        const newChange = { ...change };
         newChange.p = change.p.slice(numCommonElements);
         if (!newChange.p.length) {
           delete newChange.p;
@@ -127,15 +130,15 @@ export function consolidateChanges(changes, prefixPath) {
       path = commonPrefix;
     } else {
       // Zap empty p
-      changes = changes.map(change => {
-        const newChange = {...change};
+      changes = changes.map((change) => {
+        const newChange = { ...change };
         if (newChange.p && !newChange.p.length) {
           delete newChange.p;
         }
         return newChange;
       });
     }
-    change = {"c": changes};
+    change = { c: changes };
   }
   if (path?.length) {
     change["p"] = path;
@@ -152,14 +155,13 @@ export function consolidateChanges(changes, prefixPath) {
   return change;
 }
 
-
 function unnestSingleChildren(change) {
   const children = change.c?.map(unnestSingleChildren).filter(hasChange);
 
   if (!children?.length) {
     if (children?.length === 0) {
       // Remove empty children array
-      change = {...change};
+      change = { ...change };
       delete change.c;
     }
     if (!change.f) {
@@ -170,7 +172,7 @@ function unnestSingleChildren(change) {
   }
   // Recursively unnest and prune
   if (children.length !== 1) {
-    change = {...change};
+    change = { ...change };
     change.c = children;
     return change;
   }
@@ -182,7 +184,7 @@ function unnestSingleChildren(change) {
   } else {
     path = childPath;
   }
-  change = {...child};
+  change = { ...child };
   if (path.length) {
     change.p = path;
   } else {
@@ -191,13 +193,11 @@ function unnestSingleChildren(change) {
   return change;
 }
 
-
 function addPathPrefix(change, prefixPath) {
-  const prefixedChanged = {...change};
+  const prefixedChanged = { ...change };
   prefixedChanged.p = prefixPath.concat(prefixedChanged.p || []);
   return prefixedChanged;
 }
-
 
 function findCommonPrefix(changes) {
   const commonPrefix = [];
@@ -226,26 +226,27 @@ function findCommonPrefix(changes) {
   return commonPrefix;
 }
 
-
 const baseChangeFunctions = {
-  "=": (subject, key, item) => subject[key] = item,
+  "=": (subject, key, item) => (subject[key] = item),
   "d": (subject, key) => delete subject[key],
   "-": (subject, index, deleteCount = 1) => subject.splice(index, deleteCount),
   "+": (subject, index, ...items) => subject.splice(index, 0, ...items),
-  ":": (subject, index, deleteCount, ...items) => subject.splice(index, deleteCount, ...items),
+  ":": (subject, index, deleteCount, ...items) =>
+    subject.splice(index, deleteCount, ...items),
 };
-
 
 // TODO: Refactor. These don't really belong here, and should ideally be registered from outside
 const changeFunctions = {
   ...baseChangeFunctions,
   "=xy": (path, pointIndex, x, y) => path.setPointPosition(pointIndex, x, y),
-  "insertContour": (path, contourIndex, contour) => path.insertContour(contourIndex, contour),
+  "insertContour": (path, contourIndex, contour) =>
+    path.insertContour(contourIndex, contour),
   "deleteContour": (path, contourIndex) => path.deleteContour(contourIndex),
-  "deletePoint": (path, contourIndex, contourPointIndex) => path.deletePoint(contourIndex, contourPointIndex),
-  "insertPoint": (path, contourIndex, contourPointIndex, point) => path.insertPoint(contourIndex, contourPointIndex, point),
+  "deletePoint": (path, contourIndex, contourPointIndex) =>
+    path.deletePoint(contourIndex, contourPointIndex),
+  "insertPoint": (path, contourIndex, contourPointIndex, point) =>
+    path.insertPoint(contourIndex, contourPointIndex, point),
 };
-
 
 //
 // A "change" object is a simple JS object containing several
@@ -262,7 +263,6 @@ const changeFunctions = {
 //
 // "c": Array of child changes. Optional.
 //
-
 
 export function applyChange(subject, change) {
   const path = change["p"] || [];
@@ -287,11 +287,9 @@ export function applyChange(subject, change) {
   }
 }
 
-
 export function matchChangePath(change, matchPath) {
   return matchChangePattern(change, patternFromPath(matchPath));
 }
-
 
 function patternFromPath(matchPath) {
   const pattern = {};
@@ -306,7 +304,6 @@ function patternFromPath(matchPath) {
   }
   return pattern;
 }
-
 
 export function matchChangePattern(change, matchPattern) {
   //
@@ -339,7 +336,6 @@ export function matchChangePattern(change, matchPattern) {
   return false;
 }
 
-
 export function filterChangePattern(change, matchPattern, inverse) {
   //
   // Return a subset of the `change` according to the `matchPattern`, or `None`
@@ -369,13 +365,13 @@ export function filterChangePattern(change, matchPattern, inverse) {
 
   const filteredChildren = [];
   for (let childChange of change.c || []) {
-    childChange = filterChangePattern(childChange, node, inverse)
+    childChange = filterChangePattern(childChange, node, inverse);
     if (childChange !== null) {
       filteredChildren.push(childChange);
     }
   }
 
-  const result = {...change, "c": filteredChildren};
+  const result = { ...change, c: filteredChildren };
   if (!inverse) {
     // We've at most matched one or more children, but not the root change
     delete result.f;
@@ -385,18 +381,17 @@ export function filterChangePattern(change, matchPattern, inverse) {
   return normalizeChange(result);
 }
 
-
 function normalizeChange(change) {
   let result;
   const children = change.c || [];
 
   if (!("f" in change) && children.length == 1) {
-      // Turn only child into root change
-      result = {...children[0]};
-      // Prefix child path with original root path
-      result["p"] = (change.p || []).concat(result.p || []);
+    // Turn only child into root change
+    result = { ...children[0] };
+    // Prefix child path with original root path
+    result["p"] = (change.p || []).concat(result.p || []);
   } else {
-    result = {...change};
+    result = { ...change };
   }
 
   if (result.p !== undefined && !result.p.length) {
@@ -418,9 +413,8 @@ function normalizeChange(change) {
     result = null;
   }
 
-  return result
+  return result;
 }
-
 
 export function collectChangePaths(change, depth) {
   //
@@ -433,12 +427,10 @@ export function collectChangePaths(change, depth) {
   }
   const paths = [...pathsSet];
   paths.sort();
-  return paths.map(item => JSON.parse(item));
-
+  return paths.map((item) => JSON.parse(item));
 }
 
-
-function *iterateChangePaths(change, depth, prefix) {
+function* iterateChangePaths(change, depth, prefix) {
   if (!prefix) {
     prefix = [];
   }
@@ -454,7 +446,6 @@ function *iterateChangePaths(change, depth, prefix) {
   }
 }
 
-
 function equalPath(p1, p2) {
   if (p1.length !== p2?.length) {
     return false;
@@ -467,13 +458,11 @@ function equalPath(p1, p2) {
   return true;
 }
 
-
 function lastItem(array) {
   if (array.length) {
     return array[array.length - 1];
   }
 }
-
 
 export function hasChange(obj) {
   // This assumes a change object that has passed through consolidateChanges,

--- a/src/fontra/client/core/cmap.js
+++ b/src/fontra/client/core/cmap.js
@@ -1,6 +1,5 @@
 import { makeUPlusStringFromCodePoint } from "./utils.js";
 
-
 //
 // A `characterMap` is an object with integer numbers representing unicode code
 // points as keys, and glyph names as values. Note: we're using a JS Object, not
@@ -21,7 +20,6 @@ import { makeUPlusStringFromCodePoint } from "./utils.js";
 // matching counterpart (`glyphMap` and `characterMap` respectively) up-to-date.
 //
 
-
 export function makeGlyphMapFromCharacterMap(characterMap) {
   // Return a `glyphMap` constructed from `characterMap`
   const glyphMap = {};
@@ -36,7 +34,6 @@ export function makeGlyphMapFromCharacterMap(characterMap) {
   return glyphMap;
 }
 
-
 export function makeCharacterMapFromGlyphMap(glyphMap, strict = true) {
   // Return a `characterMap` constructed from `glyphMap`
   // If the `strict` flag is `true` (default), an Error is thrown when a code
@@ -45,10 +42,11 @@ export function makeCharacterMapFromGlyphMap(glyphMap, strict = true) {
   for (const [glyphName, unicodes] of Object.entries(glyphMap)) {
     for (const codePoint of unicodes) {
       if (codePoint in characterMap) {
-        const message = (
-          "invalid glyph map: duplicate code point " + 
-          `("${glyphName}", "${characterMap[codePoint]}", ${makeUPlusStringFromCodePoint(codePoint)})`
-        );
+        const message =
+          "invalid glyph map: duplicate code point " +
+          `("${glyphName}", "${
+            characterMap[codePoint]
+          }", ${makeUPlusStringFromCodePoint(codePoint)})`;
         if (strict) {
           throw new Error(message);
         }
@@ -64,7 +62,6 @@ export function makeCharacterMapFromGlyphMap(glyphMap, strict = true) {
   }
   return characterMap;
 }
-
 
 export function getGlyphMapProxy(glyphMap, characterMap) {
   //
@@ -86,8 +83,8 @@ export function getGlyphMapProxy(glyphMap, characterMap) {
       }
       const existingCodePoints = glyphMap[prop] || [];
       glyphMap[prop] = value;
-      existingCodePoints.forEach(codePoint => delete characterMap[codePoint]);
-      value.forEach(codePoint => characterMap[codePoint] = prop);
+      existingCodePoints.forEach((codePoint) => delete characterMap[codePoint]);
+      value.forEach((codePoint) => (characterMap[codePoint] = prop));
       return true;
     },
 
@@ -98,14 +95,13 @@ export function getGlyphMapProxy(glyphMap, characterMap) {
     deleteProperty(glyphMap, prop) {
       const existingCodePoints = glyphMap[prop] || [];
       delete glyphMap[prop];
-      existingCodePoints.forEach(codePoint => delete characterMap[codePoint]);
+      existingCodePoints.forEach((codePoint) => delete characterMap[codePoint]);
       return true;
-    }
-  }
+    },
+  };
 
   return new Proxy(glyphMap, handler);
 }
-
 
 export function getCharacterMapProxy(characterMap, glyphMap) {
   //
@@ -150,12 +146,11 @@ export function getCharacterMapProxy(characterMap, glyphMap) {
         }
       }
       return true;
-    }
-  }
+    },
+  };
 
   return new Proxy(characterMap, handler);
 }
-
 
 function removeReverseMapping(glyphMap, glyphName, codePoint) {
   //
@@ -173,7 +168,6 @@ function removeReverseMapping(glyphMap, glyphName, codePoint) {
   }
 }
 
-
 function arrayDiscardItem(array, item) {
   // Remove `item` from `array` if present
   const index = array.indexOf(item);
@@ -181,7 +175,6 @@ function arrayDiscardItem(array, item) {
     array.splice(index, 1);
   }
 }
-
 
 function arrayInsertSortedItem(array, item) {
   // Insert integer `item` into the sorted `array`, maintaining the sorted order

--- a/src/fontra/client/core/context-menu.js
+++ b/src/fontra/client/core/context-menu.js
@@ -1,17 +1,15 @@
 import { reversed } from "./utils.js";
 
-
 export class ContextMenu {
-
   constructor(elementID, menuItems) {
     this.element = document.querySelector(`#${elementID}`);
 
     this.element.classList.add("visible");
     this.element.focus();
-    this.element.onkeydown = event => this.handleKeyDown(event);
+    this.element.onkeydown = (event) => this.handleKeyDown(event);
 
     this.element.innerHTML = "";
-    this.element.oncontextmenu = event => event.preventDefault();  // No context menu on our context menu please
+    this.element.oncontextmenu = (event) => event.preventDefault(); // No context menu on our context menu please
 
     for (const item of menuItems) {
       const el = document.createElement("div");
@@ -25,14 +23,15 @@ export class ContextMenu {
         itemElement.classList.toggle("enabled", !item.disabled);
         itemElement.innerText = item.title;
         if (!item.disabled) {
-          itemElement.onmouseenter = event => this.selectItem(itemElement);
-          itemElement.onmousemove = event => {
+          itemElement.onmouseenter = (event) => this.selectItem(itemElement);
+          itemElement.onmousemove = (event) => {
             if (!itemElement.classList.contains("selected")) {
               this.selectItem(itemElement);
             }
-          }
-          itemElement.onmouseleave = event => itemElement.classList.remove("selected");
-          itemElement.onclick = event => {
+          };
+          itemElement.onmouseleave = (event) =>
+            itemElement.classList.remove("selected");
+          itemElement.onclick = (event) => {
             if (item.callback) {
               item.callback(event);
             }
@@ -44,11 +43,16 @@ export class ContextMenu {
     }
 
     const container = this.element.parentElement;
-    let {clientX: mouseX, clientY: mouseY} = event;
+    let { clientX: mouseX, clientY: mouseY } = event;
     mouseX -= container.offsetLeft;
     mouseY -= container.offsetTop;
 
-    const [normalizedX, normalizedY] = normalizedPosition(container, this.element, mouseX, mouseY);
+    const [normalizedX, normalizedY] = normalizedPosition(
+      container,
+      this.element,
+      mouseX,
+      mouseY
+    );
 
     this.element.style.top = `${normalizedY - 1}px`;
     this.element.style.left = `${normalizedX + 1}px`;
@@ -67,7 +71,7 @@ export class ContextMenu {
   }
 
   handleKeyDown(event) {
-    switch(event.key) {
+    switch (event.key) {
       case "Escape":
         this.dismiss();
         break;
@@ -118,7 +122,7 @@ export class ContextMenu {
         }
       }
     } else {
-      const f = isNext ? a => a : reversed;
+      const f = isNext ? (a) => a : reversed;
       for (const item of f(this.element.children)) {
         if (item.classList.contains("enabled")) {
           this.selectItem(item);
@@ -127,15 +131,11 @@ export class ContextMenu {
       }
     }
   }
-
 }
 
-
 function normalizedPosition(container, contextMenu, mouseX, mouseY) {
-  const {
-    left: containerOffsetX,
-    top: containerOffsetY,
-  } = container.getBoundingClientRect();
+  const { left: containerOffsetX, top: containerOffsetY } =
+    container.getBoundingClientRect();
 
   const containerX = mouseX - containerOffsetX;
   const containerY = mouseY - containerOffsetY;

--- a/src/fontra/client/core/convex-hull.js
+++ b/src/fontra/client/core/convex-hull.js
@@ -1,7 +1,6 @@
 import { equalRect, normalizeRect, sectRect } from "./rectangle.js";
 import { reversed } from "./utils.js";
 
-
 export function pointInConvexPolygon(x, y, polygon) {
   // Adapted from a comment on
   // https://stackoverflow.com/questions/1119627/how-to-test-if-a-point-is-inside-of-a-convex-polygon-in-2d-integer-coordinates
@@ -11,7 +10,7 @@ export function pointInConvexPolygon(x, y, polygon) {
     return false;
   }
 
-  const testPoint = {"x": x, "y": y};
+  const testPoint = { x: x, y: y };
 
   // n>2 Keep track of cross product sign changes
   let pos = 0;
@@ -46,7 +45,6 @@ export function pointInConvexPolygon(x, y, polygon) {
   return true;
 }
 
-
 export function rectIntersectsPolygon(rect, polygon) {
   // Return true when the rectangle intersects the polygon, or if the
   // polygon is fully enclosed by the rectangle. It misses the case
@@ -62,14 +60,12 @@ export function rectIntersectsPolygon(rect, polygon) {
   return false;
 }
 
-
-const EPSILON = 0.0001;  // we deal with font units, this should be small enough
-
+const EPSILON = 0.0001; // we deal with font units, this should be small enough
 
 function lineIntersectsRect(p1, p2, rect) {
   // Return true if line p1,p2 intersects any of the sides of rect,
   // or if it is fully enclosed by rect.
-  const lineRect = normalizeRect({"xMin": p1.x, "yMin": p1.y, "xMax": p2.x, "yMax": p2.y});
+  const lineRect = normalizeRect({ xMin: p1.x, yMin: p1.y, xMax: p2.x, yMax: p2.y });
   const lineSectRect = sectRect(rect, lineRect);
   if (!lineSectRect) {
     return false;
@@ -92,7 +88,7 @@ function lineIntersectsRect(p1, p2, rect) {
     }
     const v = [p1.y + t[0] * dy, p1.y + t[1] * dy];
     v.sort(compare);
-    return (v[0] <= rect.yMax && v[1] >= rect.yMin);
+    return v[0] <= rect.yMax && v[1] >= rect.yMin;
   } else {
     const t = clipT(p1.y, dy, rect.yMin, rect.yMax);
     if (!t) {
@@ -100,11 +96,10 @@ function lineIntersectsRect(p1, p2, rect) {
     }
     const v = [p1.x + t[0] * dx, p1.x + t[1] * dx];
     v.sort(compare);
-    return (v[0] <= rect.xMax && v[1] >= rect.xMin);
+    return v[0] <= rect.xMax && v[1] >= rect.xMin;
   }
-  return false;  // unreachable
+  return false; // unreachable
 }
-
 
 function clipT(a, b, minimum, maximum) {
   const t = [(minimum - a) / b, (maximum - a) / b];
@@ -118,12 +113,10 @@ function clipT(a, b, minimum, maximum) {
   return t[0] <= t[1] ? t : undefined;
 }
 
-
 function compare(a, b) {
   // Return -1 when a < b, 1 when a > b, and 0 when a == b
   return (a > b) - (a < b);
 }
-
 
 export function convexHull(points) {
   // Adapted from https://en.wikipedia.org/wiki/Graham_scan
@@ -140,13 +133,15 @@ export function convexHull(points) {
   return upper.concat(lower);
 }
 
-
 function halfConvexHull(points) {
   // Returns half of the convex hull for a set of sorted points.
   // Call with the points reversed for the other half.
   const stack = [];
   for (const point of points) {
-    while (stack.length > 1 && ccw(stack[stack.length-2], stack[stack.length-1], point) <= 0) {
+    while (
+      stack.length > 1 &&
+      ccw(stack[stack.length - 2], stack[stack.length - 1], point) <= 0
+    ) {
       stack.pop();
     }
     stack.push(point);
@@ -154,7 +149,6 @@ function halfConvexHull(points) {
   stack.pop();
   return stack;
 }
-
 
 function ccw(p1, p2, p3) {
   // Return a positive number if p1,p2,p3 make a counter-clockwise turn,

--- a/src/fontra/client/core/errors.js
+++ b/src/fontra/client/core/errors.js
@@ -10,4 +10,4 @@ export class VariationError extends Error {
     super(message);
     this.name = "VariationError";
   }
-};
+}

--- a/src/fontra/client/core/font-controller.js
+++ b/src/fontra/client/core/font-controller.js
@@ -12,25 +12,22 @@ import { StaticGlyph, VariableGlyph } from "./var-glyph.js";
 import { locationToString } from "./var-model.js";
 import { throttleCalls } from "./utils.js";
 
-
 const GLYPH_CACHE_SIZE = 1000;
 
-
 export class FontController {
-
-  constructor (font, location) {
+  constructor(font, location) {
     this.font = font;
     this.location = location;
-    this._glyphsPromiseCache = new LRUCache(GLYPH_CACHE_SIZE);  // glyph name -> var-glyph promise
-    this._glyphInstancePromiseCache = new LRUCache(GLYPH_CACHE_SIZE);  // instance cache key -> instance promise
-    this._glyphInstancePromiseCacheKeys = {};  // glyphName -> Set(instance cache keys)
+    this._glyphsPromiseCache = new LRUCache(GLYPH_CACHE_SIZE); // glyph name -> var-glyph promise
+    this._glyphInstancePromiseCache = new LRUCache(GLYPH_CACHE_SIZE); // instance cache key -> instance promise
+    this._glyphInstancePromiseCacheKeys = {}; // glyphName -> Set(instance cache keys)
     this._editListeners = new Set();
-    this.glyphUsedBy = {};  // Loaded glyphs only: this is for updating the scene
+    this.glyphUsedBy = {}; // Loaded glyphs only: this is for updating the scene
     this.glyphMadeOf = {};
     this.ensureInitialized = new Promise((resolve, reject) => {
       this._resolveInitialized = resolve;
     });
-    this.undoStacks = {};  // glyph name -> undo stack
+    this.undoStacks = {}; // glyph name -> undo stack
     this._rootObject = {};
   }
 
@@ -148,14 +145,16 @@ export class FontController {
       throw new Error(`assert -- glyph "${glyphName}" already exists`);
     }
     if (codePoint && typeof codePoint != "number") {
-      throw new Error(`assert -- codePoint must be an integer or falsey, got ${typeof codePoint}`);
+      throw new Error(
+        `assert -- codePoint must be an integer or falsey, got ${typeof codePoint}`
+      );
     }
-    const sourceName = "<default>";  // TODO: get from backend (via namedLocations?)
+    const sourceName = "<default>"; // TODO: get from backend (via namedLocations?)
 
     const glyph = VariableGlyph.fromObject({
-      "name": glyphName,
-      "sources": [{"name": sourceName, "location": {}, "layerName": sourceName}],
-      "layers": [{"name": sourceName, glyph: structuredClone(templateInstance)}],
+      name: glyphName,
+      sources: [{ name: sourceName, location: {}, layerName: sourceName }],
+      layers: [{ name: sourceName, glyph: structuredClone(templateInstance) }],
     });
     const glyphController = new VariableGlyphController(glyph, this.globalAxes);
     this._glyphsPromiseCache.put(glyphName, Promise.resolve(glyphController));
@@ -165,26 +164,30 @@ export class FontController {
 
     await this.glyphChanged(glyphName);
 
-    const change = {"c":
-      [
-        {"p": ["glyphs"], "f": "=", "a": [glyphName, glyph]},
-        {"p": ["glyphMap"], "f": "=", "a": [glyphName, codePoints]},
+    const change = {
+      c: [
+        { p: ["glyphs"], f: "=", a: [glyphName, glyph] },
+        { p: ["glyphMap"], f: "=", a: [glyphName, codePoints] },
       ],
     };
-    const rollbackChange = {"c":
-      [
-        {"p": ["glyphs"], "f": "d", "a": [glyphName]},
-        {"p": ["glyphMap"], "f": "d", "a": [glyphName]},
+    const rollbackChange = {
+      c: [
+        { p: ["glyphs"], f: "d", a: [glyphName] },
+        { p: ["glyphMap"], f: "d", a: [glyphName] },
       ],
-    }
+    };
     const error = await this.font.editFinal(
-      change, rollbackChange, `new glyph "${glyphName}"`, true);
+      change,
+      rollbackChange,
+      `new glyph "${glyphName}"`,
+      true
+    );
     // TODO handle error
     this.notifyEditListeners("editFinal", this);
   }
 
   async glyphChanged(glyphName) {
-    const glyphNames = [glyphName, ...this.iterGlyphUsedBy(glyphName)]
+    const glyphNames = [glyphName, ...this.iterGlyphUsedBy(glyphName)];
     for (const glyphName of glyphNames) {
       this._purgeInstanceCache(glyphName);
     }
@@ -205,7 +208,10 @@ export class FontController {
     let instancePromise = this._glyphInstancePromiseCache.get(instanceCacheKey);
     if (instancePromise === undefined) {
       instancePromise = this._getGlyphInstance(glyphName, location, instanceCacheKey);
-      const deletedItem = this._glyphInstancePromiseCache.put(instanceCacheKey, instancePromise);
+      const deletedItem = this._glyphInstancePromiseCache.put(
+        instanceCacheKey,
+        instancePromise
+      );
       if (deletedItem !== undefined) {
         const chacheGlyphName = (await deletedItem.value)?.name;
         this._glyphInstancePromiseCacheKeys[chacheGlyphName]?.delete(instanceCacheKey);
@@ -221,12 +227,15 @@ export class FontController {
   async _getGlyphInstance(glyphName, location) {
     const varGlyph = await this.getGlyph(glyphName);
     const getGlyphFunc = this.getGlyph.bind(this);
-    const instanceController = await varGlyph.instantiateController(location, getGlyphFunc);
+    const instanceController = await varGlyph.instantiateController(
+      location,
+      getGlyphFunc
+    );
     return instanceController;
   }
 
   getDummyGlyphInstanceController(glyphName = "<dummy>") {
-    const dummyGlyph = StaticGlyph.fromObject({"xAdvance": this.unitsPerEm / 2});
+    const dummyGlyph = StaticGlyph.fromObject({ xAdvance: this.unitsPerEm / 2 });
     return new StaticGlyphController(glyphName, dummyGlyph, undefined);
   }
 
@@ -320,7 +329,8 @@ export class FontController {
   }
 
   _purgeInstanceCache(glyphName) {
-    for (const instanceCacheKey of this._glyphInstancePromiseCacheKeys[glyphName] || []) {
+    for (const instanceCacheKey of this._glyphInstancePromiseCacheKeys[glyphName] ||
+      []) {
       this._glyphInstancePromiseCache.delete(instanceCacheKey);
     }
     delete this._glyphInstancePromiseCacheKeys[glyphName];
@@ -345,10 +355,10 @@ export class FontController {
       this.undoStacks[glyphName] = new UndoStack();
     }
     const undoRecord = {
-      "change": change,
-      "rollbackChange": rollbackChange,
-      "info": undoInfo,
-    }
+      change: change,
+      rollbackChange: rollbackChange,
+      info: undoInfo,
+    };
     this.undoStacks[glyphName].pushUndoRecord(undoRecord);
   }
 
@@ -367,34 +377,32 @@ export class FontController {
     // Hmmm, would be nice to have this abstracted more
     await this.applyChange(undoRecord.rollbackChange);
     const error = await this.font.editFinal(
-      undoRecord.rollbackChange, undoRecord.change, undoRecord.info.label, true);
+      undoRecord.rollbackChange,
+      undoRecord.change,
+      undoRecord.info.label,
+      true
+    );
     // TODO handle error
     // Do not call this.notifyEditListeners() right away, but next time through the event loop;
     // It's a bit messy, but our caller sets the selection based on our return value; but the
     // edit listeners need that new selection. TODO: think of a better solution...
-    setTimeout(
-      () => this.notifyEditListeners("editFinal", this),
-      0,
-    );
+    setTimeout(() => this.notifyEditListeners("editFinal", this), 0);
     return undoRecord["info"];
   }
-
 }
-
 
 function reverseUndoRecord(undoRecord) {
   return {
-    "change": undoRecord.rollbackChange,
-    "rollbackChange": undoRecord.change,
-    "info": reverseUndoInfo(undoRecord.info),
+    change: undoRecord.rollbackChange,
+    rollbackChange: undoRecord.change,
+    info: reverseUndoInfo(undoRecord.info),
   };
 }
 
-
 function reverseUndoInfo(undoInfo) {
   const map = {
-    "redoSelection": "undoSelection",
-    "undoSelection": "redoSelection",
+    redoSelection: "undoSelection",
+    undoSelection: "redoSelection",
   };
   const revUndoInfo = {};
   for (const [k, v] of Object.entries(undoInfo)) {
@@ -403,22 +411,30 @@ function reverseUndoInfo(undoInfo) {
   return revUndoInfo;
 }
 
-
 class GlyphEditContext {
-
   constructor(fontController, glyphController, senderID) {
     this.fontController = fontController;
     this.glyphController = glyphController;
     this.instance = glyphController.instance;
     this.senderID = senderID;
-    this.throttledEditIncremental = throttleCalls(async change => {fontController.font.editIncremental(change)}, 50);
+    this.throttledEditIncremental = throttleCalls(async (change) => {
+      fontController.font.editIncremental(change);
+    }, 50);
     this._throttledEditIncrementalTimeoutID = null;
   }
 
   async setup() {
     const varGlyph = await this.fontController.getGlyph(this.glyphController.name);
-    const layerIndex = varGlyph.getLayerIndex(varGlyph.sources[this.glyphController.sourceIndex].layerName);
-    this.baseChangePath = ["glyphs", this.glyphController.name, "layers", layerIndex, "glyph"];
+    const layerIndex = varGlyph.getLayerIndex(
+      varGlyph.sources[this.glyphController.sourceIndex].layerName
+    );
+    this.baseChangePath = [
+      "glyphs",
+      this.glyphController.name,
+      "layers",
+      layerIndex,
+      "glyph",
+    ];
     await this.fontController.notifyEditListeners("editBegin", this.senderID);
   }
 
@@ -442,7 +458,12 @@ class GlyphEditContext {
     }
     change = consolidateChanges(change, this.baseChangePath);
     rollback = consolidateChanges(rollback, this.baseChangePath);
-    const error = await this.fontController.font.editFinal(change, rollback, undoInfo.label, broadcast);
+    const error = await this.fontController.font.editFinal(
+      change,
+      rollback,
+      undoInfo.label,
+      broadcast
+    );
     // TODO: handle error, rollback
     await this.fontController.notifyEditListeners("editFinal", this.senderID);
     await this.fontController.notifyEditListeners("editEnd", this.senderID);
@@ -453,12 +474,9 @@ class GlyphEditContext {
     await this.fontController.glyphChanged(this.glyphController.name);
     await this.fontController.notifyEditListeners("editEnd", this.senderID);
   }
-
 }
 
-
 class UndoStack {
-
   constructor() {
     this.undoStack = [];
     this.redoStack = [];
@@ -483,9 +501,7 @@ class UndoStack {
       return _popUndoRedoRecord(this.redoStack, this.undoStack);
     }
   }
-
 }
-
 
 function _popUndoRedoRecord(popStack, pushStack) {
   if (!popStack.length) {
@@ -496,9 +512,8 @@ function _popUndoRedoRecord(popStack, pushStack) {
   return undoRecord;
 }
 
-
 function collectGlyphNames(change) {
-  return collectChangePaths(change, 2).filter(
-    item => item[0] === "glyphs" && item[1] !== undefined
-  ).map(item => item[1]);
+  return collectChangePaths(change, 2)
+    .filter((item) => item[0] === "glyphs" && item[1] !== undefined)
+    .map((item) => item[1]);
 }

--- a/src/fontra/client/core/loader-spinner.js
+++ b/src/fontra/client/core/loader-spinner.js
@@ -3,28 +3,25 @@ export async function loaderSpinner(promise) {
   let returnValue;
   try {
     returnValue = await promise;
-  } catch(error) {
+  } catch (error) {
     decrementSpinnerStatus();
     throw error;
   }
   decrementSpinnerStatus();
-  return returnValue; 
+  return returnValue;
 }
-
 
 let spinnerStatus = 0;
 let spinnerStartTimerID;
-
 
 function incrementSpinnerStatus() {
   if (spinnerStatus == 0) {
     const spinner = document.querySelector("#global-loader-spinner");
     cancelTimer();
-    spinnerStartTimerID = setTimeout(() => spinner.style.display = "inherit", 300);
+    spinnerStartTimerID = setTimeout(() => (spinner.style.display = "inherit"), 300);
   }
   spinnerStatus += 1;
 }
-
 
 function decrementSpinnerStatus() {
   spinnerStatus -= 1;
@@ -33,10 +30,9 @@ function decrementSpinnerStatus() {
   } else if (spinnerStatus == 0) {
     cancelTimer();
     const spinner = document.querySelector("#global-loader-spinner");
-    spinner.style.display = "none";    
+    spinner.style.display = "none";
   }
 }
-
 
 function cancelTimer() {
   if (spinnerStartTimerID) {

--- a/src/fontra/client/core/lru-cache.js
+++ b/src/fontra/client/core/lru-cache.js
@@ -1,8 +1,6 @@
 // based on https://www.section.io/engineering-education/lru-cache-implementation-in-javascript/
 
-
 export class LRUCache {
-
   constructor(capacity) {
     this.capacity = capacity;
     this.map = new Map(); // this stores the entire array
@@ -45,7 +43,7 @@ export class LRUCache {
     } else {
       // check if map size is at capacity
       if (this.map.size === this.capacity) {
-        deletedItem = {key: this.head.next.key, value: this.head.next.value};
+        deletedItem = { key: this.head.next.key, value: this.head.next.value };
         //delete item both from map and DLL
         this.map.delete(deletedItem.key); // delete first element of list
         this.head.next = this.head.next.next; // update first element as next element
@@ -114,7 +112,5 @@ export class LRUCache {
       keys.push(node.key);
     }
     return keys;
-
   }
-
 }

--- a/src/fontra/client/core/mouse-tracker.js
+++ b/src/fontra/client/core/mouse-tracker.js
@@ -1,11 +1,8 @@
 import { QueueIterator } from "./queue-iterator.js";
 
-
 const modifierKeys = ["Shift", "Control", "Alt", "Meta"];
 
-
 export class MouseTracker {
-
   constructor(options) {
     this._dragFunc = options.drag;
     this._hoverFunc = options.hover;
@@ -16,20 +13,24 @@ export class MouseTracker {
   }
 
   _addEventListeners(element) {
-    element.addEventListener("mousedown", event => this.handleMouseDown(event))
-    element.addEventListener("touchstart", event => this.handleMouseDown(event))
-    element.addEventListener("keydown", event => this.handleModifierKeyChange(event));
-    element.addEventListener("keyup", event => this.handleModifierKeyChange(event));
-    element.addEventListener("mousemove", event => this.handleMouseMove(event));
-    element.addEventListener("touchmove", event => this.handleMouseMove(event));
-    element.addEventListener("touchend", event => this.handleMouseUp(event));
+    element.addEventListener("mousedown", (event) => this.handleMouseDown(event));
+    element.addEventListener("touchstart", (event) => this.handleMouseDown(event));
+    element.addEventListener("keydown", (event) => this.handleModifierKeyChange(event));
+    element.addEventListener("keyup", (event) => this.handleModifierKeyChange(event));
+    element.addEventListener("mousemove", (event) => this.handleMouseMove(event));
+    element.addEventListener("touchmove", (event) => this.handleMouseMove(event));
+    element.addEventListener("touchend", (event) => this.handleMouseUp(event));
 
     if (!window._fontraDidInstallMouseTrackerListeners) {
       // We add "mouseup" and "mousemove" as window-level event listeners,
       // because otherwise we will not receive them if they occur outside the
       // target element's box.
-      window.addEventListener("mouseup", event => window._fontraMouseTracker?.handleMouseUp(event));
-      window.addEventListener("mousemove", event => window._fontraMouseTracker?.handleMouseMove(event));
+      window.addEventListener("mouseup", (event) =>
+        window._fontraMouseTracker?.handleMouseUp(event)
+      );
+      window.addEventListener("mousemove", (event) =>
+        window._fontraMouseTracker?.handleMouseMove(event)
+      );
       window._fontraDidInstallMouseTrackerListeners = true;
     }
   }
@@ -39,7 +40,10 @@ export class MouseTracker {
       // We're not handling contextual menus
       return;
     }
-    if (this._lastMouseDownEvent !== undefined && event.type !== this._lastMouseDownEvent.type) {
+    if (
+      this._lastMouseDownEvent !== undefined &&
+      event.type !== this._lastMouseDownEvent.type
+    ) {
       // Ignore MouseEvents that com after TouchEvent, yet don't
       // do event.preventDefault().
       return;
@@ -65,7 +69,7 @@ export class MouseTracker {
       // hovering
       this._hoverFunc(event);
     }
-    event.stopImmediatePropagation();  // handle element-level or window-level event, but not both
+    event.stopImmediatePropagation(); // handle element-level or window-level event, but not both
   }
 
   handleMouseUp(event) {
@@ -91,17 +95,15 @@ export class MouseTracker {
       this._eventStream = undefined;
     }
   }
-
 }
-
 
 function getTapCounter() {
   let lastEvent;
   let tapCount = 1;
-  return event => {
+  return (event) => {
     if (lastEvent && areEventsClose(event, lastEvent)) {
       const timeSince = event.timeStamp - lastEvent.timeStamp;
-      if ((timeSince < 600) && (timeSince > 0)) {
+      if (timeSince < 600 && timeSince > 0) {
         tapCount += 1;
       } else {
         tapCount = 1;
@@ -114,11 +116,10 @@ function getTapCounter() {
   };
 }
 
-
 function areEventsClose(event1, event2) {
   const maxDistance = 3;
   return (
     Math.abs(event1.pageX - event2.pageX) < maxDistance &&
     Math.abs(event1.pageY - event2.pageY) < maxDistance
-  )
+  );
 }

--- a/src/fontra/client/core/queue-iterator.js
+++ b/src/fontra/client/core/queue-iterator.js
@@ -1,5 +1,4 @@
 export class QueueIterator {
-
   constructor(maxQueueSize = 10) {
     this._done = false;
     this._queue = [];
@@ -37,21 +36,20 @@ export class QueueIterator {
 
   next() {
     if (this._queue.length) {
-      return Promise.resolve({"value": this._queue.shift(), "done": false})
+      return Promise.resolve({ value: this._queue.shift(), done: false });
     } else if (this._done) {
-      return Promise.resolve({"done": true})
+      return Promise.resolve({ done: true });
     } else {
-      return new Promise(resolve => {
+      return new Promise((resolve) => {
         this._signal = () => {
           if (this._queue.length) {
-            resolve({"value": this._queue.shift(), "done": false});
+            resolve({ value: this._queue.shift(), done: false });
           } else {
-            resolve({"done": true})
+            resolve({ done: true });
           }
           this._signal = null;
-        }
+        };
       });
     }
   }
-
 }

--- a/src/fontra/client/core/rectangle.js
+++ b/src/fontra/client/core/rectangle.js
@@ -1,12 +1,6 @@
 export function pointInRect(x, y, rect) {
-  return (
-    x >= rect.xMin &&
-    x <= rect.xMax &&
-    y >= rect.yMin &&
-    y <= rect.yMax
-  );
+  return x >= rect.xMin && x <= rect.xMax && y >= rect.yMin && y <= rect.yMax;
 }
-
 
 export function centeredRect(x, y, width, height) {
   if (height === undefined) {
@@ -19,42 +13,39 @@ export function centeredRect(x, y, width, height) {
     yMin: y - halfHeight,
     xMax: x + halfWidth,
     yMax: y + halfHeight,
-  }
+  };
 }
-
 
 export function normalizeRect(rect) {
   const nRect = {
-    "xMin": Math.min(rect.xMin, rect.xMax),
-    "yMin": Math.min(rect.yMin, rect.yMax),
-    "xMax": Math.max(rect.xMin, rect.xMax),
-    "yMax": Math.max(rect.yMin, rect.yMax),
+    xMin: Math.min(rect.xMin, rect.xMax),
+    yMin: Math.min(rect.yMin, rect.yMax),
+    xMax: Math.max(rect.xMin, rect.xMax),
+    yMax: Math.max(rect.yMin, rect.yMax),
   };
   return nRect;
 }
 
-
 export function sectRect(rect1, rect2) {
-    // Test for rectangle-rectangle intersection.
+  // Test for rectangle-rectangle intersection.
 
-    // Args:
-    //     rect1: First bounding rectangle
-    //     rect2: Second bounding rectangle
+  // Args:
+  //     rect1: First bounding rectangle
+  //     rect2: Second bounding rectangle
 
-    // Returns:
-    //     A rectangle or null.
-    //     If the input rectangles intersect, returns the intersecting rectangle.
-    //     Returns ``null`` if the input rectangles do not intersect.
-    const xMin = Math.max(rect1.xMin, rect2.xMin);
-    const yMin = Math.max(rect1.yMin, rect2.yMin);
-    const xMax = Math.min(rect1.xMax, rect2.xMax);
-    const yMax = Math.min(rect1.yMax, rect2.yMax);
-    if (xMin > xMax || yMin > yMax) {
-      return undefined;
-    }
-    return {"xMin": xMin, "yMin": yMin, "xMax": xMax, "yMax": yMax};
+  // Returns:
+  //     A rectangle or null.
+  //     If the input rectangles intersect, returns the intersecting rectangle.
+  //     Returns ``null`` if the input rectangles do not intersect.
+  const xMin = Math.max(rect1.xMin, rect2.xMin);
+  const yMin = Math.max(rect1.yMin, rect2.yMin);
+  const xMax = Math.min(rect1.xMax, rect2.xMax);
+  const yMax = Math.min(rect1.yMax, rect2.yMax);
+  if (xMin > xMax || yMin > yMax) {
+    return undefined;
+  }
+  return { xMin: xMin, yMin: yMin, xMax: xMax, yMax: yMax };
 }
-
 
 export function unionRect(...rectangles) {
   if (!rectangles.length) {
@@ -72,42 +63,38 @@ export function unionRect(...rectangles) {
     xMax = Math.max(xMax, rect.xMax);
     yMax = Math.max(yMax, rect.yMax);
   }
-  return {"xMin": xMin, "yMin": yMin, "xMax": xMax, "yMax": yMax};
+  return { xMin: xMin, yMin: yMin, xMax: xMax, yMax: yMax };
 }
-
 
 export function offsetRect(rect, x, y) {
   return {
-    "xMin": rect.xMin + x,
-    "yMin": rect.yMin + y,
-    "xMax": rect.xMax + x,
-    "yMax": rect.yMax + y,
+    xMin: rect.xMin + x,
+    yMin: rect.yMin + y,
+    xMax: rect.xMax + x,
+    yMax: rect.yMax + y,
   };
 }
-
 
 export function scaleRect(rect, sx, sy) {
   if (sy === undefined) {
     sy = sx;
   }
   return {
-    "xMin": rect.xMin * sx,
-    "yMin": rect.yMin * sy,
-    "xMax": rect.xMax * sx,
-    "yMax": rect.yMax * sy,
+    xMin: rect.xMin * sx,
+    yMin: rect.yMin * sy,
+    xMax: rect.xMax * sx,
+    yMax: rect.yMax * sy,
   };
 }
-
 
 export function insetRect(rect, dx, dy) {
   return {
-    "xMin": rect.xMin + dx,
-    "yMin": rect.yMin + dy,
-    "xMax": rect.xMax - dx,
-    "yMax": rect.yMax - dy,
+    xMin: rect.xMin + dx,
+    yMin: rect.yMin + dy,
+    xMax: rect.xMax - dx,
+    yMax: rect.yMax - dy,
   };
 }
-
 
 export function equalRect(rect1, rect2) {
   return (
@@ -115,32 +102,30 @@ export function equalRect(rect1, rect2) {
     rect1.yMin === rect2.yMin &&
     rect1.xMax === rect2.xMax &&
     rect1.yMax === rect2.yMax
-  )
+  );
 }
-
 
 export function rectCenter(rect) {
-  return {"x": (rect.xMin + rect.xMax) / 2, "y": (rect.yMin + rect.yMax) / 2};
+  return { x: (rect.xMin + rect.xMax) / 2, y: (rect.yMin + rect.yMax) / 2 };
 }
-
 
 export function rectSize(rect) {
-  return {"width": Math.abs(rect.xMax - rect.xMin), "height": Math.abs(rect.yMax - rect.yMin)};
+  return {
+    width: Math.abs(rect.xMax - rect.xMin),
+    height: Math.abs(rect.yMax - rect.yMin),
+  };
 }
-
 
 export function rectFromArray(array) {
   if (array.length != 4) {
     throw new Error("rect array must have length == 4");
   }
-  return {"xMin": array[0], "yMin": array[1], "xMax": array[2], "yMax": array[3]}
+  return { xMin: array[0], yMin: array[1], xMax: array[2], yMax: array[3] };
 }
-
 
 export function rectToArray(rect) {
   return [rect.xMin, rect.yMin, rect.xMax, rect.yMax];
 }
-
 
 export function isEmptyRect(rect) {
   const size = rectSize(rect);

--- a/src/fontra/client/core/remote.js
+++ b/src/fontra/client/core/remote.js
@@ -1,6 +1,5 @@
 import { RemoteError } from "./errors.js";
 
-
 export async function getRemoteProxy(wsURL) {
   const remote = new RemoteObject(wsURL);
   await remote.connect();
@@ -23,9 +22,7 @@ export async function getRemoteProxy(wsURL) {
   return remoteProxy;
 }
 
-
 export class RemoteObject {
-
   constructor(wsURL) {
     if (crypto.randomUUID) {
       this.clientUUID = crypto.randomUUID();
@@ -37,14 +34,20 @@ export class RemoteObject {
     this._callReturnCallbacks = {};
 
     const g = _genNextClientCallID();
-    this._getNextClientCallID = () => {return g.next().value};
+    this._getNextClientCallID = () => {
+      return g.next().value;
+    };
 
-    document.addEventListener("visibilitychange", event => {
-      if (document.visibilityState === "visible" && this.websocket.readyState > 1) {
-        // console.log("wake reconnect");
-        this.connect();
-      }
-    }, false);
+    document.addEventListener(
+      "visibilitychange",
+      (event) => {
+        if (document.visibilityState === "visible" && this.websocket.readyState > 1) {
+          // console.log("wake reconnect");
+          this.connect();
+        }
+      },
+      false
+    );
   }
 
   connect() {
@@ -56,9 +59,9 @@ export class RemoteObject {
       throw new Error("assert -- trying to open new websocket while we still have one");
     }
     this.websocket = new WebSocket(this.wsURL);
-    this.websocket.onmessage = event => this._handleIncomingMessage(event);
+    this.websocket.onmessage = (event) => this._handleIncomingMessage(event);
     this._connectPromise = new Promise((resolve, reject) => {
-      this.websocket.onopen = event => {
+      this.websocket.onopen = (event) => {
         resolve(event);
         delete this._connectPromise;
         const message = {
@@ -98,11 +101,14 @@ export class RemoteObject {
           }
           method = method.bind(this.receiver);
           const returnValue = await method(...message["arguments"]);
-          returnMessage = {"server-call-id": serverCallID, "return-value": returnValue};
-        } catch(error) {
+          returnMessage = {
+            "server-call-id": serverCallID,
+            "return-value": returnValue,
+          };
+        } catch (error) {
           console.log("exception in receiver call", error.toString());
           console.error(error, error.stack);
-          returnMessage = {"server-call-id": serverCallID, "error": error.toString()};
+          returnMessage = { "server-call-id": serverCallID, "error": error.toString() };
         }
         this.websocket.send(JSON.stringify(returnMessage));
       } else {
@@ -125,15 +131,13 @@ export class RemoteObject {
     }
     this.websocket.send(JSON.stringify(message));
 
-    this._callReturnCallbacks[clientCallID] = {}
+    this._callReturnCallbacks[clientCallID] = {};
     return new Promise((resolve, reject) => {
       this._callReturnCallbacks[clientCallID].resolve = resolve;
       this._callReturnCallbacks[clientCallID].reject = reject;
     });
   }
-
 }
-
 
 function* _genNextClientCallID() {
   let clientCallID = 0;
@@ -143,9 +147,8 @@ function* _genNextClientCallID() {
   }
 }
 
-
 function randomUUIDFallback() {
-  return ([1e7]+-1e3+-4e3+-8e3+-1e11).replace(/[018]/g, c =>
-    (c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16)
+  return ([1e7] + -1e3 + -4e3 + -8e3 + -1e11).replace(/[018]/g, (c) =>
+    (c ^ (crypto.getRandomValues(new Uint8Array(1))[0] & (15 >> (c / 4)))).toString(16)
   );
 }

--- a/src/fontra/client/core/scene-view.js
+++ b/src/fontra/client/core/scene-view.js
@@ -1,8 +1,6 @@
 import { withSavedState } from "./utils.js";
 
-
 export class SceneView {
-
   constructor(model, drawFunc) {
     this.model = model;
     this.drawFunc = drawFunc;
@@ -14,7 +12,7 @@ export class SceneView {
     if (!this.visible) {
       return;
     }
-    this.subviews.forEach(view => view.draw(canvasController));
+    this.subviews.forEach((view) => view.draw(canvasController));
     if (this.drawFunc === undefined) {
       return;
     }
@@ -22,5 +20,4 @@ export class SceneView {
       this.drawFunc(this.model, canvasController);
     });
   }
-
 }

--- a/src/fontra/client/core/set-ops.js
+++ b/src/fontra/client/core/set-ops.js
@@ -1,7 +1,6 @@
 // Copied mostly from
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set
 
-
 export function isEqualSet(set1, set2) {
   if (set1.size !== set2.size) {
     return false;
@@ -17,48 +16,48 @@ export function isEqualSet(set1, set2) {
 export function isSuperset(set, subset) {
   for (let elem of subset) {
     if (!set.has(elem)) {
-      return false
+      return false;
     }
   }
-  return true
+  return true;
 }
 
 export function union(setA, setB) {
-  let _union = new Set(setA)
+  let _union = new Set(setA);
   for (let elem of setB) {
-    _union.add(elem)
+    _union.add(elem);
   }
-  return _union
+  return _union;
 }
 
 export function intersection(setA, setB) {
-  let _intersection = new Set()
+  let _intersection = new Set();
   for (let elem of setB) {
     if (setA.has(elem)) {
-      _intersection.add(elem)
+      _intersection.add(elem);
     }
   }
-  return _intersection
+  return _intersection;
 }
 
 export function symmetricDifference(setA, setB) {
-  let _difference = new Set(setA)
+  let _difference = new Set(setA);
   for (let elem of setB) {
     if (_difference.has(elem)) {
-      _difference.delete(elem)
+      _difference.delete(elem);
     } else {
-      _difference.add(elem)
+      _difference.add(elem);
     }
   }
-  return _difference
+  return _difference;
 }
 
 export function difference(setA, setB) {
-  let _difference = new Set(setA)
+  let _difference = new Set(setA);
   for (let elem of setB) {
-    _difference.delete(elem)
+    _difference.delete(elem);
   }
-  return _difference
+  return _difference;
 }
 
 export function lenientIsEqualSet(set1, set2) {

--- a/src/fontra/client/core/svg-glyph.js
+++ b/src/fontra/client/core/svg-glyph.js
@@ -1,5 +1,4 @@
 export class SVGPath2D {
-
   constructor(scaleFactor = 1, numDigits = 1, offsetX = 0, offsetY = 0) {
     const precisionFactor = 10 ** numDigits;
     this.numerator = scaleFactor * precisionFactor;
@@ -14,7 +13,14 @@ export class SVGPath2D {
   }
 
   _format(x, y) {
-    return formatCoordinate(x, y, this.numerator, this.denominator, this.offsetX, this.offsetY);
+    return formatCoordinate(
+      x,
+      y,
+      this.numerator,
+      this.denominator,
+      this.offsetX,
+      this.offsetY
+    );
   }
 
   moveTo(x, y) {
@@ -26,7 +32,9 @@ export class SVGPath2D {
   }
 
   bezierCurveTo(x1, y1, x2, y2, x3, y3) {
-    this.items.push(`C${this._format(x1, y1)} ${this._format(x2, y2)} ${this._format(x3, y3)}`);
+    this.items.push(
+      `C${this._format(x1, y1)} ${this._format(x2, y2)} ${this._format(x3, y3)}`
+    );
   }
 
   quadraticCurveTo(x1, y1, x2, y2) {
@@ -37,7 +45,6 @@ export class SVGPath2D {
     this.items.push("Z");
   }
 }
-
 
 function formatCoordinate(x, y, numerator, denominator, dx, dy) {
   x = Math.round(x * numerator + dx) / denominator;

--- a/src/fontra/client/core/transform.js
+++ b/src/fontra/client/core/transform.js
@@ -1,8 +1,6 @@
 // Partial port of fontTools.misc.transform.Transform
 
-
 export class Transform {
-
   constructor(xx = 1, xy = 0, yx = 0, yy = 1, dx = 0, dy = 0) {
     this.xx = xx;
     this.xy = xy;
@@ -12,75 +10,75 @@ export class Transform {
     this.dy = dy;
   }
 
-	transformPoint(x, y) {
-		// Transform a point.
+  transformPoint(x, y) {
+    // Transform a point.
 
-		// Example:
-		// 	>>> t = new Transform()
-		// 	>>> t = t.scale(2.5, 5.5)
-		// 	>>> t.transformPoint(100, 100)
-		// 	(250.0, 550.0)
-		return [this.xx * x + this.yx * y + this.dx, this.xy * x + this.yy * y + this.dy];
+    // Example:
+    // 	>>> t = new Transform()
+    // 	>>> t = t.scale(2.5, 5.5)
+    // 	>>> t.transformPoint(100, 100)
+    // 	(250.0, 550.0)
+    return [this.xx * x + this.yx * y + this.dx, this.xy * x + this.yy * y + this.dy];
   }
 
-	translate(x, y) {
-		// Return a new transformation, translated (offset) by x, y.
+  translate(x, y) {
+    // Return a new transformation, translated (offset) by x, y.
 
-		// Example:
-		// 	>>> t = new Transform()
-		// 	>>> t.translate(20, 30)
-		// 	<Transform [1 0 0 1 20 30]>
-		return this._transform(1, 0, 0, 1, x, y);
+    // Example:
+    // 	>>> t = new Transform()
+    // 	>>> t.translate(20, 30)
+    // 	<Transform [1 0 0 1 20 30]>
+    return this._transform(1, 0, 0, 1, x, y);
   }
 
-	scale(x, y) {
-		// Return a new transformation, scaled by x, y. The 'y' argument
-		// may be None, which implies to use the x value for y as well.
+  scale(x, y) {
+    // Return a new transformation, scaled by x, y. The 'y' argument
+    // may be None, which implies to use the x value for y as well.
 
-		// Example:
-		// 	>>> t = new Transform()
-		// 	>>> t.scale(5)
-		// 	<Transform [5 0 0 5 0 0]>
-		// 	>>> t.scale(5, 6)
-		// 	<Transform [5 0 0 6 0 0]>
-		if (y === undefined) {
-			y = x;
+    // Example:
+    // 	>>> t = new Transform()
+    // 	>>> t.scale(5)
+    // 	<Transform [5 0 0 5 0 0]>
+    // 	>>> t.scale(5, 6)
+    // 	<Transform [5 0 0 6 0 0]>
+    if (y === undefined) {
+      y = x;
     }
-		return this._transform(x, 0, 0, y, 0, 0);
+    return this._transform(x, 0, 0, y, 0, 0);
   }
 
-	rotate(angle) {
-		// Return a new transformation, rotated by 'angle' (radians).
+  rotate(angle) {
+    // Return a new transformation, rotated by 'angle' (radians).
 
-		// Example:
-		// 	>>> import math
-		// 	>>> t = new Transform()
-		// 	>>> t.rotate(math.pi / 2)
-		// 	<Transform [0 1 -1 0 0 0]>
-		const c = _normSinCos(Math.cos(angle));
-		const s = _normSinCos(Math.sin(angle));
-		return this._transform(c, s, -s, c, 0, 0)
+    // Example:
+    // 	>>> import math
+    // 	>>> t = new Transform()
+    // 	>>> t.rotate(math.pi / 2)
+    // 	<Transform [0 1 -1 0 0 0]>
+    const c = _normSinCos(Math.cos(angle));
+    const s = _normSinCos(Math.sin(angle));
+    return this._transform(c, s, -s, c, 0, 0);
   }
 
-	skew(x, y = 0) {
-		// Return a new transformation, skewed by x and y.
+  skew(x, y = 0) {
+    // Return a new transformation, skewed by x and y.
 
-		// Example:
-		// 	>>> import math
-		// 	>>> t = new Transform()
-		// 	>>> t.skew(math.pi / 4)
-		// 	<Transform [1 0 1 1 0 0]>
-		return this._transform(1, Math.tan(y), Math.tan(x), 1, 0, 0);
+    // Example:
+    // 	>>> import math
+    // 	>>> t = new Transform()
+    // 	>>> t.skew(math.pi / 4)
+    // 	<Transform [1 0 1 1 0 0]>
+    return this._transform(1, Math.tan(y), Math.tan(x), 1, 0, 0);
   }
 
-	transform(other) {
-		// Return a new transformation, transformed by another
-		// transformation.
+  transform(other) {
+    // Return a new transformation, transformed by another
+    // transformation.
 
-		// Example:
-		// 	>>> t = new Transform(2, 0, 0, 3, 1, 6)
-		// 	>>> t.transform((4, 3, 2, 1, 5, 6))
-		// 	<Transform [8 9 4 3 11 24]>
+    // Example:
+    // 	>>> t = new Transform(2, 0, 0, 3, 1, 6)
+    // 	>>> t.transform((4, 3, 2, 1, 5, 6))
+    // 	<Transform [8 9 4 3 11 24]>
     if (other.length === undefined) {
       other = _unpackTransformObject(other);
     }
@@ -94,66 +92,77 @@ export class Transform {
       yx * this.xx + yy * this.yx,
       yx * this.xy + yy * this.yy,
       this.xx * dx + this.yx * dy + this.dx,
-      this.xy * dx + this.yy * dy + this.dy,
+      this.xy * dx + this.yy * dy + this.dy
     );
   }
 
-	reverseTransform(other) {
-		// Return a new transformation, which is the other transformation
-		// transformed by self. self.reverseTransform(other) is equivalent to
-		// other.transform(self).
+  reverseTransform(other) {
+    // Return a new transformation, which is the other transformation
+    // transformed by self. self.reverseTransform(other) is equivalent to
+    // other.transform(self).
 
-		// Example:
-		// 	>>> t = new Transform(2, 0, 0, 3, 1, 6)
-		// 	>>> t.reverseTransform((4, 3, 2, 1, 5, 6))
-		// 	<Transform [8 6 6 3 21 15]>
-		// 	>>> Transform(4, 3, 2, 1, 5, 6).transform((2, 0, 0, 3, 1, 6))
-		// 	<Transform [8 6 6 3 21 15]>
+    // Example:
+    // 	>>> t = new Transform(2, 0, 0, 3, 1, 6)
+    // 	>>> t.reverseTransform((4, 3, 2, 1, 5, 6))
+    // 	<Transform [8 6 6 3 21 15]>
+    // 	>>> Transform(4, 3, 2, 1, 5, 6).transform((2, 0, 0, 3, 1, 6))
+    // 	<Transform [8 6 6 3 21 15]>
     if (other.length === undefined) {
       other = _unpackTransformObject(other);
     }
     const [xx, xy, yx, yy, dx, dy] = other;
-		return new this.constructor(
-			this.xx * xx + this.xy * yx,
-			this.xx * xy + this.xy * yy,
-			this.yx * xx + this.yy * yx,
-			this.yx * xy + this.yy * yy,
-			xx * this.dx + yx * this.dy + dx,
-			xy * this.dx + yy * this.dy + dy,
+    return new this.constructor(
+      this.xx * xx + this.xy * yx,
+      this.xx * xy + this.xy * yy,
+      this.yx * xx + this.yy * yx,
+      this.yx * xy + this.yy * yy,
+      xx * this.dx + yx * this.dy + dx,
+      xy * this.dx + yy * this.dy + dy
     );
   }
 
-	inverse() {
-		// Return the inverse transformation.
+  inverse() {
+    // Return the inverse transformation.
 
-		// Example:
-		// 	>>> t = Identity.translate(2, 3).scale(4, 5)
-		// 	>>> t.transformPoint(10, 20)
-		// 	(42, 103)
-		// 	>>> it = t.inverse()
-		// 	>>> it.transformPoint(42, 103)
-		// 	(10.0, 20.0)
-		if (this.xx === 1 && this.xy === 0 && this.yx === 0 && this.yy === 1 && this.dx === 0 && this.dy === 0) {
-			return this;
+    // Example:
+    // 	>>> t = Identity.translate(2, 3).scale(4, 5)
+    // 	>>> t.transformPoint(10, 20)
+    // 	(42, 103)
+    // 	>>> it = t.inverse()
+    // 	>>> it.transformPoint(42, 103)
+    // 	(10.0, 20.0)
+    if (
+      this.xx === 1 &&
+      this.xy === 0 &&
+      this.yx === 0 &&
+      this.yy === 1 &&
+      this.dx === 0 &&
+      this.dy === 0
+    ) {
+      return this;
     }
-		let [xx, xy, yx, yy, dx, dy] = [this.xx, this.xy, this.yx, this.yy, this.dx, this.dy];
-		const det = xx*yy - yx*xy;
-		[xx, xy, yx, yy] = [yy/det, -xy/det, -yx/det, xx/det];
-		[dx, dy] = [-xx*dx - yx*dy, -xy*dx - yy*dy];
-		return new this.constructor(xx, xy, yx, yy, dx, dy);
+    let [xx, xy, yx, yy, dx, dy] = [
+      this.xx,
+      this.xy,
+      this.yx,
+      this.yy,
+      this.dx,
+      this.dy,
+    ];
+    const det = xx * yy - yx * xy;
+    [xx, xy, yx, yy] = [yy / det, -xy / det, -yx / det, xx / det];
+    [dx, dy] = [-xx * dx - yx * dy, -xy * dx - yy * dy];
+    return new this.constructor(xx, xy, yx, yy, dx, dy);
   }
 
-	toArray() {
-		return _unpackTransformObject(this);
+  toArray() {
+    return _unpackTransformObject(this);
   }
-
 }
-
 
 function _unpackTransformObject(t) {
-    return [t.xx, t.xy, t.yx, t.yy, t.dx, t.dy];
+  return [t.xx, t.xy, t.yx, t.yy, t.dx, t.dy];
 }
-
 
 const _EPSILON = 1e-15;
 const _ONE_EPSILON = 1 - _EPSILON;

--- a/src/fontra/client/core/ui-dialog.js
+++ b/src/fontra/client/core/ui-dialog.js
@@ -1,11 +1,10 @@
 import { enumerate } from "./utils.js";
 
-
 export function dialog(headline, message, buttonDefs, autoDismissTimeout) {
   /* return a Promise the the result of the user action, or null for cancel */
 
   let dismissTimeoutID;
-  const dialogDone = result => {
+  const dialogDone = (result) => {
     if (dismissTimeoutID) {
       clearTimeout(dismissTimeoutID);
       dismissTimeoutID = undefined;
@@ -14,24 +13,24 @@ export function dialog(headline, message, buttonDefs, autoDismissTimeout) {
     container.classList.remove("visible");
     currentActiveElement.focus();
     resolveDialogResult(result);
-  }
+  };
 
   let resolveDialogResult;
-  const resultPromise = new Promise(resolve => {
+  const resultPromise = new Promise((resolve) => {
     resolveDialogResult = resolve;
-  })
+  });
 
   const currentActiveElement = document.activeElement;
 
   const container = document.querySelector("#ui-dialog-container");
   const content = document.createElement("div");
   content.className = "ui-dialog-content";
-  content.tabIndex = 1;  /* so we can receive key events */
+  content.tabIndex = 1; /* so we can receive key events */
   container.appendChild(content);
 
   const headlineElement = document.createElement("div");
   headlineElement.classList.add("ui-dialog-headline");
-  headlineElement.innerText = headline
+  headlineElement.innerText = headline;
   const messageElement = document.createElement("div");
   messageElement.classList.add("ui-dialog-message");
   messageElement.innerText = message;
@@ -40,13 +39,15 @@ export function dialog(headline, message, buttonDefs, autoDismissTimeout) {
   content.appendChild(messageElement);
 
   let defaultButtonElement, cancelButtonElement;
-  buttonDefs = buttonDefs.map(bd => {return {...bd};});
+  buttonDefs = buttonDefs.map((bd) => {
+    return { ...bd };
+  });
   if (buttonDefs.length === 1) {
     buttonDefs[0].isDefaultButton = true;
   }
   for (const [buttonIndex, buttonDef] of enumerate(buttonDefs, 4 - buttonDefs.length)) {
     const buttonElement = document.createElement("input");
-    buttonElement.type = "button"
+    buttonElement.type = "button";
     buttonElement.className = `ui-dialog-button button-${buttonIndex}`;
     if (buttonDef.isDefaultButton) {
       buttonElement.classList.add("default");
@@ -55,13 +56,13 @@ export function dialog(headline, message, buttonDefs, autoDismissTimeout) {
       cancelButtonElement = buttonElement;
     }
     buttonElement.value = buttonDef.title;
-    buttonElement.onclick = event => {
+    buttonElement.onclick = (event) => {
       dialogDone(buttonDef.resultValue || buttonDef.title);
-    }
+    };
     content.appendChild(buttonElement);
   }
 
-  content.onkeydown = event => {
+  content.onkeydown = (event) => {
     if (event.key == "Enter") {
       defaultButtonElement?.click();
     } else if (event.key == "Escape") {
@@ -74,7 +75,7 @@ export function dialog(headline, message, buttonDefs, autoDismissTimeout) {
   };
 
   /* prevent clicks on the dialog itself to propagate to the container */
-  content.onclick = event => event.stopImmediatePropagation();
+  content.onclick = (event) => event.stopImmediatePropagation();
 
   if (autoDismissTimeout) {
     dismissTimeoutID = setTimeout(() => dialogDone(null), autoDismissTimeout);
@@ -82,9 +83,9 @@ export function dialog(headline, message, buttonDefs, autoDismissTimeout) {
 
   container.classList.add("visible");
   content.focus();
-  container.onclick = event => {
+  container.onclick = (event) => {
     dialogDone(null);
-  }
+  };
 
   return resultPromise;
 }

--- a/src/fontra/client/core/ui-form.js
+++ b/src/fontra/client/core/ui-form.js
@@ -1,9 +1,7 @@
 import { QueueIterator } from "./queue-iterator.js";
 import { capitalizeFirstLetter, hyphenatedToCamelCase } from "./utils.js";
 
-
 export class Form {
-
   constructor(formID, fieldDescriptions) {
     this.container = document.querySelector(`#${formID}`);
     if (!this.container) {
@@ -46,7 +44,7 @@ export class Form {
       let label = fieldItem.label || fieldItem.key || "";
       if (label.length && fieldItem.type !== "header") {
         label += ":";
-      };
+      }
       labelElement.innerHTML = label;
       this.container.appendChild(labelElement);
       if (fieldItem.type === "header") {
@@ -56,7 +54,7 @@ export class Form {
 
       const methodName = hyphenatedToCamelCase("_add-" + fieldItem.type);
       if (this[methodName] === undefined) {
-          throw new Error(`Unknown field type: ${fieldItem.type}`);
+        throw new Error(`Unknown field type: ${fieldItem.type}`);
       }
       this[methodName](valueElement, fieldItem);
     }
@@ -74,7 +72,7 @@ export class Form {
     if (fieldItem.value !== undefined) {
       valueElement.innerText = fieldItem.value;
       this._fieldGetters[fieldItem.key] = () => valueElement.innerText;
-      this._fieldSetters[fieldItem.key] = value => valueElement.innerText = value;
+      this._fieldSetters[fieldItem.key] = (value) => (valueElement.innerText = value);
     }
   }
 
@@ -83,11 +81,11 @@ export class Form {
     inputElement.type = "text";
     inputElement.value = fieldItem.value || "";
     inputElement.disabled = fieldItem.disabled;
-    inputElement.onchange = event => {
+    inputElement.onchange = (event) => {
       this._fieldChanging(fieldItem.key, inputElement.value, undefined);
     };
     this._fieldGetters[fieldItem.key] = () => inputElement.value;
-    this._fieldSetters[fieldItem.key] = value => inputElement.value = value;
+    this._fieldSetters[fieldItem.key] = (value) => (inputElement.value = value);
     valueElement.appendChild(inputElement);
   }
 
@@ -97,11 +95,11 @@ export class Form {
     inputElement.value = fieldItem.value;
     inputElement.step = "any";
     inputElement.disabled = fieldItem.disabled;
-    inputElement.onchange = event => {
+    inputElement.onchange = (event) => {
       this._fieldChanging(fieldItem.key, parseFloat(inputElement.value), undefined);
     };
     this._fieldGetters[fieldItem.key] = () => inputElement.value;
-    this._fieldSetters[fieldItem.key] = value => inputElement.value = value;
+    this._fieldSetters[fieldItem.key] = (value) => (inputElement.value = value);
     valueElement.appendChild(inputElement);
   }
 
@@ -121,7 +119,7 @@ export class Form {
     {
       // Slider change closure
       let valueStream = undefined;
-      sliderElement.oninput = event => {
+      sliderElement.oninput = (event) => {
         // Continuous changes
         inputElement.value = myRound(sliderElement.value, 3);
         const value = parseFloat(inputElement.value);
@@ -130,17 +128,17 @@ export class Form {
           this._fieldChanging(fieldItem.key, value, valueStream);
         }
         valueStream.put(value);
-        this._dispatchEvent("doChange", {"key": fieldItem.key, "value": value});
+        this._dispatchEvent("doChange", { key: fieldItem.key, value: value });
       };
-      sliderElement.onchange = event => {
+      sliderElement.onchange = (event) => {
         // Single change, or final change after continuous changes
         if (valueStream) {
           valueStream.done();
           valueStream = undefined;
-          this._dispatchEvent("endChange", {"key": fieldItem.key});
+          this._dispatchEvent("endChange", { key: fieldItem.key });
         }
-      }
-      sliderElement.onmouseup = event => {
+      };
+      sliderElement.onmouseup = (event) => {
         // sliderElement.onchange is ONLY triggered when the final slider value
         // is different from the initial value. However, we may have been in
         // a live drag, and we need to handle the end of the slider drag no
@@ -150,16 +148,16 @@ export class Form {
       };
     }
 
-    inputElement.onchange = event => {
+    inputElement.onchange = (event) => {
       sliderElement.value = inputElement.value;
-      inputElement.value = sliderElement.value;  // Use slider's clamping
+      inputElement.value = sliderElement.value; // Use slider's clamping
       this._fieldChanging(fieldItem.key, parseFloat(inputElement.value), undefined);
     };
     this._fieldGetters[fieldItem.key] = () => sliderElement.value;
-    this._fieldSetters[fieldItem.key] = value => {
+    this._fieldSetters[fieldItem.key] = (value) => {
       inputElement.value = value;
       sliderElement.value = value;
-    }
+    };
     valueElement.appendChild(inputElement);
     valueElement.appendChild(sliderElement);
   }
@@ -170,9 +168,9 @@ export class Form {
 
   _fieldChanging(fieldKey, value, valueStream) {
     if (valueStream) {
-      this._dispatchEvent("beginChange", {"key": fieldKey});
+      this._dispatchEvent("beginChange", { key: fieldKey });
     } else {
-      this._dispatchEvent("doChange", {"key": fieldKey, "value": value});
+      this._dispatchEvent("doChange", { key: fieldKey, value: value });
     }
     const handlerName = "onFieldChange";
     if (this[handlerName] !== undefined) {
@@ -182,8 +180,8 @@ export class Form {
 
   _dispatchEvent(eventName, detail) {
     const event = new CustomEvent(eventName, {
-      "bubbles": false,
-      "detail": detail,
+      bubbles: false,
+      detail: detail,
     });
     this.container.dispatchEvent(event);
   }
@@ -207,9 +205,7 @@ export class Form {
     }
     setter(value);
   }
-
 }
-
 
 function myRound(n, digits) {
   const f = 10 ** digits;

--- a/src/fontra/client/core/ui-list.js
+++ b/src/fontra/client/core/ui-list.js
@@ -1,8 +1,6 @@
-const LIST_CHUNK_SIZE = 200;  // the amount of items added to the list at a time
-
+const LIST_CHUNK_SIZE = 200; // the amount of items added to the list at a time
 
 export class List {
-
   constructor(listID, columnDescriptions) {
     this.container = document.querySelector(`#${listID}`);
     if (!this.container) {
@@ -16,23 +14,43 @@ export class List {
     if (!columnDescriptions) {
       columnDescriptions = [
         {
-          "key": "default",
-          "get": item => item,
-        }
+          key: "default",
+          get: (item) => item,
+        },
       ];
     }
-    this.columnDescriptions = columnDescriptions
+    this.columnDescriptions = columnDescriptions;
 
     this.itemEqualFunc = null;
 
     this.contents = document.createElement("div");
-    this.contents.className = "contents"
+    this.contents.className = "contents";
     this.container.appendChild(this.contents);
-    this.contents.addEventListener("click", event => this._clickHandler(event), false);
-    this.contents.addEventListener("dblclick", event => this._dblClickHandler(event), false);
-    this.container.addEventListener("scroll", event => this._scrollHandler(event), false)
-    this.container.addEventListener("keydown", event => this._keyDownHandler(event), false)
-    this.container.addEventListener("keyup", event => this._keyUpHandler(event), false)
+    this.contents.addEventListener(
+      "click",
+      (event) => this._clickHandler(event),
+      false
+    );
+    this.contents.addEventListener(
+      "dblclick",
+      (event) => this._dblClickHandler(event),
+      false
+    );
+    this.container.addEventListener(
+      "scroll",
+      (event) => this._scrollHandler(event),
+      false
+    );
+    this.container.addEventListener(
+      "keydown",
+      (event) => this._keyDownHandler(event),
+      false
+    );
+    this.container.addEventListener(
+      "keyup",
+      (event) => this._keyUpHandler(event),
+      false
+    );
     this.selectedItemIndex = undefined;
     this.container.classList.add("empty");
   }
@@ -81,7 +99,8 @@ export class List {
   _addMoreItemsIfNeeded() {
     while (
       this._itemsBackLog.length > 0 &&
-      this.container.scrollTop + this.container.offsetHeight + 200 > this.contents.offsetHeight
+      this.container.scrollTop + this.container.offsetHeight + 200 >
+        this.contents.offsetHeight
     ) {
       this._addMoreItems();
       if (this.container.offsetHeight === 0) {
@@ -164,8 +183,8 @@ export class List {
 
   _dispatchEvent(eventName) {
     const event = new CustomEvent(eventName, {
-      "bubbles": false,
-      "detail": this,
+      bubbles: false,
+      detail: this,
     });
     this.container.dispatchEvent(event);
   }
@@ -192,7 +211,7 @@ export class List {
     this._isKeyRepeating = event.repeat;
     this.setSelectedItemIndex(rowIndex, true);
     const newRow = this.contents.children[rowIndex];
-    newRow?.scrollIntoView({behavior: "auto", block: "nearest", inline: "nearest"});
+    newRow?.scrollIntoView({ behavior: "auto", block: "nearest", inline: "nearest" });
   }
 
   _keyUpHandler(event) {
@@ -207,5 +226,4 @@ export class List {
   _scrollHandler(event) {
     this._addMoreItemsIfNeeded();
   }
-
 }

--- a/src/fontra/client/core/ui-sliders.js
+++ b/src/fontra/client/core/ui-sliders.js
@@ -1,5 +1,4 @@
 export class Sliders {
-
   constructor(slidersID, sliderDescriptions) {
     this.container = document.querySelector(`#${slidersID}`);
     this.setSliderDescriptions(sliderDescriptions);
@@ -11,14 +10,14 @@ export class Sliders {
 
   _dispatchListSelectionChanged() {
     const event = new CustomEvent("slidersChanged", {
-      "bubbles": false,
-      "detail": this,
+      bubbles: false,
+      detail: this,
     });
     this.container.dispatchEvent(event);
   }
 
   setSliderDescriptions(sliderDescriptions) {
-    this.container.innerHTML = "";  // Delete previous sliders
+    this.container.innerHTML = ""; // Delete previous sliders
     for (const sliderInfo of sliderDescriptions) {
       if (sliderInfo.isDivider) {
         const divider = document.createElement("hr");
@@ -35,7 +34,7 @@ export class Sliders {
         slider.max = sliderInfo.maxValue;
         slider.value = sliderInfo.defaultValue;
         slider.dataset.name = sliderInfo.name;
-        slider.oninput = event => this._dispatchListSelectionChanged();
+        slider.oninput = (event) => this._dispatchListSelectionChanged();
         label.appendChild(slider);
         label.append(sliderInfo.name);
         this.container.appendChild(label);

--- a/src/fontra/client/core/utils.js
+++ b/src/fontra/client/core/utils.js
@@ -15,7 +15,6 @@ export function objectsEqual(obj1, obj2) {
   return true;
 }
 
-
 export function withSavedState(context, func) {
   context.save();
   try {
@@ -26,7 +25,6 @@ export function withSavedState(context, func) {
   }
   context.restore();
 }
-
 
 export function scheduleCalls(func, timeout = 0) {
   // Schedule calls to func with a timer. If a previously scheduled call
@@ -46,7 +44,6 @@ export function scheduleCalls(func, timeout = 0) {
   };
 }
 
-
 export function throttleCalls(func, minTime) {
   // Return a wrapped function. If the function gets called before
   // minTime (in ms) has elapsed since the last call, don't call
@@ -56,7 +53,7 @@ export function throttleCalls(func, minTime) {
   return (...args) => {
     if (timeoutID !== null) {
       clearTimeout(timeoutID);
-      timeoutID = null
+      timeoutID = null;
     }
     const now = Date.now();
     if (now - lastTime > minTime) {
@@ -74,34 +71,29 @@ export function throttleCalls(func, minTime) {
   };
 }
 
-
 export function parseCookies(str) {
   // https://www.geekstrick.com/snippets/how-to-parse-cookies-in-javascript/
   if (!str.trim()) {
     return {};
   }
   return str
-  .split(';')
-  .map(v => v.split('='))
-  .reduce((acc, v) => {
-    acc[decodeURIComponent(v[0].trim())] = decodeURIComponent(v[1].trim());
-    return acc;
-  }, {});
+    .split(";")
+    .map((v) => v.split("="))
+    .reduce((acc, v) => {
+      acc[decodeURIComponent(v[0].trim())] = decodeURIComponent(v[1].trim());
+      return acc;
+    }, {});
 }
-
 
 export function capitalizeFirstLetter(s) {
   return s.charAt(0).toUpperCase() + s.slice(1);
 }
 
-
 export function hyphenatedToCamelCase(s) {
-  return s.replace(/-([a-z])/g, m => m[1].toUpperCase());
+  return s.replace(/-([a-z])/g, (m) => m[1].toUpperCase());
 }
 
-
 export const THEME_KEY = "fontra-theme";
-
 
 export function themeSwitch(value) {
   const rootElement = document.querySelector("html");
@@ -112,18 +104,15 @@ export function themeSwitch(value) {
   }
 }
 
-
 export function themeSwitchFromLocalStorage() {
   _themeSwitchFromLocalStorage();
 
-  addEventListener("storage", event => {
+  addEventListener("storage", (event) => {
     if (event.key === THEME_KEY) {
       _themeSwitchFromLocalStorage();
     }
   });
-
 }
-
 
 function _themeSwitchFromLocalStorage() {
   const themeValue = localStorage.getItem(THEME_KEY);
@@ -131,7 +120,6 @@ function _themeSwitchFromLocalStorage() {
     themeSwitch(themeValue);
   }
 }
-
 
 export function hasShortcutModifierKey(event) {
   if (navigator.platform.toLowerCase().indexOf("mac") >= 0) {
@@ -141,21 +129,18 @@ export function hasShortcutModifierKey(event) {
   }
 }
 
-
 export const arrowKeyDeltas = {
-  "ArrowUp": [0, 1],
-  "ArrowDown": [0, -1],
-  "ArrowLeft": [-1, 0],
-  "ArrowRight": [1, 0],
-}
-
+  ArrowUp: [0, 1],
+  ArrowDown: [0, -1],
+  ArrowLeft: [-1, 0],
+  ArrowRight: [1, 0],
+};
 
 export function modulo(v, n) {
   // Modulo with Python behavior for negative values of `v`
   // Assumes `n` to be positive
-  return v >= 0 ? v % n : (v % n + n) % n;
+  return v >= 0 ? v % n : ((v % n) + n) % n;
 }
-
 
 export function sign(v) {
   if (v > 0) {
@@ -167,22 +152,19 @@ export function sign(v) {
   }
 }
 
-
 export function boolInt(v) {
   // Return 1 if `v` is true-y, 0 if `v` is false-y
   return v ? 1 : 0;
 }
 
-
-export function *reversed(seq) {
+export function* reversed(seq) {
   // Like Python's reversed(seq) builtin
   for (let i = seq.length - 1; i >= 0; i--) {
     yield seq[i];
   }
 }
 
-
-export function *enumerate(iterable, start = 0) {
+export function* enumerate(iterable, start = 0) {
   let i = start;
   for (const item of iterable) {
     yield [i, item];
@@ -190,8 +172,7 @@ export function *enumerate(iterable, start = 0) {
   }
 }
 
-
-export function *range(start, stop, step = 1) {
+export function* range(start, stop, step = 1) {
   if (stop === undefined) {
     stop = start;
     start = 0;
@@ -201,12 +182,11 @@ export function *range(start, stop, step = 1) {
   }
 }
 
-
 export async function tryFinally(func, finallyFunc) {
   let error;
   try {
     await func();
-  } catch(e) {
+  } catch (e) {
     error = e;
   }
   await finallyFunc();
@@ -214,7 +194,6 @@ export async function tryFinally(func, finallyFunc) {
     throw error;
   }
 }
-
 
 export function parseSelection(selection) {
   const result = {};
@@ -232,16 +211,13 @@ export function parseSelection(selection) {
   return result;
 }
 
-
 export function makeUPlusStringFromCodePoint(codePoint) {
   if (codePoint && typeof codePoint != "number") {
-    throw new Error(`codePoint argument must be a number or falsey; ${typeof codePoint} found`);
+    throw new Error(
+      `codePoint argument must be a number or falsey; ${typeof codePoint} found`
+    );
   }
-  return (
-    typeof codePoint == "number"
-    ?
-    "U+" + codePoint.toString(16).toUpperCase().padStart(4, "0")
-    :
-    ""
-  );
+  return typeof codePoint == "number"
+    ? "U+" + codePoint.toString(16).toUpperCase().padStart(4, "0")
+    : "";
 }

--- a/src/fontra/client/core/value-controller.js
+++ b/src/fontra/client/core/value-controller.js
@@ -1,5 +1,4 @@
 export class ValueController {
-
   constructor() {
     this._observers = new Map();
   }
@@ -34,5 +33,4 @@ export class ValueController {
   removeObserver(observerID) {
     this._observers.delete(observerID);
   }
-
 }

--- a/src/fontra/client/core/var-array.js
+++ b/src/fontra/client/core/var-array.js
@@ -1,8 +1,6 @@
-import { VariationError } from "./errors.js"
-
+import { VariationError } from "./errors.js";
 
 export default class VarArray extends Array {
-
   copy() {
     return this.slice();
   }
@@ -10,7 +8,9 @@ export default class VarArray extends Array {
   addItemwise(other) {
     const numItems = this.length;
     if (numItems !== other.length) {
-      throw new VariationError(`arrays have different lengths: ${numItems} vs. ${other.length}`);
+      throw new VariationError(
+        `arrays have different lengths: ${numItems} vs. ${other.length}`
+      );
     }
     const result = new this.constructor(numItems);
     for (let i = 0; i < numItems; i++) {
@@ -22,7 +22,9 @@ export default class VarArray extends Array {
   subItemwise(other) {
     const numItems = this.length;
     if (numItems !== other.length) {
-      throw new VariationError(`arrays have different lengths: ${numItems} vs. ${other.length}`);
+      throw new VariationError(
+        `arrays have different lengths: ${numItems} vs. ${other.length}`
+      );
     }
     const result = new this.constructor(numItems);
     for (let i = 0; i < numItems; i++) {

--- a/src/fontra/client/core/var-funcs.js
+++ b/src/fontra/client/core/var-funcs.js
@@ -1,10 +1,10 @@
-import { VariationError } from "./errors.js"
-
+import { VariationError } from "./errors.js";
 
 export function addItemwise(a, b) {
   if (typeof a !== typeof b) {
     throw new VariationError(`incompatible object types: typeof ${a} != typeof ${b}`);
-  } if (typeof a === "string") {
+  }
+  if (typeof a === "string") {
     if (a !== b) {
       throw new VariationError(`unexpected different strings: ${a} != ${b}`);
     }
@@ -20,7 +20,6 @@ export function addItemwise(a, b) {
   }
   return itemwiseFunc(a, b, addItemwise);
 }
-
 
 export function subItemwise(a, b) {
   if (typeof a !== typeof b) {
@@ -42,7 +41,6 @@ export function subItemwise(a, b) {
   return itemwiseFunc(a, b, subItemwise);
 }
 
-
 export function mulScalar(o, scalar) {
   if (scalar === 1 || typeof o === "string") {
     return o;
@@ -58,13 +56,14 @@ export function mulScalar(o, scalar) {
   return objectMap(o, scalar, mulScalar);
 }
 
-
 function itemwiseFunc(a, b, func) {
   var result;
   if (Array.isArray(a)) {
     result = new a.constructor(a.length);
     if (a.length != b.length) {
-      throw new VariationError(`arrays have incompatible lengths: ${a.length} != ${b.length}`);
+      throw new VariationError(
+        `arrays have incompatible lengths: ${a.length} != ${b.length}`
+      );
     }
     for (let i = 0; i < a.length; i++) {
       result[i] = func(a[i], b[i]);
@@ -75,13 +74,19 @@ function itemwiseFunc(a, b, func) {
     if (keys.length != Object.keys(b).length) {
       // console.log("--> a", a);
       // console.log("--> b", b);
-      throw new VariationError(`objects have incompatible number of entries: ${keys.length} != ${Object.keys(b).length}`);
+      throw new VariationError(
+        `objects have incompatible number of entries: ${keys.length} != ${
+          Object.keys(b).length
+        }`
+      );
     }
     for (const key of keys) {
       const valueA = a[key];
       const valueB = b[key];
-      if ( (valueA === undefined) !== (valueB === undefined) ) {
-        throw new VariationError(`objects have incompatible key sets: ${keys} != ${Object.keys(b)}`);
+      if ((valueA === undefined) !== (valueB === undefined)) {
+        throw new VariationError(
+          `objects have incompatible key sets: ${keys} != ${Object.keys(b)}`
+        );
       }
       result[key] = func(valueA, valueB);
     }
@@ -89,11 +94,10 @@ function itemwiseFunc(a, b, func) {
   return result;
 }
 
-
 function objectMap(o, argument, func) {
   var result;
   if (Array.isArray(o)) {
-    return o.map(item => func(item, argument));
+    return o.map((item) => func(item, argument));
   } else {
     result = new o.constructor();
     for (const key of Object.keys(o)) {

--- a/src/fontra/client/core/var-glyph.js
+++ b/src/fontra/client/core/var-glyph.js
@@ -1,18 +1,16 @@
 import { VarPackedPath } from "./var-path.js";
 
-
 export class VariableGlyph {
-
   static fromObject(obj) {
     const glyph = new VariableGlyph();
     glyph.name = obj.name;
     glyph.axes = obj.axes || [];
-    glyph.sources = obj.sources.map(source => Source.fromObject(source));
-    glyph.layers = obj.layers.map(layer => {
+    glyph.sources = obj.sources.map((source) => Source.fromObject(source));
+    glyph.layers = obj.layers.map((layer) => {
       return {
-        "name": layer.name,
-        "glyph": StaticGlyph.fromObject(layer.glyph),
-      }
+        name: layer.name,
+        glyph: StaticGlyph.fromObject(layer.glyph),
+      };
     });
     return glyph;
   }
@@ -34,12 +32,9 @@ export class VariableGlyph {
       }
     }
   }
-
 }
 
-
 class Source {
-
   static fromObject(obj) {
     const source = new Source();
     source.name = obj.name;
@@ -47,12 +42,9 @@ class Source {
     source.layerName = obj.layerName;
     return source;
   }
-
 }
 
-
 export class StaticGlyph {
-
   static fromObject(obj) {
     const source = new StaticGlyph();
     source.xAdvance = obj.xAdvance;
@@ -64,7 +56,6 @@ export class StaticGlyph {
       source.path = new VarPackedPath();
     }
     source.components = obj.components || [];
-    return source
+    return source;
   }
-
 }

--- a/src/fontra/client/core/var-model.js
+++ b/src/fontra/client/core/var-model.js
@@ -1,16 +1,14 @@
 // Partial port of fontTools.varLib.models.VariationModel
 
 import { VariationError } from "./errors.js";
-import { addItemwise, subItemwise, mulScalar } from "./var-funcs.js"
+import { addItemwise, subItemwise, mulScalar } from "./var-funcs.js";
 import { isSuperset } from "./set-ops.js";
 
-
 export class VariationModel {
-
   constructor(locations, axisOrder = null) {
     this.locations = locations;
     this.axisOrder = axisOrder || [];
-    const locationsSet = new Set(locations.map(item => locationToString(item)));
+    const locationsSet = new Set(locations.map((item) => locationToString(item)));
     if (locationsSet.size != locations.length) {
       console.log("locations:", locations);
       throw new VariationError("locations must be unique");
@@ -22,8 +20,8 @@ export class VariationModel {
     // Mapping from user's master order to our master order
     const locationsStr = locations.map(locationToString);
     const thisLocationsStr = this.locations.map(locationToString);
-    this.mapping = locationsStr.map(loc => thisLocationsStr.indexOf(loc));
-    this.reverseMapping = thisLocationsStr.map(loc => locationsStr.indexOf(loc));
+    this.mapping = locationsStr.map((loc) => thisLocationsStr.indexOf(loc));
+    this.reverseMapping = thisLocationsStr.map((loc) => locationsStr.indexOf(loc));
 
     this._computeMasterSupports();
   }
@@ -44,10 +42,12 @@ export class VariationModel {
         // If it's NOT in the current box, it does not participate
         let relevant = true;
         for (const [axis, [lower, peak, upper]] of Object.entries(region)) {
-          if (prev_region[axis] === undefined ||
-              !(prev_region[axis][1] === peak ||
-                (lower < prev_region[axis][1] && prev_region[axis][1] < upper)
-              )
+          if (
+            prev_region[axis] === undefined ||
+            !(
+              prev_region[axis][1] === peak ||
+              (lower < prev_region[axis][1] && prev_region[axis][1] < upper)
+            )
           ) {
             relevant = false;
             break;
@@ -70,7 +70,7 @@ export class VariationModel {
           const val = prev_region[axis][1];
           // assert axis in region
           const [lower, locV, upper] = region[axis];
-          let [newLower, newUpper] = [lower, upper]
+          let [newLower, newUpper] = [lower, upper];
           let ratio;
           if (val < locV) {
             newLower = val;
@@ -78,7 +78,8 @@ export class VariationModel {
           } else if (locV < val) {
             newUpper = val;
             ratio = (val - locV) / (upper - locV);
-          } else {  // val == locV
+          } else {
+            // val == locV
             // Can't split box in this direction.
             continue;
           }
@@ -97,7 +98,7 @@ export class VariationModel {
       }
       this.supports.push(region);
     }
-    this._computeDeltaWeights()
+    this._computeDeltaWeights();
   }
 
   _locationsToRegions() {
@@ -122,7 +123,7 @@ export class VariationModel {
           region[axis] = [minV[axis], locV, 0];
         }
       }
-      regions.push(region)
+      regions.push(region);
     }
     return regions;
   }
@@ -133,7 +134,7 @@ export class VariationModel {
       const loc = this.locations[i];
       const deltaWeight = new Map();
       // Walk over previous masters now, populate deltaWeight
-      for (let j = 0; j < i; j ++) {
+      for (let j = 0; j < i; j++) {
         const support = this.supports[j];
         const scalar = supportScalar(loc, support);
         if (scalar) {
@@ -146,7 +147,9 @@ export class VariationModel {
 
   getDeltas(masterValues) {
     if (masterValues.length !== this.deltaWeights.length) {
-      throw new VariationError("masterValues must have the same length as this.deltaWeights")
+      throw new VariationError(
+        "masterValues must have the same length as this.deltaWeights"
+      );
     }
     const mapping = this.reverseMapping;
     const out = [];
@@ -160,7 +163,7 @@ export class VariationModel {
           } else {
             delta = subItemwise(delta, mulScalar(out[j], weight));
           }
-        } catch(error) {
+        } catch (error) {
           console.log(`error in master ${mapping[i]}`);
           throw error;
         }
@@ -171,24 +174,21 @@ export class VariationModel {
   }
 
   getScalars(loc) {
-    return this.supports.map(support => supportScalar(loc, support));
+    return this.supports.map((support) => supportScalar(loc, support));
   }
 
   interpolateFromDeltas(loc, deltas) {
     const scalars = this.getScalars(loc);
     return interpolateFromDeltasAndScalars(deltas, scalars);
   }
-
 }
-
 
 function sortedLocations(locations, axisOrder = null) {
   // decorate, sort, undecorate
   const decoratedLocations = getDecoratedMasterLocations(locations, axisOrder || []);
   decoratedLocations.sort((a, b) => deepCompare(a[0], b[0]));
-  return decoratedLocations.map(item => item[1]);
+  return decoratedLocations.map((item) => item[1]);
 }
-
 
 function getDecoratedMasterLocations(locations, axisOrder) {
   if (!locationsContainsBaseMaster(locations)) {
@@ -223,24 +223,27 @@ function getDecoratedMasterLocations(locations, axisOrder) {
         onPointAxes.push(axis);
       }
     }
-    const orderedAxes = axisOrder.filter(axis => loc[axis] !== undefined);
-    orderedAxes.push(...(Object.keys(loc).sort()).filter(axis => axisOrder.indexOf(axis) === -1));
+    const orderedAxes = axisOrder.filter((axis) => loc[axis] !== undefined);
+    orderedAxes.push(
+      ...Object.keys(loc)
+        .sort()
+        .filter((axis) => axisOrder.indexOf(axis) === -1)
+    );
     const deco = [
-      rank,  // First, order by increasing rank
-      -onPointAxes.length,  // Next, by decreasing number of onPoint axes
-      orderedAxes.map(axis => {
+      rank, // First, order by increasing rank
+      -onPointAxes.length, // Next, by decreasing number of onPoint axes
+      orderedAxes.map((axis) => {
         const index = axisOrder.indexOf(axis);
         return index != -1 ? index : 0x10000;
-      }),  // Next, by known axes
-      orderedAxes,  // Next, by all axes
-      orderedAxes.map(axis => sign(loc[axis])),  // Next, by signs of axis values
-      orderedAxes.map(axis => Math.abs(loc[axis])),  // Next, by absolute value of axis values
+      }), // Next, by known axes
+      orderedAxes, // Next, by all axes
+      orderedAxes.map((axis) => sign(loc[axis])), // Next, by signs of axis values
+      orderedAxes.map((axis) => Math.abs(loc[axis])), // Next, by absolute value of axis values
     ];
     result[i] = [deco, locations[i]];
   }
   return result;
 }
-
 
 function locationsContainsBaseMaster(locations) {
   for (let i = 0; i < locations.length; i++) {
@@ -251,7 +254,6 @@ function locationsContainsBaseMaster(locations) {
   return false;
 }
 
-
 function objectGet(o, k, dflt) {
   const result = o[k];
   if (result === undefined) {
@@ -260,18 +262,15 @@ function objectGet(o, k, dflt) {
   return result;
 }
 
-
 function sign(v) {
-  return v < 0 ? -1 : v > 0 ? 1 : 0
+  return v < 0 ? -1 : v > 0 ? 1 : 0;
 }
-
 
 function sorted(a) {
   const result = a.slice();
   result.sort();
   return result;
 }
-
 
 export function locationToString(loc) {
   const sortedLoc = {};
@@ -281,10 +280,9 @@ export function locationToString(loc) {
   return JSON.stringify(sortedLoc);
 }
 
-
 export function normalizeValue(v, lower, dflt, upper) {
   // Normalizes value based on a min/default/max triple.
-  if (!((lower <= dflt) && (dflt <= upper))) {
+  if (!(lower <= dflt && dflt <= upper)) {
     throw new VariationError(
       `Invalid axis values, must be minimum, default, maximum: ${lower}, ${dflt}, ${upper}`
     );
@@ -297,9 +295,8 @@ export function normalizeValue(v, lower, dflt, upper) {
   } else {
     v = (v - dflt) / (upper - dflt);
   }
-  return v
+  return v;
 }
-
 
 export function normalizeLocation(location, axisList) {
   // Normalizes location based on axis min/default/max values from axes.
@@ -314,8 +311,7 @@ export function normalizeLocation(location, axisList) {
   return out;
 }
 
-
-export function supportScalar(location, support, ot=true) {
+export function supportScalar(location, support, ot = true) {
   // Returns the scalar multiplier at location, for a master
   // with support.  If ot is True, then a peak value of zero
   // for support of an axis means "axis does not participate".  That
@@ -355,9 +351,8 @@ export function supportScalar(location, support, ot=true) {
       scalar *= (v - upper) / (peak - upper);
     }
   }
-  return scalar
+  return scalar;
 }
-
 
 function interpolateFromDeltasAndScalars(deltas, scalars) {
   if (deltas.length !== scalars.length) {
@@ -378,7 +373,6 @@ function interpolateFromDeltasAndScalars(deltas, scalars) {
   }
   return v;
 }
-
 
 export function deepCompare(a, b) {
   if (typeof a !== typeof b) {
@@ -416,19 +410,16 @@ export function deepCompare(a, b) {
   }
 }
 
-
 export function mapForward(location, axes) {
   return _mapSpace(location, axes, _fromEntries);
 }
-
 
 export function mapBackward(location, axes) {
   return _mapSpace(location, axes, _reverseFromEntries);
 }
 
-
 function _mapSpace(location, axes, mapFunc) {
-  const mappedLocation = {...location};
+  const mappedLocation = { ...location };
   const axesWithMap = {};
 
   for (const axis of axes) {
@@ -443,14 +434,12 @@ function _mapSpace(location, axes, mapFunc) {
   return mappedLocation;
 }
 
-
 function _fromEntries(mappingArray) {
   if (!mappingArray) {
     return undefined;
   }
   return Object.fromEntries(mappingArray);
 }
-
 
 function _reverseFromEntries(mappingArray) {
   if (!mappingArray) {
@@ -462,7 +451,6 @@ function _reverseFromEntries(mappingArray) {
   }
   return mapping;
 }
-
 
 export function piecewiseLinearMap(v, mapping) {
   if (!mapping) {
@@ -484,9 +472,9 @@ export function piecewiseLinearMap(v, mapping) {
     return v + mapping[k] - k;
   }
   // Interpolate
-  const a = Math.max(...keys.filter(k => k < v));  // (k for k in keys if k < v)
-  const b = Math.min(...keys.filter(k => k > v));  // (k for k in keys if k > v)
+  const a = Math.max(...keys.filter((k) => k < v)); // (k for k in keys if k < v)
+  const b = Math.min(...keys.filter((k) => k > v)); // (k for k in keys if k > v)
   const va = mapping[a];
   const vb = mapping[b];
-  return va + (vb - va) * (v - a) / (b - a);
+  return va + ((vb - va) * (v - a)) / (b - a);
 }

--- a/src/fontra/client/core/var-path.js
+++ b/src/fontra/client/core/var-path.js
@@ -1,16 +1,13 @@
-import VarArray from "./var-array.js"
-import { VariationError } from "./errors.js"
+import VarArray from "./var-array.js";
+import { VariationError } from "./errors.js";
 import { pointInRect } from "./rectangle.js";
 import { convexHull } from "./convex-hull.js";
 import { enumerate } from "./utils.js";
 
-
 export const POINT_TYPE_OFF_CURVE_QUAD = "quad";
 export const POINT_TYPE_OFF_CURVE_CUBIC = "cubic";
 
-
 export class VarPackedPath {
-
   // point types
   static ON_CURVE = 0x00;
   static OFF_CURVE_QUAD = 0x01;
@@ -81,7 +78,7 @@ export class VarPackedPath {
       xMax = Math.max(x, xMax);
       yMax = Math.max(y, yMax);
     }
-    return {"xMin": xMin, "yMin": yMin, "xMax": xMax, "yMax": yMax};
+    return { xMin: xMin, yMin: yMin, xMax: xMax, yMax: yMax };
   }
 
   getConvexHull() {
@@ -90,7 +87,7 @@ export class VarPackedPath {
     }
     const points = [];
     for (let i = 0; i < this.coordinates.length; i += 2) {
-      points.push({"x": this.coordinates[i], "y": this.coordinates[i + 1]});
+      points.push({ x: this.coordinates[i], y: this.coordinates[i + 1] });
     }
     return convexHull(points);
   }
@@ -103,18 +100,17 @@ export class VarPackedPath {
     let lo = 0;
     let hi = this.contourInfo.length;
     while (lo < hi) {
-      const mid = (lo + hi) >> 1;  // Math.floor((lo + hi) / 2)
+      const mid = (lo + hi) >> 1; // Math.floor((lo + hi) / 2)
       if (pointIndex <= this.contourInfo[mid].endPoint) {
         hi = mid;
-      }
-      else {
+      } else {
         lo = mid + 1;
       }
     }
     if (lo >= this.contourInfo.length) {
       return undefined;
     }
-    return lo
+    return lo;
   }
 
   getContourAndPointIndex(pointIndex) {
@@ -135,8 +131,8 @@ export class VarPackedPath {
   _getUnpackedContour(contourIndex) {
     const contourInfo = this.contourInfo[contourIndex];
     return {
-      "points": Array.from(this._iterPointsOfContour(contourIndex)),
-      "isClosed": contourInfo.isClosed,
+      points: Array.from(this._iterPointsOfContour(contourIndex)),
+      isClosed: contourInfo.isClosed,
     };
   }
 
@@ -153,9 +149,9 @@ export class VarPackedPath {
     const contour = this.contourInfo[contourIndex];
     const startPoint = this._getContourStartPoint(contourIndex);
     return {
-      "coordinates": this.coordinates.slice(startPoint * 2, (contour.endPoint + 1) * 2),
-      "pointTypes": this.pointTypes.slice(startPoint, contour.endPoint + 1),
-      "isClosed": contour.isClosed,
+      coordinates: this.coordinates.slice(startPoint * 2, (contour.endPoint + 1) * 2),
+      pointTypes: this.pointTypes.slice(startPoint, contour.endPoint + 1),
+      isClosed: contour.isClosed,
     };
   }
 
@@ -163,7 +159,12 @@ export class VarPackedPath {
     contourIndex = this._normalizeContourIndex(contourIndex);
     const startPoint = this._getContourStartPoint(contourIndex);
     const numOldPoints = this.contourInfo[contourIndex].endPoint + 1 - startPoint;
-    this._replacePoints(startPoint, numOldPoints, contour.coordinates, contour.pointTypes);
+    this._replacePoints(
+      startPoint,
+      numOldPoints,
+      contour.coordinates,
+      contour.pointTypes
+    );
     this._moveEndPoints(contourIndex, contour.pointTypes.length - numOldPoints);
     this.contourInfo[contourIndex].isClosed = contour.isClosed;
   }
@@ -176,8 +177,8 @@ export class VarPackedPath {
     contourIndex = this._normalizeContourIndex(contourIndex, true);
     const startPoint = this._getContourStartPoint(contourIndex);
     this._replacePoints(startPoint, 0, contour.coordinates, contour.pointTypes);
-    const contourInfo = {"endPoint": startPoint - 1, "isClosed": contour.isClosed};
-    this.contourInfo.splice(contourIndex, 0, contourInfo)
+    const contourInfo = { endPoint: startPoint - 1, isClosed: contour.isClosed };
+    this.contourInfo.splice(contourIndex, 0, contourInfo);
     this._moveEndPoints(contourIndex, contour.pointTypes.length);
   }
 
@@ -201,13 +202,10 @@ export class VarPackedPath {
     }
     const pointType = this.pointTypes[pointIndex] & VarPackedPath.POINT_TYPE_MASK;
     if (pointType) {
-      point["type"] = (
+      point["type"] =
         pointType === VarPackedPath.OFF_CURVE_CUBIC
-        ?
-        POINT_TYPE_OFF_CURVE_CUBIC
-        :
-        POINT_TYPE_OFF_CURVE_QUAD
-      );
+          ? POINT_TYPE_OFF_CURVE_CUBIC
+          : POINT_TYPE_OFF_CURVE_QUAD;
     } else if (this.pointTypes[pointIndex] & VarPackedPath.SMOOTH_FLAG) {
       point["smooth"] = true;
     }
@@ -234,19 +232,31 @@ export class VarPackedPath {
 
   getContourPoint(contourIndex, contourPointIndex) {
     contourIndex = this._normalizeContourIndex(contourIndex);
-    const pointIndex = this.getAbsolutePointIndex(contourIndex, contourPointIndex, false);
+    const pointIndex = this.getAbsolutePointIndex(
+      contourIndex,
+      contourPointIndex,
+      false
+    );
     return this.getPoint(pointIndex);
   }
 
   setContourPoint(contourIndex, contourPointIndex, point) {
     contourIndex = this._normalizeContourIndex(contourIndex);
-    const pointIndex = this.getAbsolutePointIndex(contourIndex, contourPointIndex, false);
+    const pointIndex = this.getAbsolutePointIndex(
+      contourIndex,
+      contourPointIndex,
+      false
+    );
     this.setPoint(pointIndex, point);
   }
 
   insertPoint(contourIndex, contourPointIndex, point) {
     contourIndex = this._normalizeContourIndex(contourIndex);
-    const pointIndex = this.getAbsolutePointIndex(contourIndex, contourPointIndex, true);
+    const pointIndex = this.getAbsolutePointIndex(
+      contourIndex,
+      contourPointIndex,
+      true
+    );
     this._insertPoint(contourIndex, pointIndex, point);
   }
 
@@ -345,13 +355,23 @@ export class VarPackedPath {
     for (const contour of this.contourInfo) {
       const endPoint = contour.endPoint;
       let prevIndex = contour.isClosed ? endPoint : startPoint;
-      for (let nextIndex = startPoint + (contour.isClosed ? 0 : 1); nextIndex <= endPoint; nextIndex++) {
+      for (
+        let nextIndex = startPoint + (contour.isClosed ? 0 : 1);
+        nextIndex <= endPoint;
+        nextIndex++
+      ) {
         const prevType = this.pointTypes[prevIndex] & VarPackedPath.POINT_TYPE_MASK;
         const nextType = this.pointTypes[nextIndex] & VarPackedPath.POINT_TYPE_MASK;
         if (prevType != nextType) {
           yield [
-            {x: this.coordinates[prevIndex * 2], y: this.coordinates[prevIndex * 2 + 1]},
-            {x: this.coordinates[nextIndex * 2], y: this.coordinates[nextIndex * 2 + 1]},
+            {
+              x: this.coordinates[prevIndex * 2],
+              y: this.coordinates[prevIndex * 2 + 1],
+            },
+            {
+              x: this.coordinates[nextIndex * 2],
+              y: this.coordinates[nextIndex * 2 + 1],
+            },
           ];
         }
         prevIndex = nextIndex;
@@ -363,7 +383,7 @@ export class VarPackedPath {
   *iterPointsInRect(rect) {
     for (const [pointIndex, point] of enumerate(this.iterPoints())) {
       if (pointInRect(point.x, point.y, rect)) {
-        yield {...point, pointIndex: pointIndex};
+        yield { ...point, pointIndex: pointIndex };
       }
     }
   }
@@ -372,7 +392,9 @@ export class VarPackedPath {
     return new this.constructor(
       this.coordinates.copy(),
       this.pointTypes.slice(),
-      this.contourInfo.map(item => { return {...item} }),
+      this.contourInfo.map((item) => {
+        return { ...item };
+      })
     );
   }
 
@@ -383,7 +405,7 @@ export class VarPackedPath {
   }
 
   moveTo(x, y) {
-    this.appendContour({"coordinates": [], "pointTypes": [], "isClosed": false})
+    this.appendContour({ coordinates: [], pointTypes: [], isClosed: false });
     this._appendPoint(x, y, VarPackedPath.ON_CURVE);
   }
 
@@ -421,7 +443,11 @@ export class VarPackedPath {
     } else {
       otherCoordinates = other;
     }
-    return new this.constructor(this.coordinates.addItemwise(otherCoordinates), this.pointTypes, this.contourInfo);
+    return new this.constructor(
+      this.coordinates.addItemwise(otherCoordinates),
+      this.pointTypes,
+      this.contourInfo
+    );
   }
 
   subItemwise(other) {
@@ -432,7 +458,11 @@ export class VarPackedPath {
     } else {
       otherCoordinates = other;
     }
-    return new this.constructor(this.coordinates.subItemwise(otherCoordinates), this.pointTypes, this.contourInfo);
+    return new this.constructor(
+      this.coordinates.subItemwise(otherCoordinates),
+      this.pointTypes,
+      this.contourInfo
+    );
   }
 
   _ensureCompatibility(other) {
@@ -445,11 +475,15 @@ export class VarPackedPath {
   }
 
   mulScalar(scalar) {
-    return new this.constructor(this.coordinates.mulScalar(scalar), this.pointTypes, this.contourInfo);
+    return new this.constructor(
+      this.coordinates.mulScalar(scalar),
+      this.pointTypes,
+      this.contourInfo
+    );
   }
 
   drawToPath2d(path) {
-    let startPoint = 0
+    let startPoint = 0;
     const coordinates = this.coordinates;
     const pointTypes = this.pointTypes;
 
@@ -461,14 +495,25 @@ export class VarPackedPath {
 
       // Determine the index of the first on-curve point, if any
       for (let i = 0; i < numPoints; i++) {
-        if ((pointTypes[i + startPoint] & VarPackedPath.POINT_TYPE_MASK) === VarPackedPath.ON_CURVE) {
+        if (
+          (pointTypes[i + startPoint] & VarPackedPath.POINT_TYPE_MASK) ===
+          VarPackedPath.ON_CURVE
+        ) {
           firstOnCurve = i;
           break;
         }
       }
 
       if (firstOnCurve !== null) {
-        drawContourToPath(path, coordinates, pointTypes, startPoint, numPoints, firstOnCurve, contour.isClosed);
+        drawContourToPath(
+          path,
+          coordinates,
+          pointTypes,
+          startPoint,
+          numPoints,
+          firstOnCurve,
+          contour.isClosed
+        );
       } else {
         // draw quad blob
         // create copy of contour points, and insert implied on-curve at front
@@ -478,7 +523,15 @@ export class VarPackedPath {
         const yMid = (blobCoordinates[1] + blobCoordinates[endPoint * 2 + 1]) / 2;
         blobCoordinates.unshift(xMid, yMid);
         blobPointTypes.unshift(VarPackedPath.ON_CURVE);
-        drawContourToPath(path, blobCoordinates, blobPointTypes, 0, numPoints + 1, 0, true);
+        drawContourToPath(
+          path,
+          blobCoordinates,
+          blobPointTypes,
+          0,
+          numPoints + 1,
+          0,
+          true
+        );
       }
 
       startPoint = endPoint + 1;
@@ -499,7 +552,9 @@ export class VarPackedPath {
     const result = new VarPackedPath();
     result.coordinates = this.coordinates.concat(other.coordinates);
     result.pointTypes = this.pointTypes.concat(other.pointTypes);
-    result.contourInfo = this.contourInfo.concat(other.contourInfo).map(c => { return {...c}; });
+    result.contourInfo = this.contourInfo.concat(other.contourInfo).map((c) => {
+      return { ...c };
+    });
     const endPointOffset = this.numPoints;
     for (let i = this.contourInfo.length; i < result.contourInfo.length; i++) {
       result.contourInfo[i].endPoint += endPointOffset;
@@ -527,16 +582,24 @@ export class VarPackedPath {
     }
     return bad;
   }
-
 }
 
-
-function drawContourToPath(path, coordinates, pointTypes, startPoint, numPoints, firstOnCurve, isClosed) {
+function drawContourToPath(
+  path,
+  coordinates,
+  pointTypes,
+  startPoint,
+  numPoints,
+  firstOnCurve,
+  isClosed
+) {
   let currentSegment = [];
   let segmentFunc = drawLineSegment;
   const lastIndex = isClosed ? numPoints : numPoints - 1 - firstOnCurve;
   for (let i = 0; i <= lastIndex; i++) {
-    const index = isClosed ? (startPoint + (firstOnCurve + i) % numPoints) : (startPoint + firstOnCurve + i);
+    const index = isClosed
+      ? startPoint + ((firstOnCurve + i) % numPoints)
+      : startPoint + firstOnCurve + i;
     const pointType = pointTypes[index] & VarPackedPath.POINT_TYPE_MASK;
     const x = coordinates[index * 2];
     const y = coordinates[index * 2 + 1];
@@ -546,7 +609,7 @@ function drawContourToPath(path, coordinates, pointTypes, startPoint, numPoints,
       currentSegment.push(x, y);
       switch (pointType) {
         case VarPackedPath.ON_CURVE:
-          segmentFunc(path, currentSegment)
+          segmentFunc(path, currentSegment);
           currentSegment = [];
           segmentFunc = drawLineSegment;
           break;
@@ -566,11 +629,9 @@ function drawContourToPath(path, coordinates, pointTypes, startPoint, numPoints,
   }
 }
 
-
 function drawLineSegment(path, segment) {
   path.lineTo(...segment);
 }
-
 
 function drawQuadSegment(path, segment) {
   let [x1, y1] = [segment[0], segment[1]];
@@ -584,7 +645,6 @@ function drawQuadSegment(path, segment) {
   }
   path.quadraticCurveTo(x1, y1, segment[lastIndex], segment[lastIndex + 1]);
 }
-
 
 function drawCubicSegment(path, segment) {
   if (segment.length === 4) {
@@ -602,42 +662,38 @@ function drawCubicSegment(path, segment) {
   }
 }
 
-
 function arrayEquals(a, b) {
   // Oh well
   return JSON.stringify(a) === JSON.stringify(b);
 }
-
 
 function pointTypesEquals(a, b) {
   if (a.length !== b.length) {
     return false;
   }
   for (let i = 0; i < a.length; i++) {
-    if ((a[i] & VarPackedPath.POINT_TYPE_MASK) != (b[i] & VarPackedPath.POINT_TYPE_MASK)) {
+    if (
+      (a[i] & VarPackedPath.POINT_TYPE_MASK) !=
+      (b[i] & VarPackedPath.POINT_TYPE_MASK)
+    ) {
       return false;
     }
   }
   return true;
 }
 
-
 function packPointType(type, smooth) {
   let pointType = VarPackedPath.ON_CURVE;
   if (type) {
-    pointType = (
+    pointType =
       type === POINT_TYPE_OFF_CURVE_CUBIC
-      ?
-      VarPackedPath.OFF_CURVE_CUBIC
-      :
-      VarPackedPath.OFF_CURVE_QUAD
-    );
+        ? VarPackedPath.OFF_CURVE_CUBIC
+        : VarPackedPath.OFF_CURVE_QUAD;
   } else if (smooth) {
     pointType |= VarPackedPath.SMOOTH_FLAG;
   }
   return pointType;
 }
-
 
 export function packContour(unpackedContour) {
   const coordinates = new VarArray(unpackedContour.points.length * 2);
@@ -649,8 +705,8 @@ export function packContour(unpackedContour) {
     pointTypes[i] = packPointType(point.type, point.smooth);
   }
   return {
-    "coordinates": coordinates,
-    "pointTypes": pointTypes,
-    "isClosed": unpackedContour.isClosed,
+    coordinates: coordinates,
+    pointTypes: pointTypes,
+    isClosed: unpackedContour.isClosed,
   };
 }

--- a/src/fontra/client/core/vector.js
+++ b/src/fontra/client/core/vector.js
@@ -1,27 +1,22 @@
 export function addVectors(vectorA, vectorB) {
-  return {"x": vectorA.x + vectorB.x, "y": vectorA.y + vectorB.y};
+  return { x: vectorA.x + vectorB.x, y: vectorA.y + vectorB.y };
 }
-
 
 export function subVectors(vectorA, vectorB) {
-  return {"x": vectorA.x - vectorB.x, "y": vectorA.y - vectorB.y};
+  return { x: vectorA.x - vectorB.x, y: vectorA.y - vectorB.y };
 }
-
 
 export function mulVector(vector, scalar) {
-  return {"x": vector.x * scalar, "y": vector.y * scalar};
+  return { x: vector.x * scalar, y: vector.y * scalar };
 }
-
 
 export function rotateVector90CW(vector) {
-  return {"x": vector.y, "y": -vector.x};
+  return { x: vector.y, y: -vector.x };
 }
-
 
 export function vectorLength(vector) {
   return Math.hypot(vector.x, vector.y);
 }
-
 
 export function normalizeVector(vector) {
   const length = Math.hypot(vector.x, vector.y);
@@ -31,14 +26,11 @@ export function normalizeVector(vector) {
   return mulVector(vector, 1 / length);
 }
 
-
 export function roundVector(vector) {
-  return {"x": Math.round(vector.x), "y": Math.round(vector.y)};
+  return { x: Math.round(vector.x), y: Math.round(vector.y) };
 }
 
-
 const _EPSILON = 1e-10;
-
 
 export function intersect(pt1, pt2, pt3, pt4) {
   // Return the intersection point of pt1-pt2 and pt3-pt4 as well as
@@ -55,15 +47,14 @@ export function intersect(pt1, pt2, pt3, pt4) {
   let intersection, t1, t2;
   const delta1 = subVectors(pt2, pt1);
   const delta2 = subVectors(pt4, pt3);
-  const determinant = (delta2.y*delta1.x - delta2.x*delta1.y);
+  const determinant = delta2.y * delta1.x - delta2.x * delta1.y;
   if (Math.abs(determinant) > _EPSILON) {
-    t1 = ((pt3.x - pt1.x)*delta2.y + (pt1.y - pt3.y)*delta2.x) / determinant;
-    t2 = ((pt1.x - pt3.x)*delta1.y + (pt3.y - pt1.y)*delta1.x) / -determinant;
+    t1 = ((pt3.x - pt1.x) * delta2.y + (pt1.y - pt3.y) * delta2.x) / determinant;
+    t2 = ((pt1.x - pt3.x) * delta1.y + (pt3.y - pt1.y) * delta1.x) / -determinant;
     intersection = addVectors(mulVector(delta1, t1), pt1);
   }
   return [intersection, t1, t2];
 }
-
 
 export function distance(pt1, pt2) {
   return vectorLength(subVectors(pt2, pt1));

--- a/src/fontra/client/css/context-menu.css
+++ b/src/fontra/client/css/context-menu.css
@@ -1,5 +1,5 @@
 :root {
-  --context-menu-background-color-light: #F0F0F0;
+  --context-menu-background-color-light: #f0f0f0;
   --context-menu-background-color-dark: #333;
 
   --context-menu-foreground-color-light: black;
@@ -15,36 +15,48 @@
 :root {
   --context-menu-background-color: var(--context-menu-background-color-light);
   --context-menu-foreground-color: var(--context-menu-foreground-color-light);
-  --context-menu-background-active-color: var(--context-menu-background-active-color-light);
-  --context-menu-foreground-active-color: var(--context-menu-foreground-active-color-light);
+  --context-menu-background-active-color: var(
+    --context-menu-background-active-color-light
+  );
+  --context-menu-foreground-active-color: var(
+    --context-menu-foreground-active-color-light
+  );
 }
 
 :root.dark-theme {
   --context-menu-background-color: var(--context-menu-background-color-dark);
   --context-menu-foreground-color: var(--context-menu-foreground-color-dark);
-  --context-menu-background-active-color: var(--context-menu-background-active-color-dark);
-  --context-menu-foreground-active-color: var(--context-menu-foreground-active-color-dark);
+  --context-menu-background-active-color: var(
+    --context-menu-background-active-color-dark
+  );
+  --context-menu-foreground-active-color: var(
+    --context-menu-foreground-active-color-dark
+  );
 }
 
-
 @media (prefers-color-scheme: dark) {
-
   :root {
     --context-menu-background-color: var(--context-menu-background-color-dark);
     --context-menu-foreground-color: var(--context-menu-foreground-color-dark);
-    --context-menu-background-active-color: var(--context-menu-background-active-color-dark);
-    --context-menu-foreground-active-color: var(--context-menu-foreground-active-color-dark);
+    --context-menu-background-active-color: var(
+      --context-menu-background-active-color-dark
+    );
+    --context-menu-foreground-active-color: var(
+      --context-menu-foreground-active-color-dark
+    );
   }
 
   :root.light-theme {
     --context-menu-background-color: var(--context-menu-background-color-light);
     --context-menu-foreground-color: var(--context-menu-foreground-color-light);
-    --context-menu-background-active-color: var(--context-menu-background-active-color-light);
-    --context-menu-foreground-active-color: var(--context-menu-foreground-active-color-light);
+    --context-menu-background-active-color: var(
+      --context-menu-background-active-color-light
+    );
+    --context-menu-foreground-active-color: var(
+      --context-menu-foreground-active-color-light
+    );
   }
-
 }
-
 
 #context-menu {
   display: none;
@@ -75,7 +87,7 @@
 
 .context-menu-item {
   padding: 0.2em 1.5em 0.2em 1em; /* top, right, bottom, left */
-  color: #808080A0;
+  color: #808080a0;
 }
 
 .context-menu-item.enabled {

--- a/src/fontra/client/css/core.css
+++ b/src/fontra/client/css/core.css
@@ -10,24 +10,21 @@
   font-weight: 700;
 }
 
-
 @font-face {
   font-family: "fontra-icons";
   src: url("../fonts/fontra-icons.woff2") format("woff2");
 }
-
 
 @font-face {
   font-family: "fontra-ui-semibold";
   src: url("../fonts/InriaSans-Regular.woff2") format("woff2");
 }
 
-
 :root {
-  --fontra-red-color: #F11759;
+  --fontra-red-color: #f11759;
 
   --foreground-color-light: black;
-  --background-color-light: #F6F6F6;
+  --background-color-light: #f6f6f6;
   --foreground-color-dark: white;
   --background-color-dark: #333;
 
@@ -35,15 +32,12 @@
   --background-color: var(--background-color-light);
 }
 
-
 :root.dark-theme {
   --foreground-color: var(--foreground-color-dark);
   --background-color: var(--background-color-dark);
 }
 
-
 @media (prefers-color-scheme: dark) {
-
   :root {
     --foreground-color: var(--foreground-color-dark);
     --background-color: var(--background-color-dark);
@@ -53,16 +47,15 @@
     --foreground-color: var(--foreground-color-light);
     --background-color: var(--background-color-light);
   }
-
 }
 
-
-html, body {
+html,
+body {
   font-family: fontra-ui-regular, sans-serif;
   font-feature-settings: "tnum" 1;
   font-size: 0.9em;
   padding: 0;
-  margin:  0;
+  margin: 0;
   width: 100%;
   height: 100%;
   overflow: hidden; /* Hide scrollbars */
@@ -74,7 +67,9 @@ html, body {
 }
 
 @keyframes global-loader-spinner {
-  to {transform: rotate(360deg);}
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 #global-loader-spinner {
@@ -88,7 +83,7 @@ html, body {
   margin-left: -5rem;
   box-sizing: border-box;
   border-radius: 50%;
-  border: 0.6rem solid #FFF8;
+  border: 0.6rem solid #fff8;
   border-top-color: #0005;
   border-left-color: #0005;
   animation: global-loader-spinner 0.8s linear infinite;

--- a/src/fontra/client/css/slider.css
+++ b/src/fontra/client/css/slider.css
@@ -1,6 +1,6 @@
 :root {
   --slider-thumb-color-light: #444;
-  --slider-thumb-color-dark: #BBB;
+  --slider-thumb-color-dark: #bbb;
 
   --slider-thumb-color: var(--slider-thumb-color-light);
 }
@@ -9,9 +9,7 @@
   --slider-thumb-color: var(--slider-thumb-color-dark);
 }
 
-
 @media (prefers-color-scheme: dark) {
-
   :root {
     --slider-thumb-color: var(--slider-thumb-color-dark);
   }
@@ -19,11 +17,9 @@
   :root.light-theme {
     --slider-thumb-color: var(--slider-thumb-color-light);
   }
-
 }
 
-
-input[type=range] {
+input[type="range"] {
   --slider-track-width: 10em;
   --slider-track-height: 0.3em;
   --slider-track-color: #0008;
@@ -33,17 +29,17 @@ input[type=range] {
   --slider-thumb-border-radius: 8px;
 }
 
-input[type=range] {
+input[type="range"] {
   height: var(--slider-track-height);
   -webkit-appearance: none;
   margin: 5px 10px;
   width: var(--slider-track-width);
 }
-input[type=range]:focus {
+input[type="range"]:focus {
   outline: none;
 }
 
-input[type=range]::-webkit-slider-runnable-track {
+input[type="range"]::-webkit-slider-runnable-track {
   width: var(--slider-track-width);
   height: var(--slider-track-height);
   cursor: pointer;
@@ -53,7 +49,7 @@ input[type=range]::-webkit-slider-runnable-track {
   border-radius: var(--slider-track-border-radius);
   border: 0px solid #000000;
 }
-input[type=range]::-webkit-slider-thumb {
+input[type="range"]::-webkit-slider-thumb {
   box-shadow: 0px 0px 0px #000000;
   border: 0px solid #000000;
   height: var(--slider-thumb-height);
@@ -64,10 +60,10 @@ input[type=range]::-webkit-slider-thumb {
   -webkit-appearance: none;
   margin-top: -3px;
 }
-input[type=range]:focus::-webkit-slider-runnable-track {
+input[type="range"]:focus::-webkit-slider-runnable-track {
   background: var(--slider-track-color);
 }
-input[type=range]::-moz-range-track {
+input[type="range"]::-moz-range-track {
   width: var(--slider-track-width);
   height: var(--slider-track-height);
   cursor: pointer;
@@ -77,7 +73,7 @@ input[type=range]::-moz-range-track {
   border-radius: var(--slider-track-border-radius);
   border: 0px solid #000000;
 }
-input[type=range]::-moz-range-thumb {
+input[type="range"]::-moz-range-thumb {
   box-shadow: 0px 0px 0px #000000;
   border: 0px solid #000000;
   height: var(--slider-thumb-height);
@@ -86,7 +82,7 @@ input[type=range]::-moz-range-thumb {
   background: var(--slider-thumb-color);
   cursor: pointer;
 }
-input[type=range]::-ms-track {
+input[type="range"]::-ms-track {
   width: var(--slider-track-width);
   height: var(--slider-track-height);
   cursor: pointer;
@@ -95,19 +91,19 @@ input[type=range]::-ms-track {
   border-color: transparent;
   color: transparent;
 }
-input[type=range]::-ms-fill-lower {
+input[type="range"]::-ms-fill-lower {
   background: var(--slider-track-color);
   border: 0px solid #000000;
   border-radius: var(--slider-thumb-border-radius);
   box-shadow: 0px 0px 0px #000000;
 }
-input[type=range]::-ms-fill-upper {
+input[type="range"]::-ms-fill-upper {
   background: var(--slider-track-color);
   border: 0px solid #000000;
   border-radius: var(--slider-thumb-border-radius);
   box-shadow: 0px 0px 0px #000000;
 }
-input[type=range]::-ms-thumb {
+input[type="range"]::-ms-thumb {
   margin-top: 1px;
   box-shadow: 0px 0px 0px #000000;
   border: 0px solid #000000;
@@ -117,9 +113,9 @@ input[type=range]::-ms-thumb {
   background: var(--slider-thumb-color);
   cursor: pointer;
 }
-input[type=range]:focus::-ms-fill-lower {
+input[type="range"]:focus::-ms-fill-lower {
   background: var(--slider-track-color);
 }
-input[type=range]:focus::-ms-fill-upper {
+input[type="range"]:focus::-ms-fill-upper {
   background: var(--slider-track-color);
 }

--- a/src/fontra/client/css/ui-styling.css
+++ b/src/fontra/client/css/ui-styling.css
@@ -1,9 +1,9 @@
 :root {
   --ui-list-border-color-light: lightgray;
-  --ui-list-row-border-color-light: #DDD;
+  --ui-list-row-border-color-light: #ddd;
   --ui-list-row-foreground-color-light: black;
   --ui-list-row-background-color-light: white;
-  --ui-list-row-selected-background-color-light: #DDD;
+  --ui-list-row-selected-background-color-light: #ddd;
   --ui-form-input-border-color-light: #888;
 
   --ui-list-border-color-dark: darkgray;
@@ -14,38 +14,41 @@
   --ui-form-input-border-color-dark: #222;
 }
 
-
 :root {
   --ui-list-border-color: var(--ui-list-border-color-light);
   --ui-list-row-border-color: var(--ui-list-row-border-color-light);
   --ui-list-row-foreground-color: var(--ui-list-row-foreground-color-light);
   --ui-list-row-background-color: var(--ui-list-row-background-color-light);
-  --ui-list-row-selected-background-color: var(--ui-list-row-selected-background-color-light);
+  --ui-list-row-selected-background-color: var(
+    --ui-list-row-selected-background-color-light
+  );
   --ui-form-input-foreground-color: var(--ui-list-row-foreground-color-light);
   --ui-form-input-background-color: var(--ui-list-row-background-color-light);
   --ui-form-input-border-color: var(--ui-form-input-border-color-light);
 }
-
 
 :root.dark-theme {
   --ui-list-border-color: var(--ui-list-border-color-dark);
   --ui-list-row-border-color: var(--ui-list-row-border-color-dark);
   --ui-list-row-foreground-color: var(--ui-list-row-foreground-color-dark);
   --ui-list-row-background-color: var(--ui-list-row-background-color-dark);
-  --ui-list-row-selected-background-color: var(--ui-list-row-selected-background-color-dark);
+  --ui-list-row-selected-background-color: var(
+    --ui-list-row-selected-background-color-dark
+  );
   --ui-form-input-foreground-color: var(--ui-list-row-foreground-color-dark);
   --ui-form-input-background-color: var(--ui-list-row-background-color-dark);
   --ui-form-input-border-color: var(--ui-form-input-border-color-dark);
 }
 
 @media (prefers-color-scheme: dark) {
-
   :root {
     --ui-list-border-color: var(--ui-list-border-color-dark);
     --ui-list-row-border-color: var(--ui-list-row-border-color-dark);
     --ui-list-row-foreground-color: var(--ui-list-row-foreground-color-dark);
     --ui-list-row-background-color: var(--ui-list-row-background-color-dark);
-    --ui-list-row-selected-background-color: var(--ui-list-row-selected-background-color-dark);
+    --ui-list-row-selected-background-color: var(
+      --ui-list-row-selected-background-color-dark
+    );
     --ui-form-input-foreground-color: var(--ui-list-row-foreground-color-dark);
     --ui-form-input-background-color: var(--ui-list-row-background-color-dark);
     --ui-form-input-border-color: var(--ui-form-input-border-color-dark);
@@ -56,14 +59,14 @@
     --ui-list-row-border-color: var(--ui-list-row-border-color-light);
     --ui-list-row-foreground-color: var(--ui-list-row-foreground-color-light);
     --ui-list-row-background-color: var(--ui-list-row-background-color-light);
-    --ui-list-row-selected-background-color: var(--ui-list-row-selected-background-color-light);
+    --ui-list-row-selected-background-color: var(
+      --ui-list-row-selected-background-color-light
+    );
     --ui-form-input-foreground-color: var(--ui-list-row-foreground-color-light);
     --ui-form-input-background-color: var(--ui-list-row-background-color-light);
     --ui-form-input-border-color: var(--ui-form-input-border-color-light);
   }
-
 }
-
 
 /* ui-list */
 
@@ -73,7 +76,7 @@
 }
 
 .ui-list.empty {
-  display:  none;
+  display: none;
 }
 
 .ui-list > .contents {
@@ -144,14 +147,13 @@
   width: 9.5em;
 }
 
-.ui-form-value input[type=number] {
+.ui-form-value input[type="number"] {
   width: 4em;
 }
 
-.ui-form-value input[type=range] {
+.ui-form-value input[type="range"] {
   width: 7em;
 }
-
 
 /* ui-dialog */
 
@@ -180,7 +182,7 @@
   grid-template-columns: 1fr 1fr 1fr;
   gap: 1em;
 
-  outline: none;  /* to catch key events we need to focus, but we don't want a focus border */
+  outline: none; /* to catch key events we need to focus, but we don't want a focus border */
   max-width: 32em;
   overflow-wrap: normal;
   font-size: 1.15em;

--- a/src/fontra/client/settings.html
+++ b/src/fontra/client/settings.html
@@ -1,75 +1,88 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <meta charset="utf-8"/>
-  <title>Fontra Settings</title>
-  <link href="/css/core.css" rel="stylesheet">
-  <style type="text/css">
+  <head>
+    <meta charset="utf-8" />
+    <title>Fontra Settings</title>
+    <link href="/css/core.css" rel="stylesheet" />
+    <style type="text/css">
+      body {
+        margin: 1em;
+        padding-left: 5em;
+      }
 
-body {
-  margin: 1em;
-  padding-left: 5em;
-}
+      body > div {
+        font-size: 1.1em;
+      }
 
-body > div {
-  font-size: 1.1em;
-}
+      h1 {
+        font-size: 1.5em;
+      }
 
-h1 {
-  font-size: 1.5em;
-}
+      h2 {
+        font-size: 1em;
+      }
 
-h2 {
-  font-size: 1em;
-}
+      #settings-theme {
+        display: grid;
+        grid-template-columns: min-content min-content;
+      }
+    </style>
+  </head>
+  <body>
+    <a href="/"><img src="/images/fontra-icon.svg" width="100" height="100" /></a>
+    <div>
+      <h1>Fontra Settings</h1>
+      <h2>Theme</h2>
+      <div id="settings-theme">
+        <input
+          id="theme-automatic"
+          value="automatic"
+          onclick="themeSwitchCallback()"
+          name="theme-settings"
+          type="radio"
+          checked
+        />
+        <label for="theme-automatic">Automatic (use OS setting)</label>
 
-#settings-theme {
-  display: grid;
-  grid-template-columns: min-content min-content;  
-}
+        <input
+          id="theme-light"
+          value="light"
+          onclick="themeSwitchCallback()"
+          name="theme-settings"
+          type="radio"
+        />
+        <label for="theme-light">Light theme</label>
 
-  </style>
-
-</head>
-<body>
-  <a href="/"><img src="/images/fontra-icon.svg" width="100" height="100"></a>
-  <div>
-    <h1>Fontra Settings</h1>
-    <h2>Theme</h2>
-    <div id="settings-theme">
-
-      <input id="theme-automatic" value="automatic" onclick="themeSwitchCallback()" name="theme-settings" type="radio" checked/>
-      <label for="theme-automatic">Automatic (use OS setting)</label>
-
-      <input id="theme-light" value="light" onclick="themeSwitchCallback()" name="theme-settings" type="radio" />
-      <label for="theme-light">Light theme</label>
-
-      <input id="theme-dark" value="dark" onclick="themeSwitchCallback()" name="theme-settings" type="radio" />
-      <label for="theme-dark">Dark theme</label>
-
+        <input
+          id="theme-dark"
+          value="dark"
+          onclick="themeSwitchCallback()"
+          name="theme-settings"
+          type="radio"
+        />
+        <label for="theme-dark">Dark theme</label>
+      </div>
     </div>
-  </div>
-</body>
-<script type="module">
+  </body>
+  <script type="module">
+    import { THEME_KEY, themeSwitch } from "./core/utils.js";
 
-import { THEME_KEY, themeSwitch } from "./core/utils.js";
+    function themeSwitchCallback() {
+      const themeValue = document.querySelector(
+        'input[name="theme-settings"]:checked'
+      ).value;
+      themeSwitch(themeValue);
+      localStorage.setItem(THEME_KEY, themeValue);
+    }
 
+    window.themeSwitchCallback = themeSwitchCallback;
 
-function themeSwitchCallback() {
-  const themeValue = document.querySelector('input[name="theme-settings"]:checked').value;
-  themeSwitch(themeValue)
-  localStorage.setItem(THEME_KEY, themeValue);
-}
-
-window.themeSwitchCallback = themeSwitchCallback;
-
-const themeValue = localStorage.getItem("fontra-theme");
-if (themeValue) {
-  for (const element of document.querySelectorAll('input[name="theme-settings"]')) {
-    element.checked = themeValue === element.value;
-  }
-  themeSwitch(themeValue);
-}
-
-</script>
+    const themeValue = localStorage.getItem("fontra-theme");
+    if (themeValue) {
+      for (const element of document.querySelectorAll('input[name="theme-settings"]')) {
+        element.checked = themeValue === element.value;
+      }
+      themeSwitch(themeValue);
+    }
+  </script>
 </html>

--- a/src/fontra/filesystem/landing.css
+++ b/src/fontra/filesystem/landing.css
@@ -3,8 +3,8 @@
   --landing-foreground-color-light: black;
   --landing-background-color-dark: black;
   --landing-foreground-color-dark: white;
-  --landing-project-item-hover-color-light: #E8E8E8;
-  --landing-project-item-active-color-light: #CCC;
+  --landing-project-item-hover-color-light: #e8e8e8;
+  --landing-project-item-active-color-light: #ccc;
   --landing-project-item-hover-color-dark: #444;
   --landing-project-item-active-color-dark: #666;
 
@@ -22,7 +22,6 @@
 }
 
 @media (prefers-color-scheme: dark) {
-
   :root {
     --landing-background-color: var(--landing-background-color-dark);
     --landing-foreground-color: var(--landing-foreground-color-dark);
@@ -36,16 +35,13 @@
     --landing-project-item-hover-color: var(--landing-project-item-hover-color-light);
     --landing-project-item-active-color: var(--landing-project-item-active-color-light);
   }
-
 }
-
 
 a {
   color: inherit;
   text-decoration: inherit;
   cursor: pointer;
 }
-
 
 .landing-body {
   height: 100%;
@@ -79,7 +75,6 @@ a {
   display: flex;
   flex-direction: column;
   gap: 0.25em;
-
 }
 .login-label {
   color: gray;
@@ -90,7 +85,7 @@ a {
 .login-input {
   font-family: fontra-ui-regular, sans-serif;
   font-size: 1em;
-  width:  20em;
+  width: 20em;
   padding: 0.25em;
   color: var(--landing-foreground-color);
   background-color: var(--landing-background-color);
@@ -98,7 +93,7 @@ a {
 
 .login-button {
   border-radius: 2em;
-  background-color: #46F;
+  background-color: #46f;
   width: max-content;
   color: white;
   padding: 0.5em 1.1em 0.5em 1em;
@@ -111,12 +106,12 @@ a {
 }
 
 .login-button:hover {
-  background-color: #24D;
+  background-color: #24d;
   cursor: pointer;
 }
 
 .login-button:active {
-  background-color: #02A;
+  background-color: #02a;
   cursor: pointer;
 }
 

--- a/src/fontra/filesystem/landing.html
+++ b/src/fontra/filesystem/landing.html
@@ -1,33 +1,27 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta charset="utf-8"/>
+    <meta charset="utf-8" />
     <title>Fontra</title>
-    <link href="/css/core.css" rel="stylesheet">
-    <link href="/filesystem/landing.css" rel="stylesheet">
+    <link href="/css/core.css" rel="stylesheet" />
+    <link href="/filesystem/landing.css" rel="stylesheet" />
   </head>
   <body class="landing-body">
-
     <div id="global-loader-spinner"></div>
 
     <div class="landing-content">
-
       <div class="landing-item" id="fontra-icon-header">
-        <img src="/images/fontra-icon.svg" width="100" height="100">
+        <img src="/images/fontra-icon.svg" width="100" height="100" />
         <div>
           <a href="/settings.html">Edit Settings...</a>
         </div>
       </div>
 
       <div class="landing-item" id="project-list" tabindex="3"></div>
-
     </div>
-
   </body>
   <script type="module">
-
     import { startupLandingPage } from "/filesystem/landing.js";
     startupLandingPage();
-
   </script>
 </html>

--- a/src/fontra/filesystem/landing.js
+++ b/src/fontra/filesystem/landing.js
@@ -2,7 +2,6 @@ import { loaderSpinner } from "/core/loader-spinner.js";
 import { getRemoteProxy } from "/core/remote.js";
 import { themeSwitchFromLocalStorage } from "/core/utils.js";
 
-
 export async function startupLandingPage(authenticateFunc) {
   themeSwitchFromLocalStorage();
 
@@ -16,14 +15,13 @@ export async function startupLandingPage(authenticateFunc) {
   projectListContainer.classList.remove("hidden");
 
   for (const project of projectList) {
-    const projectElement = document.createElement("a")
+    const projectElement = document.createElement("a");
     projectElement.href = "/editor/-/" + project;
     projectElement.className = "project-item";
     projectElement.append(project);
     projectListContainer.appendChild(projectElement);
   }
 }
-
 
 async function fetchJSON(url) {
   const response = await fetch(url);

--- a/src/fontra/views/editor/edit-behavior-support.js
+++ b/src/fontra/views/editor/edit-behavior-support.js
@@ -1,13 +1,12 @@
 import { boolInt, modulo, reversed } from "../core/utils.js";
 
-
 // Or-able constants for rule definitions
-export const NIL = 1 << 0;  // Does not exist
-export const SEL = 1 << 1;  // Selected
-export const UNS = 1 << 2;  // Unselected
-export const SHA = 1 << 3;  // Sharp On-Curve
-export const SMO = 1 << 4;  // Smooth On-Curve
-export const OFF = 1 << 5;  // Off-Curve
+export const NIL = 1 << 0; // Does not exist
+export const SEL = 1 << 1; // Selected
+export const UNS = 1 << 2; // Unselected
+export const SHA = 1 << 3; // Sharp On-Curve
+export const SMO = 1 << 4; // Smooth On-Curve
+export const OFF = 1 << 5; // Off-Curve
 export const ANY = SHA | SMO | OFF;
 
 // Some examples:
@@ -16,7 +15,6 @@ export const ANY = SHA | SMO | OFF;
 //     OFF|SEL    point must be off-curve and selected
 //     ANY|UNS    point can be off-curve, sharp or smooth, and must not be selected
 
-
 const SHARP_SELECTED = "SHARP_SELECTED";
 const SHARP_UNSELECTED = "SHARP_UNSELECTED";
 const SMOOTH_SELECTED = "SMOOTH_SELECTED";
@@ -24,7 +22,6 @@ const SMOOTH_UNSELECTED = "SMOOTH_UNSELECTED";
 const OFFCURVE_SELECTED = "OFFCURVE_SELECTED";
 const OFFCURVE_UNSELECTED = "OFFCURVE_UNSELECTED";
 const DOESNT_EXIST = "DOESNT_EXIST";
-
 
 const POINT_TYPES = [
   // usage: POINT_TYPES[smooth][oncurve][selected]
@@ -39,12 +36,11 @@ const POINT_TYPES = [
   // smooth
   [
     // off-curve
-    [OFFCURVE_UNSELECTED, OFFCURVE_SELECTED],  // smooth off-curve points don't really exist
+    [OFFCURVE_UNSELECTED, OFFCURVE_SELECTED], // smooth off-curve points don't really exist
     // on-curve
     [SMOOTH_UNSELECTED, SMOOTH_SELECTED],
   ],
 ];
-
 
 export function buildPointMatchTree(rules) {
   const matchTree = {};
@@ -54,24 +50,23 @@ export function buildPointMatchTree(rules) {
       throw new Error("assert -- invalid rule");
     }
     const matchPoints = rule.slice(0, 6);
-    matchPoints.push(ANY|NIL);
+    matchPoints.push(ANY | NIL);
     const actionForward = {
-      "constrain": rule[6],
-      "action": rule[7],
-      "direction": 1,
-      "ruleIndex": ruleIndex,
-    }
+      constrain: rule[6],
+      action: rule[7],
+      direction: 1,
+      ruleIndex: ruleIndex,
+    };
     const actionBackward = {
       ...actionForward,
-      "direction": -1,
-    }
+      direction: -1,
+    };
     populateTree(matchTree, Array.from(reversed(matchPoints)), actionBackward);
     populateTree(matchTree, matchPoints, actionForward);
     ruleIndex++;
   }
   return matchTree;
 }
-
 
 function populateTree(tree, matchPoints, action) {
   const matchPoint = matchPoints[0];
@@ -91,9 +86,8 @@ function populateTree(tree, matchPoints, action) {
   }
 }
 
-
 function convertPointType(matchPoint) {
-  if (matchPoint === (ANY|NIL)) {
+  if (matchPoint === (ANY | NIL)) {
     return ["*"];
   }
   const sel = matchPoint & SEL;
@@ -141,8 +135,13 @@ function convertPointType(matchPoint) {
   return pointTypes;
 }
 
-
-export function findPointMatch(matchTree, pointIndex, contourPoints, numPoints, isClosed) {
+export function findPointMatch(
+  matchTree,
+  pointIndex,
+  contourPoints,
+  numPoints,
+  isClosed
+) {
   const neighborIndices = new Array();
   for (let neighborOffset = -3; neighborOffset < 4; neighborOffset++) {
     let neighborIndex = pointIndex + neighborOffset;
@@ -154,7 +153,6 @@ export function findPointMatch(matchTree, pointIndex, contourPoints, numPoints, 
   const match = _findPointMatch(matchTree, neighborIndices, contourPoints);
   return [match, neighborIndices];
 }
-
 
 function _findPointMatch(matchTree, neighborIndices, contourPoints) {
   const neighborIndex = neighborIndices[0];

--- a/src/fontra/views/editor/edit-behavior.js
+++ b/src/fontra/views/editor/edit-behavior.js
@@ -519,7 +519,6 @@ const actionFactories = {
 
 }
 
-
 const defaultRules = [
   //   prev3       prevPrev    prev        the point   next        nextNext    Constrain   Action
 

--- a/src/fontra/views/editor/edit-tools-base.js
+++ b/src/fontra/views/editor/edit-tools-base.js
@@ -1,17 +1,13 @@
 export class BaseTool {
-
   constructor(editor) {
     this.editor = editor;
     this.canvasController = editor.canvasController;
     this.sceneController = editor.sceneController;
     this.sceneModel = this.sceneController.sceneModel;
   }
-
 }
 
-
 const MINIMUM_DRAG_DISTANCE = 2;
-
 
 export async function shouldInitiateDrag(eventStream, initialEvent) {
   // drop events until the pointer moved a minimal distance

--- a/src/fontra/views/editor/edit-tools-hand.js
+++ b/src/fontra/views/editor/edit-tools-hand.js
@@ -1,10 +1,8 @@
 import { BaseTool } from "./edit-tools-base.js";
 
-
 export class HandTool extends BaseTool {
-
   handleHover(event) {
-    this.canvasController.canvas.style.cursor = "grab";    
+    this.canvasController.canvas.style.cursor = "grab";
   }
 
   async handleDrag(eventStream, initialEvent) {
@@ -20,5 +18,4 @@ export class HandTool extends BaseTool {
     }
     this.canvasController.canvas.style.cursor = "grab";
   }
-
 }

--- a/src/fontra/views/editor/editor.css
+++ b/src/fontra/views/editor/editor.css
@@ -1,11 +1,11 @@
 :root {
-  --editor-glyphs-search-input-background-color-light: #EEE;
+  --editor-glyphs-search-input-background-color-light: #eee;
   --editor-glyphs-search-input-background-color-dark: #333;
 
   --editor-glyphs-search-input-foreground-color-light: black;
   --editor-glyphs-search-input-foreground-color-dark: white;
 
-  --editor-text-entry-input-background-color-light: #EEE;
+  --editor-text-entry-input-background-color-light: #eee;
   --editor-text-entry-input-background-color-dark: #333;
 
   --editor-text-entry-input-foreground-color-light: black;
@@ -14,16 +14,16 @@
   --editor-overlay-item-background-color-light: white;
   --editor-overlay-item-background-color-dark: #484848;
 
-  --editor-tool-button-hover-background-color-light: #EEE;
+  --editor-tool-button-hover-background-color-light: #eee;
   --editor-tool-button-hover-background-color-dark: #333;
 
-  --editor-tool-button-active-background-color-light: #CCC;
+  --editor-tool-button-active-background-color-light: #ccc;
   --editor-tool-button-active-background-color-dark: #555;
 
   --editor-tool-button-selected-background-color-light: #666;
-  --editor-tool-button-selected-background-color-dark: #CCC;
+  --editor-tool-button-selected-background-color-dark: #ccc;
 
-  --editor-mini-console-background-color-light: #DDD;
+  --editor-mini-console-background-color-light: #ddd;
   --editor-mini-console-background-color-dark: #444;
 
   --editor-mini-console-foreground-color-light: black;
@@ -31,65 +31,141 @@
 }
 
 :root {
-  --editor-glyphs-search-input-background-color: var(--editor-glyphs-search-input-background-color-light);
-  --editor-glyphs-search-input-foreground-color: var(--editor-glyphs-search-input-foreground-color-light);
-  --editor-text-entry-input-background-color: var(--editor-text-entry-input-background-color-light);
-  --editor-text-entry-input-foreground-color: var(--editor-text-entry-input-foreground-color-light);
-  --editor-overlay-item-background-color: var(--editor-overlay-item-background-color-light);
-  --editor-tool-button-hover-background-color: var(--editor-tool-button-hover-background-color-light);
-  --editor-tool-button-active-background-color: var(--editor-tool-button-active-background-color-light);
-  --editor-tool-button-selected-background-color: var(--editor-tool-button-selected-background-color-light);
-  --editor-mini-console-background-color: var(--editor-mini-console-background-color-light);
-  --editor-mini-console-foreground-color: var(--editor-mini-console-foreground-color-light);
+  --editor-glyphs-search-input-background-color: var(
+    --editor-glyphs-search-input-background-color-light
+  );
+  --editor-glyphs-search-input-foreground-color: var(
+    --editor-glyphs-search-input-foreground-color-light
+  );
+  --editor-text-entry-input-background-color: var(
+    --editor-text-entry-input-background-color-light
+  );
+  --editor-text-entry-input-foreground-color: var(
+    --editor-text-entry-input-foreground-color-light
+  );
+  --editor-overlay-item-background-color: var(
+    --editor-overlay-item-background-color-light
+  );
+  --editor-tool-button-hover-background-color: var(
+    --editor-tool-button-hover-background-color-light
+  );
+  --editor-tool-button-active-background-color: var(
+    --editor-tool-button-active-background-color-light
+  );
+  --editor-tool-button-selected-background-color: var(
+    --editor-tool-button-selected-background-color-light
+  );
+  --editor-mini-console-background-color: var(
+    --editor-mini-console-background-color-light
+  );
+  --editor-mini-console-foreground-color: var(
+    --editor-mini-console-foreground-color-light
+  );
 }
 
 :root.dark-theme {
-  --editor-glyphs-search-input-background-color: var(--editor-glyphs-search-input-background-color-dark);
-  --editor-glyphs-search-input-foreground-color: var(--editor-glyphs-search-input-foreground-color-dark);
-  --editor-text-entry-input-background-color: var(--editor-text-entry-input-background-color-dark);
-  --editor-text-entry-input-foreground-color: var(--editor-text-entry-input-foreground-color-dark);
-  --editor-overlay-item-background-color: var(--editor-overlay-item-background-color-dark);
-  --editor-tool-button-hover-background-color: var(--editor-tool-button-hover-background-color-dark);
-  --editor-tool-button-active-background-color: var(--editor-tool-button-active-background-color-dark);
-  --editor-tool-button-selected-background-color: var(--editor-tool-button-selected-background-color-dark);
-  --editor-mini-console-background-color: var(--editor-mini-console-background-color-dark);
-  --editor-mini-console-foreground-color: var(--editor-mini-console-foreground-color-dark);
+  --editor-glyphs-search-input-background-color: var(
+    --editor-glyphs-search-input-background-color-dark
+  );
+  --editor-glyphs-search-input-foreground-color: var(
+    --editor-glyphs-search-input-foreground-color-dark
+  );
+  --editor-text-entry-input-background-color: var(
+    --editor-text-entry-input-background-color-dark
+  );
+  --editor-text-entry-input-foreground-color: var(
+    --editor-text-entry-input-foreground-color-dark
+  );
+  --editor-overlay-item-background-color: var(
+    --editor-overlay-item-background-color-dark
+  );
+  --editor-tool-button-hover-background-color: var(
+    --editor-tool-button-hover-background-color-dark
+  );
+  --editor-tool-button-active-background-color: var(
+    --editor-tool-button-active-background-color-dark
+  );
+  --editor-tool-button-selected-background-color: var(
+    --editor-tool-button-selected-background-color-dark
+  );
+  --editor-mini-console-background-color: var(
+    --editor-mini-console-background-color-dark
+  );
+  --editor-mini-console-foreground-color: var(
+    --editor-mini-console-foreground-color-dark
+  );
 }
 
-
 @media (prefers-color-scheme: dark) {
-
   :root {
-    --editor-glyphs-search-input-background-color: var(--editor-glyphs-search-input-background-color-dark);
-    --editor-glyphs-search-input-foreground-color: var(--editor-glyphs-search-input-foreground-color-dark);
-    --editor-text-entry-input-background-color: var(--editor-text-entry-input-background-color-dark);
-    --editor-text-entry-input-foreground-color: var(--editor-text-entry-input-foreground-color-dark);
-    --editor-overlay-item-background-color: var(--editor-overlay-item-background-color-dark);
-    --editor-tool-button-hover-background-color: var(--editor-tool-button-hover-background-color-dark);
-    --editor-tool-button-active-background-color: var(--editor-tool-button-active-background-color-dark);
-    --editor-tool-button-selected-background-color: var(--editor-tool-button-selected-background-color-dark);
-    --editor-mini-console-background-color: var(--editor-mini-console-background-color-dark);
-    --editor-mini-console-foreground-color: var(--editor-mini-console-foreground-color-dark);
+    --editor-glyphs-search-input-background-color: var(
+      --editor-glyphs-search-input-background-color-dark
+    );
+    --editor-glyphs-search-input-foreground-color: var(
+      --editor-glyphs-search-input-foreground-color-dark
+    );
+    --editor-text-entry-input-background-color: var(
+      --editor-text-entry-input-background-color-dark
+    );
+    --editor-text-entry-input-foreground-color: var(
+      --editor-text-entry-input-foreground-color-dark
+    );
+    --editor-overlay-item-background-color: var(
+      --editor-overlay-item-background-color-dark
+    );
+    --editor-tool-button-hover-background-color: var(
+      --editor-tool-button-hover-background-color-dark
+    );
+    --editor-tool-button-active-background-color: var(
+      --editor-tool-button-active-background-color-dark
+    );
+    --editor-tool-button-selected-background-color: var(
+      --editor-tool-button-selected-background-color-dark
+    );
+    --editor-mini-console-background-color: var(
+      --editor-mini-console-background-color-dark
+    );
+    --editor-mini-console-foreground-color: var(
+      --editor-mini-console-foreground-color-dark
+    );
   }
 
   :root.light-theme {
-    --editor-glyphs-search-input-background-color: var(--editor-glyphs-search-input-background-color-light);
-    --editor-glyphs-search-input-foreground-color: var(--editor-glyphs-search-input-foreground-color-light);
-    --editor-text-entry-input-background-color: var(--editor-text-entry-input-background-color-light);
-    --editor-text-entry-input-foreground-color: var(--editor-text-entry-input-foreground-color-light);
-    --editor-overlay-item-background-color: var(--editor-overlay-item-background-color-light);
-    --editor-tool-button-hover-background-color: var(--editor-tool-button-hover-background-color-light);
-    --editor-tool-button-active-background-color: var(--editor-tool-button-active-background-color-light);
-    --editor-tool-button-selected-background-color: var(--editor-tool-button-selected-background-color-light);
-    --editor-mini-console-background-color: var(--editor-mini-console-background-color-light);
-    --editor-mini-console-foreground-color: var(--editor-mini-console-foreground-color-light);
+    --editor-glyphs-search-input-background-color: var(
+      --editor-glyphs-search-input-background-color-light
+    );
+    --editor-glyphs-search-input-foreground-color: var(
+      --editor-glyphs-search-input-foreground-color-light
+    );
+    --editor-text-entry-input-background-color: var(
+      --editor-text-entry-input-background-color-light
+    );
+    --editor-text-entry-input-foreground-color: var(
+      --editor-text-entry-input-foreground-color-light
+    );
+    --editor-overlay-item-background-color: var(
+      --editor-overlay-item-background-color-light
+    );
+    --editor-tool-button-hover-background-color: var(
+      --editor-tool-button-hover-background-color-light
+    );
+    --editor-tool-button-active-background-color: var(
+      --editor-tool-button-active-background-color-light
+    );
+    --editor-tool-button-selected-background-color: var(
+      --editor-tool-button-selected-background-color-light
+    );
+    --editor-mini-console-background-color: var(
+      --editor-mini-console-background-color-light
+    );
+    --editor-mini-console-foreground-color: var(
+      --editor-mini-console-foreground-color-light
+    );
   }
-
 }
 
-
 .editor-container {
-  /*display: flex;*/  /* or grid */
+  /*display: flex;*/ /* or grid */
   position: relative;
   width: 100vw;
   height: 100vh;
@@ -118,18 +194,17 @@
   resize: none;
 }
 
-
 .sliders-and-sources {
   display: flex;
   flex-direction: column;
-  padding: 0.5em 1em 0.75em 0.25em;  /* top right bottom left */
+  padding: 0.5em 1em 0.75em 0.25em; /* top right bottom left */
   gap: 1em;
 }
 
 .axis-sliders {
   display: flex;
   flex-direction: column;
-  gap:  0.5em;
+  gap: 0.5em;
   overflow: scroll;
   flex-shrink: 1;
 }
@@ -156,14 +231,14 @@
 }
 
 .canvas-container {
-  position: relative;  /* for the children */
+  position: relative; /* for the children */
   width: 100%;
   height: 100%;
   overflow: hidden;
 }
 
 #edit-canvas {
-  position: absolute;  /* but relative to canvas-container */
+  position: absolute; /* but relative to canvas-container */
   padding: 0;
   margin: 0;
   overscroll-behavior: none;
@@ -188,7 +263,7 @@
   display: flex;
   background-color: var(--editor-overlay-item-background-color);
   border-radius: 0.65em;
-  box-shadow: 1.0px 1.0px 5px #0006;
+  box-shadow: 1px 1px 5px #0006;
   cursor: pointer;
   height: min-content;
   pointer-events: auto;
@@ -200,8 +275,8 @@
   font-size: 1.7rem;
   user-select: none;
   background-color: var(--editor-overlay-item-background-color);
-  width:  2.7rem;
-  height:  1.9rem;
+  width: 2.7rem;
+  height: 1.9rem;
   padding: 0.1rem;
   text-align: center;
   transition: 0.15s;
@@ -214,7 +289,7 @@
 
 .tool-icon:hover {
   position: relative;
-  transform: scale(1.1, 1.1)
+  transform: scale(1.1, 1.1);
 }
 
 .tool-button:hover {
@@ -231,7 +306,7 @@
 }
 
 #mini-console {
-  display: none;  /* will be set to 'inherit' when needed */
+  display: none; /* will be set to 'inherit' when needed */
   z-index: 3;
   position: absolute;
   color: var(--editor-mini-console-foreground-color);

--- a/src/fontra/views/editor/editor.html
+++ b/src/fontra/views/editor/editor.html
@@ -1,415 +1,420 @@
 <!DOCTYPE html>
 <html>
-
-<head>
-  <meta charset="utf-8"/>
-  <title>Fontra</title>
-  <link href="/css/ui-styling.css" rel="stylesheet">
-  <link href="/css/slider.css" rel="stylesheet">
-  <link href="/css/context-menu.css" rel="stylesheet">
-  <link href="/css/core.css" rel="stylesheet">
-  <link href="/editor/editor.css" rel="stylesheet">
-</head>
-
-<style type="text/css">
-
-/* TODO: this should move to editor.css */
-
-html, body {
-  margin: 0;
-  padding: 0;
-  height: 100vh;
-}
-
-:root {
-  --sidebar-tab-width: 1.55em;
-  --sidebar-content-width-left: 20em;
-  --sidebar-content-width-right: 22em;
-}
-
-.editor-container {
-  display: grid;
-  position: relative;
-  grid-template-columns: auto 1fr auto;
-  grid-template-rows: 100%;
-  height: 100%;
-}
-
-.sidebar-container {
-  z-index: 100;
-
-  background-color: var(--editor-overlay-item-background-color);
-  width: 0;
-  height: 100%;
-  transition: 120ms;  /* timing should match timer in tabClick() */
-}
-
-.sidebar-container.left.visible {
-  width: var(--sidebar-content-width-left);
-}
-
-.sidebar-container.right.visible {
-  width: var(--sidebar-content-width-right);
-}
-
-.main-container {
-  position: relative;
-  grid-column: 2;
-}
-
-.main-content {
-  position: relative;
-  width: 100%;
-  height: 100%;
-}
-
-.main-overlay-container {
-  position: absolute;
-  display: grid;
-  grid-template-columns: 3.5em 1fr 3.5em;
-
-  box-sizing: border-box;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-
-  pointer-events: none;
-}
-
-.tab-overlay-container {
-  display: grid;
-  gap: 1em;
-  padding-top: 1em;
-  align-content: start;
-}
-
-.tab-overlay-container.left {
-  justify-content: start;
-  justify-items: start;
-}
-
-.tab-overlay-container.right {
-  justify-content: end;
-  justify-items: end;
-}
-
-.sidebar-shadow-box {
-  z-index: 10;
-  position: absolute;
-  display: none;
-
-  box-shadow: 0px 0px 8px #0006;
-  top: 0;
-  width: 50px;  /* arbitrary > blur radius */
-  height: 100%;
-}
-
-.sidebar-shadow-box.visible {
-  display: inherit;
-}
-
-.tab-overlay-container.left > .sidebar-shadow-box {
-  left: -50px;
-}
-
-.tab-overlay-container.right > .sidebar-shadow-box {
-  right: -50px;
-}
-
-.sidebar-tab {
-  z-index: 0;  /* below the shadow box */
-
-  box-sizing: border-box;
-  width: var(--sidebar-tab-width);
-  height: 1.4em;
-  background-color: var(--editor-overlay-item-background-color);
-  box-shadow: 0px 3px 8px #0006;
-
-  padding: 0.25em 0.25em 0.45em 0.25em;
-  font-family: fontra-icons, sans-serif;
-  font-size: 2em;
-  line-height: 0.7em;
-
-  cursor: pointer;
-  pointer-events: auto;
-  user-select: none;
-
-  animation-duration: 120ms;
-  animation-direction: alternate;
-  animation-timing-function: ease-out;
-  animation-iteration-count: 2;
-}
-
-.sidebar-tab.selected {
-  z-index: 20;  /* elevate it above the shadow box */
-}
-
-@keyframes tab-slide-out-animation {
-  100% { width: calc(var(--sidebar-tab-width) + 0.1em); }
-}
-
-@keyframes tab-slide-in-animation {
-  100% { width: calc(var(--sidebar-tab-width) - 0.1em); }
-}
-
-.sidebar-tab:hover {
-  animation-name: tab-slide-out-animation;
-}
-
-.sidebar-tab.selected:hover {
-  animation-name: tab-slide-in-animation;
-}
-
-.tab-overlay-container.left > .sidebar-tab {
-  border-radius: 0 0.4em 0.4em 0;
-  text-align: right;
-}
-
-.tab-overlay-container.right > .sidebar-tab {
-  border-radius: 0.4em 0 0 0.4em;
-  text-align: left;
-}
-
-.sidebar-content {
-  display: none;
-
-  box-sizing: border-box;
-  height: 100%;
-}
-
-.sidebar-container.left > .sidebar-content {
-  float: right;
-  width: var(--sidebar-content-width-left);
-}
-
-.sidebar-container.right > .sidebar-content {
-  float: left;
-  width: var(--sidebar-content-width-right);
-}
-
-.sidebar-container > .sidebar-content.selected {
-  display: inherit;
-}
-
-/* overlay content styling */
-
-.tool-overlay-container {
-  display: grid;
-  margin: 0;
-}
-
-#text-entry-overlay {
-  margin: 1em;
-}
-
-/* sidebar content styling */
-
-.sidebar-text-entry {
-  box-sizing: border-box;
-  height: 100%;
-  display: grid;
-  gap: 0.5em;
-  padding: 1em;
-  grid-template-rows: auto auto 1fr;
-}
-
-#text-align-menu {
-  display: grid;
-  grid-template-columns: auto auto auto;
-  justify-content: start;
-  gap: 0.5em;
-}
-
-#text-align-menu > div {
-  position: relative;
-  font-family: fontra-icons;
-  font-size: 1.5em;
-  padding: 0.02em 0.3em 0.2em 0.3em;
-  border-radius: 0.5em;
-  cursor: pointer;
-  user-select: none;
-  transition: 120ms;
-}
-
-#text-align-menu > div:hover {
-  background-color: #C0C0C050;
-}
-
-#text-align-menu > div:active {
-  background-color: #C0C0C080;
-}
-
-#text-align-menu > div.selected {
-  background-color: #C0C0C060;
-}
-
-.sidebar-glyph-search {
-  box-sizing: border-box;
-  height: 100%;
-  display: grid;
-  gap: 1em;
-  padding: 1em;
-  grid-template-rows: auto 1fr;
-}
-
-#glyphs-search-input {
-  border-radius: 2em;
-  height: 1.8em;
-  box-sizing: border-box;
-  width: 100%;
-  background-color: var(--editor-glyphs-search-input-background-color);
-  color: var(--editor-glyphs-search-input-foreground-color);
-  border: none;
-  padding-left: 0.8em;
-  padding-right: 0.8em;
-}
-
-.designspace-sliders {
-  box-sizing: border-box;
-  height: 100%;
-  display: grid;
-  gap: 1em;
-  padding: 1em;
-  grid-template-rows: auto 1fr;
-}
-
-.sidebar-selection-info {
-  box-sizing: border-box;
-  height: 100%;
-  overflow-x: hidden;
-  overflow-y: scroll;
-  padding: 1em;
-}
-
-</style>
-
-<body>
-
-<div id="ui-dialog-container">
-  <!-- <div id="ui-dialog-content" tabindex="1"></div> -->
-</div>
-
-<div id="global-loader-spinner"></div>
-
-<div class="editor-container">
-
-  <div class="sidebar-container left cleanable-overlay">
-
-    <div class="sidebar-content" data-sidebar-name="text-entry">
-      <div class="sidebar-text-entry">
-
-        <textarea rows="1" wrap="off" id="text-entry-textarea"></textarea>
-
-        <div id="text-align-menu">
-          <div>alignleft</div>
-          <div class="selected">aligncenter</div>
-          <div>alignright</div>
-        </div>
-
-      </div>
+  <head>
+    <meta charset="utf-8" />
+    <title>Fontra</title>
+    <link href="/css/ui-styling.css" rel="stylesheet" />
+    <link href="/css/slider.css" rel="stylesheet" />
+    <link href="/css/context-menu.css" rel="stylesheet" />
+    <link href="/css/core.css" rel="stylesheet" />
+    <link href="/editor/editor.css" rel="stylesheet" />
+  </head>
+
+  <style type="text/css">
+    /* TODO: this should move to editor.css */
+
+    html,
+    body {
+      margin: 0;
+      padding: 0;
+      height: 100vh;
+    }
+
+    :root {
+      --sidebar-tab-width: 1.55em;
+      --sidebar-content-width-left: 20em;
+      --sidebar-content-width-right: 22em;
+    }
+
+    .editor-container {
+      display: grid;
+      position: relative;
+      grid-template-columns: auto 1fr auto;
+      grid-template-rows: 100%;
+      height: 100%;
+    }
+
+    .sidebar-container {
+      z-index: 100;
+
+      background-color: var(--editor-overlay-item-background-color);
+      width: 0;
+      height: 100%;
+      transition: 120ms; /* timing should match timer in tabClick() */
+    }
+
+    .sidebar-container.left.visible {
+      width: var(--sidebar-content-width-left);
+    }
+
+    .sidebar-container.right.visible {
+      width: var(--sidebar-content-width-right);
+    }
+
+    .main-container {
+      position: relative;
+      grid-column: 2;
+    }
+
+    .main-content {
+      position: relative;
+      width: 100%;
+      height: 100%;
+    }
+
+    .main-overlay-container {
+      position: absolute;
+      display: grid;
+      grid-template-columns: 3.5em 1fr 3.5em;
+
+      box-sizing: border-box;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+
+      pointer-events: none;
+    }
+
+    .tab-overlay-container {
+      display: grid;
+      gap: 1em;
+      padding-top: 1em;
+      align-content: start;
+    }
+
+    .tab-overlay-container.left {
+      justify-content: start;
+      justify-items: start;
+    }
+
+    .tab-overlay-container.right {
+      justify-content: end;
+      justify-items: end;
+    }
+
+    .sidebar-shadow-box {
+      z-index: 10;
+      position: absolute;
+      display: none;
+
+      box-shadow: 0px 0px 8px #0006;
+      top: 0;
+      width: 50px; /* arbitrary > blur radius */
+      height: 100%;
+    }
+
+    .sidebar-shadow-box.visible {
+      display: inherit;
+    }
+
+    .tab-overlay-container.left > .sidebar-shadow-box {
+      left: -50px;
+    }
+
+    .tab-overlay-container.right > .sidebar-shadow-box {
+      right: -50px;
+    }
+
+    .sidebar-tab {
+      z-index: 0; /* below the shadow box */
+
+      box-sizing: border-box;
+      width: var(--sidebar-tab-width);
+      height: 1.4em;
+      background-color: var(--editor-overlay-item-background-color);
+      box-shadow: 0px 3px 8px #0006;
+
+      padding: 0.25em 0.25em 0.45em 0.25em;
+      font-family: fontra-icons, sans-serif;
+      font-size: 2em;
+      line-height: 0.7em;
+
+      cursor: pointer;
+      pointer-events: auto;
+      user-select: none;
+
+      animation-duration: 120ms;
+      animation-direction: alternate;
+      animation-timing-function: ease-out;
+      animation-iteration-count: 2;
+    }
+
+    .sidebar-tab.selected {
+      z-index: 20; /* elevate it above the shadow box */
+    }
+
+    @keyframes tab-slide-out-animation {
+      100% {
+        width: calc(var(--sidebar-tab-width) + 0.1em);
+      }
+    }
+
+    @keyframes tab-slide-in-animation {
+      100% {
+        width: calc(var(--sidebar-tab-width) - 0.1em);
+      }
+    }
+
+    .sidebar-tab:hover {
+      animation-name: tab-slide-out-animation;
+    }
+
+    .sidebar-tab.selected:hover {
+      animation-name: tab-slide-in-animation;
+    }
+
+    .tab-overlay-container.left > .sidebar-tab {
+      border-radius: 0 0.4em 0.4em 0;
+      text-align: right;
+    }
+
+    .tab-overlay-container.right > .sidebar-tab {
+      border-radius: 0.4em 0 0 0.4em;
+      text-align: left;
+    }
+
+    .sidebar-content {
+      display: none;
+
+      box-sizing: border-box;
+      height: 100%;
+    }
+
+    .sidebar-container.left > .sidebar-content {
+      float: right;
+      width: var(--sidebar-content-width-left);
+    }
+
+    .sidebar-container.right > .sidebar-content {
+      float: left;
+      width: var(--sidebar-content-width-right);
+    }
+
+    .sidebar-container > .sidebar-content.selected {
+      display: inherit;
+    }
+
+    /* overlay content styling */
+
+    .tool-overlay-container {
+      display: grid;
+      margin: 0;
+    }
+
+    #text-entry-overlay {
+      margin: 1em;
+    }
+
+    /* sidebar content styling */
+
+    .sidebar-text-entry {
+      box-sizing: border-box;
+      height: 100%;
+      display: grid;
+      gap: 0.5em;
+      padding: 1em;
+      grid-template-rows: auto auto 1fr;
+    }
+
+    #text-align-menu {
+      display: grid;
+      grid-template-columns: auto auto auto;
+      justify-content: start;
+      gap: 0.5em;
+    }
+
+    #text-align-menu > div {
+      position: relative;
+      font-family: fontra-icons;
+      font-size: 1.5em;
+      padding: 0.02em 0.3em 0.2em 0.3em;
+      border-radius: 0.5em;
+      cursor: pointer;
+      user-select: none;
+      transition: 120ms;
+    }
+
+    #text-align-menu > div:hover {
+      background-color: #c0c0c050;
+    }
+
+    #text-align-menu > div:active {
+      background-color: #c0c0c080;
+    }
+
+    #text-align-menu > div.selected {
+      background-color: #c0c0c060;
+    }
+
+    .sidebar-glyph-search {
+      box-sizing: border-box;
+      height: 100%;
+      display: grid;
+      gap: 1em;
+      padding: 1em;
+      grid-template-rows: auto 1fr;
+    }
+
+    #glyphs-search-input {
+      border-radius: 2em;
+      height: 1.8em;
+      box-sizing: border-box;
+      width: 100%;
+      background-color: var(--editor-glyphs-search-input-background-color);
+      color: var(--editor-glyphs-search-input-foreground-color);
+      border: none;
+      padding-left: 0.8em;
+      padding-right: 0.8em;
+    }
+
+    .designspace-sliders {
+      box-sizing: border-box;
+      height: 100%;
+      display: grid;
+      gap: 1em;
+      padding: 1em;
+      grid-template-rows: auto 1fr;
+    }
+
+    .sidebar-selection-info {
+      box-sizing: border-box;
+      height: 100%;
+      overflow-x: hidden;
+      overflow-y: scroll;
+      padding: 1em;
+    }
+  </style>
+
+  <body>
+    <div id="ui-dialog-container">
+      <!-- <div id="ui-dialog-content" tabindex="1"></div> -->
     </div>
 
-    <div class="sidebar-content" data-sidebar-name="glyph-search">
-      <div class="sidebar-glyph-search">
-        <div class="glyphs-search">
-          <input
-            type="text"
-            class="glyphs-search-input"
-            id="glyphs-search-input"
-            placeholder="Search glyphs"
-            autocomplete="off"
-            oninput="window.editorController.glyphSearchFieldChanged(value)">
-        </div>
-        <div id="glyphs-list" tabindex="1">
-          <!-- contents will be filled dynamically -->
-        </div>
-      </div>
-    </div>
+    <div id="global-loader-spinner"></div>
 
-    <div class="sidebar-content" data-sidebar-name="designspace-sliders">
-      <div class="designspace-sliders">
-        <div class="axis-sliders" id="axis-sliders">
-          <!-- contents will be filled dynamically -->
-        </div>
-        <div class="sources-list" id="sources-list" tabindex="1">
-          <!-- contents will be filled dynamically -->
-        </div>
-      </div>
-    </div>
+    <div class="editor-container">
+      <div class="sidebar-container left cleanable-overlay">
+        <div class="sidebar-content" data-sidebar-name="text-entry">
+          <div class="sidebar-text-entry">
+            <textarea rows="1" wrap="off" id="text-entry-textarea"></textarea>
 
-  </div>
-
-  <div class="main-container">
-
-    <canvas id="edit-canvas" tabindex="1"></canvas>
-
-    <div id="mini-console"></div>
-    <div id="context-menu" tabindex="0"></div>
-
-    <div class="main-overlay-container cleanable-overlay">
-
-      <div class="tab-overlay-container left">
-        <div class="sidebar-shadow-box"></div>
-        <div class="sidebar-tab" data-sidebar-name="text-entry">texttool</div>
-        <div class="sidebar-tab" data-sidebar-name="glyph-search">magnifyingglass</div>
-        <div class="sidebar-tab" data-sidebar-name="designspace-sliders">sliders</div>
-        <!-- <div class="sidebar-tab" data-sidebar-name="layers">layers</div> -->
-        <!-- <div class="sidebar-tab" data-sidebar-name="settings">gear</div> -->
-      </div>
-
-      <div class="tool-overlay-container">
-
-        <div class="tools-overlay">
-          <div id="edit-tools" class="tools-item">
-            <div class="tool-button selected"><div id="pointer-tool" class="tool-icon">pointer</div></div>
-            <div class="tool-button"><div id="pen-tool" class="tool-icon">pointeradd</div></div>
-            <div class="tool-button"><div id="hand-tool" class="tool-icon">hand</div></div>
-          </div>
-          <div id="zoom-tools" class="tools-item">
-            <div class="tool-button"><div id="zoom-out" class="tool-icon">minus</div></div>
-            <div class="tool-button"><div id="zoom-in" class="tool-icon">plus</div></div>
-            <div class="tool-button"><div id="zoom-fit-selection" class="tool-icon">bullseye</div></div>
+            <div id="text-align-menu">
+              <div>alignleft</div>
+              <div class="selected">aligncenter</div>
+              <div>alignright</div>
+            </div>
           </div>
         </div>
 
-      </div><!-- tool-overlay-container -->
+        <div class="sidebar-content" data-sidebar-name="glyph-search">
+          <div class="sidebar-glyph-search">
+            <div class="glyphs-search">
+              <input
+                type="text"
+                class="glyphs-search-input"
+                id="glyphs-search-input"
+                placeholder="Search glyphs"
+                autocomplete="off"
+                oninput="window.editorController.glyphSearchFieldChanged(value)"
+              />
+            </div>
+            <div id="glyphs-list" tabindex="1">
+              <!-- contents will be filled dynamically -->
+            </div>
+          </div>
+        </div>
 
-      <!-- <div></div> --><!-- overlay filler -->
-
-      <div class="tab-overlay-container right">
-        <div class="sidebar-shadow-box"></div>
-        <div class="sidebar-tab" data-sidebar-name="sidebar-selection-info">info</div>
-      </div>
-
-    </div>
-
-  </div>
-
-  <div class="sidebar-container right cleanable-overlay">
-    <div class="sidebar-content" data-sidebar-name="sidebar-selection-info">
-
-      <div class="sidebar-selection-info">
-        <div id="selection-info">
-          <!-- contents will be filled dynamically -->
+        <div class="sidebar-content" data-sidebar-name="designspace-sliders">
+          <div class="designspace-sliders">
+            <div class="axis-sliders" id="axis-sliders">
+              <!-- contents will be filled dynamically -->
+            </div>
+            <div class="sources-list" id="sources-list" tabindex="1">
+              <!-- contents will be filled dynamically -->
+            </div>
+          </div>
         </div>
       </div>
 
+      <div class="main-container">
+        <canvas id="edit-canvas" tabindex="1"></canvas>
+
+        <div id="mini-console"></div>
+        <div id="context-menu" tabindex="0"></div>
+
+        <div class="main-overlay-container cleanable-overlay">
+          <div class="tab-overlay-container left">
+            <div class="sidebar-shadow-box"></div>
+            <div class="sidebar-tab" data-sidebar-name="text-entry">texttool</div>
+            <div class="sidebar-tab" data-sidebar-name="glyph-search">
+              magnifyingglass
+            </div>
+            <div class="sidebar-tab" data-sidebar-name="designspace-sliders">
+              sliders
+            </div>
+            <!-- <div class="sidebar-tab" data-sidebar-name="layers">layers</div> -->
+            <!-- <div class="sidebar-tab" data-sidebar-name="settings">gear</div> -->
+          </div>
+
+          <div class="tool-overlay-container">
+            <div class="tools-overlay">
+              <div id="edit-tools" class="tools-item">
+                <div class="tool-button selected">
+                  <div id="pointer-tool" class="tool-icon">pointer</div>
+                </div>
+                <div class="tool-button">
+                  <div id="pen-tool" class="tool-icon">pointeradd</div>
+                </div>
+                <div class="tool-button">
+                  <div id="hand-tool" class="tool-icon">hand</div>
+                </div>
+              </div>
+              <div id="zoom-tools" class="tools-item">
+                <div class="tool-button">
+                  <div id="zoom-out" class="tool-icon">minus</div>
+                </div>
+                <div class="tool-button">
+                  <div id="zoom-in" class="tool-icon">plus</div>
+                </div>
+                <div class="tool-button">
+                  <div id="zoom-fit-selection" class="tool-icon">bullseye</div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <!-- tool-overlay-container -->
+
+          <!-- <div></div> --><!-- overlay filler -->
+
+          <div class="tab-overlay-container right">
+            <div class="sidebar-shadow-box"></div>
+            <div class="sidebar-tab" data-sidebar-name="sidebar-selection-info">
+              info
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="sidebar-container right cleanable-overlay">
+        <div class="sidebar-content" data-sidebar-name="sidebar-selection-info">
+          <div class="sidebar-selection-info">
+            <div id="selection-info">
+              <!-- contents will be filled dynamically -->
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
-  </div>
+  </body>
 
-</div>
+  <script type="module">
+    import { EditorController } from "/editor/editor.js";
 
-</body>
+    async function startApp() {
+      window.editorController = await EditorController.fromWebSocket();
+    }
 
-<script type="module">
-  import { EditorController } from "/editor/editor.js";
-
-  async function startApp() {
-    window.editorController = await EditorController.fromWebSocket();
-  }
-
-  startApp();
-</script>
-
+    startApp();
+  </script>
 </html>

--- a/src/fontra/views/editor/scene-draw-funcs.js
+++ b/src/fontra/views/editor/scene-draw-funcs.js
@@ -1,7 +1,10 @@
 import { isSuperset, union } from "../core/set-ops.js";
-import { makeUPlusStringFromCodePoint, parseSelection, withSavedState } from "../core/utils.js";
+import {
+  makeUPlusStringFromCodePoint,
+  parseSelection,
+  withSavedState,
+} from "../core/utils.js";
 import { subVectors } from "../core/vector.js";
-
 
 function requireEditingGlyph(func) {
   function wrapper(model, controller) {
@@ -13,7 +16,6 @@ function requireEditingGlyph(func) {
   return wrapper;
 }
 
-
 function requireSelectedGlyph(func) {
   function wrapper(model, controller) {
     if (!model.selectedGlyph || model.selectedGlyphIsEditing) {
@@ -23,7 +25,6 @@ function requireSelectedGlyph(func) {
   }
   return wrapper;
 }
-
 
 function requireHoveredGlyph(func) {
   function wrapper(model, controller) {
@@ -35,26 +36,28 @@ function requireHoveredGlyph(func) {
   return wrapper;
 }
 
-
 function glyphTranslate(func) {
   function wrapper(model, controller) {
     const positionedGlyph = model.getSelectedPositionedGlyph();
     controller.context.translate(positionedGlyph.x, positionedGlyph.y);
-    func(model, controller, controller.context, positionedGlyph.glyph, controller.drawingParameters);
+    func(
+      model,
+      controller,
+      controller.context,
+      positionedGlyph.glyph,
+      controller.drawingParameters
+    );
   }
   return wrapper;
 }
-
 
 export function drawMultiGlyphsLayer(model, controller) {
   _drawMultiGlyphsLayer(model, controller);
 }
 
-
 export function drawMultiGlyphsLayerClean(model, controller) {
   _drawMultiGlyphsLayer(model, controller, false);
 }
-
 
 function _drawMultiGlyphsLayer(model, controller, skipSelected = true) {
   if (!model.positionedLines) {
@@ -81,66 +84,84 @@ function _drawMultiGlyphsLayer(model, controller, skipSelected = true) {
   }
 }
 
-
-export const drawCJKDesignFrameLayer = requireEditingGlyph(glyphTranslate(
-(model, controller, context, glyph, drawingParameters) => {
-  const cjkDesignFrameParameters = model.fontController.fontLib["CJKDesignFrameSettings"];
-  if (!cjkDesignFrameParameters) {
-    return;
-  }
-  const [emW, emH] = cjkDesignFrameParameters["em_Dimension"];
-  const characterFace = cjkDesignFrameParameters["characterFace"] / 100;
-  const [shiftX, shiftY] = cjkDesignFrameParameters["shift"] || [0, -120];
-  const [overshootInside, overshootOutside] = cjkDesignFrameParameters["overshoot"];
-  const [faceW, faceH] = [emW * characterFace, emH * characterFace];
-  const [faceX, faceY] = [(emW - faceW) / 2, (emH - faceH) / 2]
-  let horizontalLine = cjkDesignFrameParameters["horizontalLine"];
-  let verticalLine = cjkDesignFrameParameters["verticalLine"];
-  const [overshootInsideW, overshootInsideH] = [faceW - overshootInside * 2, faceH - overshootInside * 2];
-  const [overshootOutsideW, overshootOutsideH] = [faceW + overshootOutside * 2, faceH + overshootOutside * 2];
-
-  context.translate(shiftX, shiftY);
-
-  context.strokeStyle = drawingParameters.cjkFrameStrokeColor;
-  context.lineWidth = drawingParameters.cjkFrameLineWidth;
-  context.strokeRect(0, 0, emW, emH);
-  context.strokeRect(faceX, faceY, faceW, faceH);
-
-  context.strokeStyle = drawingParameters.cjkFrameSecondLineColor;
-  if (cjkDesignFrameParameters["type"] === "han") {
-    horizontalLine /= 100;
-    verticalLine /= 100;
-    const centerX = emW / 2;
-    const centerY = emH / 2;
-    for (const y of [centerY + emH * horizontalLine, centerY - emH * horizontalLine]) {
-      strokeLine(context, 0, y, emW, y);
+export const drawCJKDesignFrameLayer = requireEditingGlyph(
+  glyphTranslate((model, controller, context, glyph, drawingParameters) => {
+    const cjkDesignFrameParameters =
+      model.fontController.fontLib["CJKDesignFrameSettings"];
+    if (!cjkDesignFrameParameters) {
+      return;
     }
-    for (const x of [centerX + emW * verticalLine, centerX - emW * verticalLine]) {
-      strokeLine(context, x, 0, x, emH);
-    }
-  } else {
-    // hangul
-    const stepX = faceW / verticalLine;
-    const stepY = faceH / horizontalLine;
-    for (let i = 1; i < horizontalLine; i++) {
-      const y = faceY + i * stepY;
-      strokeLine(context, faceX, y, faceX + faceW, y);
-    }
-    for (let i = 1; i < verticalLine; i++) {
-      const x = faceX + i * stepX;
-      strokeLine(context, x, faceY, x, faceY + faceH);
-    }
-  }
+    const [emW, emH] = cjkDesignFrameParameters["em_Dimension"];
+    const characterFace = cjkDesignFrameParameters["characterFace"] / 100;
+    const [shiftX, shiftY] = cjkDesignFrameParameters["shift"] || [0, -120];
+    const [overshootInside, overshootOutside] = cjkDesignFrameParameters["overshoot"];
+    const [faceW, faceH] = [emW * characterFace, emH * characterFace];
+    const [faceX, faceY] = [(emW - faceW) / 2, (emH - faceH) / 2];
+    let horizontalLine = cjkDesignFrameParameters["horizontalLine"];
+    let verticalLine = cjkDesignFrameParameters["verticalLine"];
+    const [overshootInsideW, overshootInsideH] = [
+      faceW - overshootInside * 2,
+      faceH - overshootInside * 2,
+    ];
+    const [overshootOutsideW, overshootOutsideH] = [
+      faceW + overshootOutside * 2,
+      faceH + overshootOutside * 2,
+    ];
 
-  // overshoot rect
-  context.fillStyle = drawingParameters.cjkFrameOvershootColor;
-  context.beginPath();
-  context.rect(faceX - overshootOutside, faceY - overshootOutside, overshootOutsideW, overshootOutsideH);
-  context.rect(faceX + overshootInside, faceY + overshootInside, overshootInsideW, overshootInsideH);
-  context.fill("evenodd");
-}
-));
+    context.translate(shiftX, shiftY);
 
+    context.strokeStyle = drawingParameters.cjkFrameStrokeColor;
+    context.lineWidth = drawingParameters.cjkFrameLineWidth;
+    context.strokeRect(0, 0, emW, emH);
+    context.strokeRect(faceX, faceY, faceW, faceH);
+
+    context.strokeStyle = drawingParameters.cjkFrameSecondLineColor;
+    if (cjkDesignFrameParameters["type"] === "han") {
+      horizontalLine /= 100;
+      verticalLine /= 100;
+      const centerX = emW / 2;
+      const centerY = emH / 2;
+      for (const y of [
+        centerY + emH * horizontalLine,
+        centerY - emH * horizontalLine,
+      ]) {
+        strokeLine(context, 0, y, emW, y);
+      }
+      for (const x of [centerX + emW * verticalLine, centerX - emW * verticalLine]) {
+        strokeLine(context, x, 0, x, emH);
+      }
+    } else {
+      // hangul
+      const stepX = faceW / verticalLine;
+      const stepY = faceH / horizontalLine;
+      for (let i = 1; i < horizontalLine; i++) {
+        const y = faceY + i * stepY;
+        strokeLine(context, faceX, y, faceX + faceW, y);
+      }
+      for (let i = 1; i < verticalLine; i++) {
+        const x = faceX + i * stepX;
+        strokeLine(context, x, faceY, x, faceY + faceH);
+      }
+    }
+
+    // overshoot rect
+    context.fillStyle = drawingParameters.cjkFrameOvershootColor;
+    context.beginPath();
+    context.rect(
+      faceX - overshootOutside,
+      faceY - overshootOutside,
+      overshootOutsideW,
+      overshootOutsideH
+    );
+    context.rect(
+      faceX + overshootInside,
+      faceY + overshootInside,
+      overshootInsideW,
+      overshootInsideH
+    );
+    context.fill("evenodd");
+  })
+);
 
 export function drawUndefinedGlyphsLayer(model, controller) {
   if (!model.positionedLines) {
@@ -162,12 +183,16 @@ export function drawUndefinedGlyphsLayer(model, controller) {
           context.fillText(glyph.glyphName, glyph.glyph.xAdvance / 2, 0);
           if (glyph.character) {
             const uniStr = makeUPlusStringFromCodePoint(glyph.character.codePointAt(0));
-            context.fillText(uniStr, glyph.glyph.xAdvance / 2, -lineDistance * glyphNameFontSize);
+            context.fillText(
+              uniStr,
+              glyph.glyph.xAdvance / 2,
+              -lineDistance * glyphNameFontSize
+            );
             context.font = `${placeholderFontSize}px fontra-ui-regular, sans-serif`;
             context.fillText(
               glyph.character,
               glyph.glyph.xAdvance / 2,
-              -lineDistance * glyphNameFontSize - 0.4 * placeholderFontSize,
+              -lineDistance * glyphNameFontSize - 0.4 * placeholderFontSize
             );
           }
         });
@@ -176,48 +201,54 @@ export function drawUndefinedGlyphsLayer(model, controller) {
   }
 }
 
-
-export const drawSelectedBaselineLayer = requireEditingGlyph(glyphTranslate(
-(model, controller, context, glyph, drawingParameters) => {
-  context.strokeStyle = drawingParameters.sidebearingBarColor;
-  context.lineWidth = drawingParameters.pathLineWidth;
-  strokeLine(context, 0, 0, glyph.xAdvance, 0);
-}
-));
-
-
-export const drawSidebearingsLayer = requireEditingGlyph(glyphTranslate(
-(model, controller, context, glyph, drawingParameters) => {
-  context.strokeStyle = drawingParameters.sidebearingBarColor;
-  context.lineWidth = drawingParameters.pathLineWidth;
-  const extent = drawingParameters.sidebearingBarExtent;
-  strokeLine(context, 0, -extent, 0, extent);
-  strokeLine(context, glyph.xAdvance, -extent, glyph.xAdvance, extent);
-  if (extent < glyph.xAdvance / 2) {
-    strokeLine(context, 0, 0, extent, 0);
-    strokeLine(context, glyph.xAdvance, 0, glyph.xAdvance - extent, 0);
-  } else {
+export const drawSelectedBaselineLayer = requireEditingGlyph(
+  glyphTranslate((model, controller, context, glyph, drawingParameters) => {
+    context.strokeStyle = drawingParameters.sidebearingBarColor;
+    context.lineWidth = drawingParameters.pathLineWidth;
     strokeLine(context, 0, 0, glyph.xAdvance, 0);
-  }
-}
-));
-
-
-export const drawHoveredEmptyGlyphLayer = requireHoveredGlyph(
-(model, controller) => {
-  _drawSelectedEmptyGlyphLayer(model, controller, model.hoveredGlyph, "hoveredEmptyGlyphColor");
-}
+  })
 );
 
-
-export const drawSelectedEmptyGlyphLayer = requireSelectedGlyph(
-(model, controller) => {
-  _drawSelectedEmptyGlyphLayer(model, controller, model.selectedGlyph, "selectedEmptyGlyphColor");
-}
+export const drawSidebearingsLayer = requireEditingGlyph(
+  glyphTranslate((model, controller, context, glyph, drawingParameters) => {
+    context.strokeStyle = drawingParameters.sidebearingBarColor;
+    context.lineWidth = drawingParameters.pathLineWidth;
+    const extent = drawingParameters.sidebearingBarExtent;
+    strokeLine(context, 0, -extent, 0, extent);
+    strokeLine(context, glyph.xAdvance, -extent, glyph.xAdvance, extent);
+    if (extent < glyph.xAdvance / 2) {
+      strokeLine(context, 0, 0, extent, 0);
+      strokeLine(context, glyph.xAdvance, 0, glyph.xAdvance - extent, 0);
+    } else {
+      strokeLine(context, 0, 0, glyph.xAdvance, 0);
+    }
+  })
 );
 
+export const drawHoveredEmptyGlyphLayer = requireHoveredGlyph((model, controller) => {
+  _drawSelectedEmptyGlyphLayer(
+    model,
+    controller,
+    model.hoveredGlyph,
+    "hoveredEmptyGlyphColor"
+  );
+});
 
-function _drawSelectedEmptyGlyphLayer(model, controller, selectedGlyph, emptyGlyphColorName) {
+export const drawSelectedEmptyGlyphLayer = requireSelectedGlyph((model, controller) => {
+  _drawSelectedEmptyGlyphLayer(
+    model,
+    controller,
+    model.selectedGlyph,
+    "selectedEmptyGlyphColor"
+  );
+});
+
+function _drawSelectedEmptyGlyphLayer(
+  model,
+  controller,
+  selectedGlyph,
+  emptyGlyphColorName
+) {
   const context = controller.context;
   const [lineIndex, glyphIndex] = selectedGlyph.split("/");
   const positionedGlyph = model.positionedLines[lineIndex].glyphs[glyphIndex];
@@ -229,11 +260,11 @@ function _drawSelectedEmptyGlyphLayer(model, controller, selectedGlyph, emptyGly
   const fillColor = controller.drawingParameters[emptyGlyphColorName];
   if (fillColor[0] === "#" && fillColor.length === 7) {
     const gradient = context.createLinearGradient(0, box.yMin, 0, box.yMax);
-    gradient.addColorStop(0.00, fillColor + "00");
-    gradient.addColorStop(0.20, fillColor + "DD");
-    gradient.addColorStop(0.50, fillColor + "FF");
-    gradient.addColorStop(0.80, fillColor + "DD");
-    gradient.addColorStop(1.00, fillColor + "00");
+    gradient.addColorStop(0.0, fillColor + "00");
+    gradient.addColorStop(0.2, fillColor + "DD");
+    gradient.addColorStop(0.5, fillColor + "FF");
+    gradient.addColorStop(0.8, fillColor + "DD");
+    gradient.addColorStop(1.0, fillColor + "00");
     context.fillStyle = gradient;
   } else {
     context.fillStyle = fillColor;
@@ -241,20 +272,23 @@ function _drawSelectedEmptyGlyphLayer(model, controller, selectedGlyph, emptyGly
   context.fillRect(box.xMin, box.yMin, box.xMax - box.xMin, box.yMax - box.yMin);
 }
 
+export const drawHoveredGlyphLayer = requireHoveredGlyph((model, controller) => {
+  _drawSelectedGlyphLayer(
+    model,
+    controller,
+    model.hoveredGlyph,
+    "hoveredGlyphStrokeColor"
+  );
+});
 
-export const drawHoveredGlyphLayer = requireHoveredGlyph(
-(model, controller) => {
-  _drawSelectedGlyphLayer(model, controller, model.hoveredGlyph, "hoveredGlyphStrokeColor");
-}
-);
-
-
-export const drawSelectedGlyphLayer = requireSelectedGlyph(
-(model, controller) => {
-  _drawSelectedGlyphLayer(model, controller, model.selectedGlyph, "selectedGlyphStrokeColor");
-}
-);
-
+export const drawSelectedGlyphLayer = requireSelectedGlyph((model, controller) => {
+  _drawSelectedGlyphLayer(
+    model,
+    controller,
+    model.selectedGlyph,
+    "selectedGlyphStrokeColor"
+  );
+});
 
 function _drawSelectedGlyphLayer(model, controller, selectedGlyph, strokeColorName) {
   const context = controller.context;
@@ -271,106 +305,99 @@ function _drawSelectedGlyphLayer(model, controller, selectedGlyph, strokeColorNa
     10 * controller.onePixelUnit,
     3 * controller.onePixelUnit,
     controller.drawingParameters[strokeColorName],
-    controller.drawingParameters.glyphFillColor,
-  )
+    controller.drawingParameters.glyphFillColor
+  );
 }
 
+export const drawPathFillLayer = requireEditingGlyph(
+  glyphTranslate((model, controller, context, glyph, drawingParameters) => {
+    context.fillStyle = drawingParameters.pathFillColor;
+    context.fill(glyph.flattenedPath2d);
+  })
+);
 
-export const drawPathFillLayer = requireEditingGlyph(glyphTranslate(
-(model, controller, context, glyph, drawingParameters) => {
-  context.fillStyle = drawingParameters.pathFillColor;
-  context.fill(glyph.flattenedPath2d);
-}
-));
+export const drawPathStrokeLayer = requireEditingGlyph(
+  glyphTranslate((model, controller, context, glyph, drawingParameters) => {
+    context.lineJoin = "round";
+    context.lineWidth = drawingParameters.pathLineWidth;
+    context.strokeStyle = drawingParameters.pathStrokeColor;
+    context.stroke(glyph.flattenedPath2d);
+  })
+);
 
+export const drawGhostPathLayer = requireEditingGlyph(
+  glyphTranslate((model, controller, context, glyph, drawingParameters) => {
+    if (!model.ghostPath) {
+      return;
+    }
+    context.lineJoin = "round";
+    context.lineWidth = drawingParameters.pathLineWidth;
+    context.strokeStyle = drawingParameters.ghostPathStrokeColor;
+    context.stroke(model.ghostPath);
+  })
+);
 
-export const drawPathStrokeLayer = requireEditingGlyph(glyphTranslate(
-(model, controller, context, glyph, drawingParameters) => {
-  context.lineJoin = "round";
-  context.lineWidth = drawingParameters.pathLineWidth;
-  context.strokeStyle = drawingParameters.pathStrokeColor;
-  context.stroke(glyph.flattenedPath2d);
-}
-));
-
-
-export const drawGhostPathLayer = requireEditingGlyph(glyphTranslate(
-(model, controller, context, glyph, drawingParameters) => {
-  if (!model.ghostPath) {
-    return;
-  }
-  context.lineJoin = "round";
-  context.lineWidth = drawingParameters.pathLineWidth;
-  context.strokeStyle = drawingParameters.ghostPathStrokeColor;
-  context.stroke(model.ghostPath);
-}
-));
-
-
-export const drawHandlesLayer = requireEditingGlyph(glyphTranslate(
-(model, controller, context, glyph, drawingParameters) => {
-  context.strokeStyle = drawingParameters.handleColor;
-  context.lineWidth = drawingParameters.handleLineWidth;
-  for (const [pt1, pt2] of glyph.path.iterHandles()) {
-    strokeLine(context, pt1.x, pt1.y, pt2.x, pt2.y);
-  }
-}
-));
-
+export const drawHandlesLayer = requireEditingGlyph(
+  glyphTranslate((model, controller, context, glyph, drawingParameters) => {
+    context.strokeStyle = drawingParameters.handleColor;
+    context.lineWidth = drawingParameters.handleLineWidth;
+    for (const [pt1, pt2] of glyph.path.iterHandles()) {
+      strokeLine(context, pt1.x, pt1.y, pt2.x, pt2.y);
+    }
+  })
+);
 
 const START_POINT_ARC_GAP_ANGLE = 0.25 * Math.PI;
 
-
-export const drawStartPointsLayer = requireEditingGlyph(glyphTranslate(
-(model, controller, context, glyph, drawingParameters) => {
-  context.strokeStyle = drawingParameters.startPointIndicatorColor;
-  context.lineWidth = drawingParameters.startPointIndicatorLineWidth;
-  const radius = drawingParameters.startPointIndicatorRadius;
-  let startPointIndex = 0;
-  for (const contourInfo of glyph.path.contourInfo) {
-    const startPoint = glyph.path.getPoint(startPointIndex);
-    let angle;
-    if (startPointIndex < contourInfo.endPoint) {
-      const nextPoint = glyph.path.getPoint(startPointIndex + 1);
-      const direction = subVectors(nextPoint, startPoint);
-      angle = Math.atan2(direction.y, direction.x);
+export const drawStartPointsLayer = requireEditingGlyph(
+  glyphTranslate((model, controller, context, glyph, drawingParameters) => {
+    context.strokeStyle = drawingParameters.startPointIndicatorColor;
+    context.lineWidth = drawingParameters.startPointIndicatorLineWidth;
+    const radius = drawingParameters.startPointIndicatorRadius;
+    let startPointIndex = 0;
+    for (const contourInfo of glyph.path.contourInfo) {
+      const startPoint = glyph.path.getPoint(startPointIndex);
+      let angle;
+      if (startPointIndex < contourInfo.endPoint) {
+        const nextPoint = glyph.path.getPoint(startPointIndex + 1);
+        const direction = subVectors(nextPoint, startPoint);
+        angle = Math.atan2(direction.y, direction.x);
+      }
+      let startAngle = 0;
+      let endAngle = 2 * Math.PI;
+      if (angle !== undefined) {
+        startAngle += angle + START_POINT_ARC_GAP_ANGLE;
+        endAngle += angle - START_POINT_ARC_GAP_ANGLE;
+      }
+      context.beginPath();
+      context.arc(startPoint.x, startPoint.y, radius, startAngle, endAngle, false);
+      context.stroke();
+      startPointIndex = contourInfo.endPoint + 1;
     }
-    let startAngle = 0;
-    let endAngle = 2 * Math.PI;
-    if (angle !== undefined) {
-      startAngle += angle + START_POINT_ARC_GAP_ANGLE;
-      endAngle += angle - START_POINT_ARC_GAP_ANGLE;
+  })
+);
+
+export const drawNodesLayer = requireEditingGlyph(
+  glyphTranslate((model, controller, context, glyph, drawingParameters) => {
+    const cornerNodeSize = drawingParameters.cornerNodeSize;
+    const smoothNodeSize = drawingParameters.smoothNodeSize;
+    const handleNodeSize = drawingParameters.handleNodeSize;
+
+    context.fillStyle = drawingParameters.nodeFillColor;
+    for (const pt of glyph.path.iterPoints()) {
+      fillNode(context, pt, cornerNodeSize, smoothNodeSize, handleNodeSize);
     }
-    context.beginPath();
-    context.arc(startPoint.x, startPoint.y, radius, startAngle, endAngle, false);
-    context.stroke();
-    startPointIndex = contourInfo.endPoint + 1;
-  }
-}
-));
+  })
+);
 
-
-export const drawNodesLayer = requireEditingGlyph(glyphTranslate(
-(model, controller, context, glyph, drawingParameters) => {
-  const cornerNodeSize = drawingParameters.cornerNodeSize;
-  const smoothNodeSize = drawingParameters.smoothNodeSize;
-  const handleNodeSize = drawingParameters.handleNodeSize;
-
-  context.fillStyle = drawingParameters.nodeFillColor;
-  for (const pt of glyph.path.iterPoints()) {
-    fillNode(context, pt, cornerNodeSize, smoothNodeSize, handleNodeSize);
-  }
-}
-));
-
-
-export const drawComponentSelectionLayer = requireEditingGlyph(glyphTranslate(
-  (model, controller, context, glyph, drawingParameters) => {
-    const isHoverSelected = model.selection?.size && isSuperset(model.selection, model.hoverSelection);
-    const {"component": hoveredComponentIndices} = parseSelection(model.hoverSelection);
+export const drawComponentSelectionLayer = requireEditingGlyph(
+  glyphTranslate((model, controller, context, glyph, drawingParameters) => {
+    const isHoverSelected =
+      model.selection?.size && isSuperset(model.selection, model.hoverSelection);
+    const { component: hoveredComponentIndices } = parseSelection(model.hoverSelection);
     const hoveredComponentIndex = hoveredComponentIndices?.[0];
     const combinedSelection = lenientUnion(model.selection, model.hoverSelection);
-    const {"component": combinedComponentIndices} = parseSelection(combinedSelection);
+    const { component: combinedComponentIndices } = parseSelection(combinedSelection);
 
     const hoveredComponentStrokeColor = drawingParameters.hoveredComponentStrokeColor;
     const selectedComponentStrokeColor = drawingParameters.selectedComponentStrokeColor;
@@ -378,23 +405,27 @@ export const drawComponentSelectionLayer = requireEditingGlyph(glyphTranslate(
     const selectedComponentLineWidth = drawingParameters.selectedComponentLineWidth;
 
     for (const componentIndex of combinedComponentIndices || []) {
-      const drawSelectionFill = isHoverSelected || componentIndex !== hoveredComponentIndex;
+      const drawSelectionFill =
+        isHoverSelected || componentIndex !== hoveredComponentIndex;
       const componentPath = glyph.components[componentIndex].path2d;
       context.save();
       context.lineJoin = "round";
-      context.lineWidth = drawSelectionFill ? selectedComponentLineWidth : hoveredComponentLineWidth;
-      context.strokeStyle = drawSelectionFill ? selectedComponentStrokeColor : hoveredComponentStrokeColor;
+      context.lineWidth = drawSelectionFill
+        ? selectedComponentLineWidth
+        : hoveredComponentLineWidth;
+      context.strokeStyle = drawSelectionFill
+        ? selectedComponentStrokeColor
+        : hoveredComponentStrokeColor;
       context.stroke(componentPath);
       context.restore();
     }
-  }
-));
+  })
+);
 
-
-export const drawPathSelectionLayer = requireEditingGlyph(glyphTranslate(
-  (model, controller, context, glyph, drawingParameters) => {
-    const {"point": hoveredPointIndices} = parseSelection(model.hoverSelection);
-    const {"point": selectedPointIndices} = parseSelection(model.selection);
+export const drawPathSelectionLayer = requireEditingGlyph(
+  glyphTranslate((model, controller, context, glyph, drawingParameters) => {
+    const { point: hoveredPointIndices } = parseSelection(model.hoverSelection);
+    const { point: selectedPointIndices } = parseSelection(model.selection);
 
     const cornerNodeSize = drawingParameters.cornerNodeSize;
     const smoothNodeSize = drawingParameters.smoothNodeSize;
@@ -402,7 +433,7 @@ export const drawPathSelectionLayer = requireEditingGlyph(glyphTranslate(
 
     context.strokeStyle = drawingParameters.hoveredNodeStrokeColor;
     context.lineWidth = drawingParameters.hoveredNodeLineWidth;
-    const hoverStrokeOffset = 4 * controller.onePixelUnit
+    const hoverStrokeOffset = 4 * controller.onePixelUnit;
     context.fillStyle = drawingParameters.selectedNodeFillColor;
 
     for (const pointIndex of hoveredPointIndices || []) {
@@ -411,7 +442,13 @@ export const drawPathSelectionLayer = requireEditingGlyph(glyphTranslate(
         // Selection is not valid
         continue;
       }
-      strokeNode(context, pt, cornerNodeSize + hoverStrokeOffset, smoothNodeSize + hoverStrokeOffset, handleNodeSize + hoverStrokeOffset);
+      strokeNode(
+        context,
+        pt,
+        cornerNodeSize + hoverStrokeOffset,
+        smoothNodeSize + hoverStrokeOffset,
+        handleNodeSize + hoverStrokeOffset
+      );
     }
     for (const pointIndex of selectedPointIndices || []) {
       const pt = glyph.path.getPoint(pointIndex);
@@ -421,9 +458,8 @@ export const drawPathSelectionLayer = requireEditingGlyph(glyphTranslate(
       }
       fillNode(context, pt, cornerNodeSize, smoothNodeSize, handleNodeSize);
     }
-  }
-));
-
+  })
+);
 
 export function drawRectangleSelectionLayer(model, controller) {
   if (model.selectionRect === undefined) {
@@ -443,7 +479,6 @@ export function drawRectangleSelectionLayer(model, controller) {
   context.strokeRect(x, y, w, h);
 }
 
-
 function fillNode(context, pt, cornerNodeSize, smoothNodeSize, handleNodeSize) {
   if (!pt.type && !pt.smooth) {
     fillSquareNode(context, pt, cornerNodeSize);
@@ -453,7 +488,6 @@ function fillNode(context, pt, cornerNodeSize, smoothNodeSize, handleNodeSize) {
     fillRoundNode(context, pt, handleNodeSize);
   }
 }
-
 
 function strokeNode(context, pt, cornerNodeSize, smoothNodeSize, handleNodeSize) {
   if (!pt.type && !pt.smooth) {
@@ -465,14 +499,8 @@ function strokeNode(context, pt, cornerNodeSize, smoothNodeSize, handleNodeSize)
   }
 }
 
-
 function fillSquareNode(context, pt, nodeSize) {
-  context.fillRect(
-    pt.x - nodeSize / 2,
-    pt.y - nodeSize / 2,
-    nodeSize,
-    nodeSize
-  );
+  context.fillRect(pt.x - nodeSize / 2, pt.y - nodeSize / 2, nodeSize, nodeSize);
 }
 
 function fillRoundNode(context, pt, nodeSize) {
@@ -481,23 +509,15 @@ function fillRoundNode(context, pt, nodeSize) {
   context.fill();
 }
 
-
 function strokeSquareNode(context, pt, nodeSize) {
-  context.strokeRect(
-    pt.x - nodeSize / 2,
-    pt.y - nodeSize / 2,
-    nodeSize,
-    nodeSize
-  );
+  context.strokeRect(pt.x - nodeSize / 2, pt.y - nodeSize / 2, nodeSize, nodeSize);
 }
-
 
 function strokeRoundNode(context, pt, nodeSize) {
   context.beginPath();
   context.arc(pt.x, pt.y, nodeSize / 2, 0, 2 * Math.PI, false);
   context.stroke();
 }
-
 
 function strokeLine(context, x1, y1, x2, y2) {
   context.beginPath();
@@ -506,11 +526,9 @@ function strokeLine(context, x1, y1, x2, y2) {
   context.stroke();
 }
 
-
 function fillPolygon(context, points, isClosed = true) {
   context.fill(polygonPath(points));
 }
-
 
 function polygonPath(points, isClosed = true) {
   const path = new Path2D();
@@ -526,21 +544,26 @@ function polygonPath(points, isClosed = true) {
   return path;
 }
 
-
-function drawWithDoubleStroke(context, path, outerLineWidth, innerLineWidth, strokeStyle, fillStyle) {
+function drawWithDoubleStroke(
+  context,
+  path,
+  outerLineWidth,
+  innerLineWidth,
+  strokeStyle,
+  fillStyle
+) {
   context.lineJoin = "round";
   context.lineWidth = outerLineWidth;
   context.strokeStyle = strokeStyle;
   context.stroke(path);
   context.lineWidth = innerLineWidth;
   context.strokeStyle = "black";
-  context.globalCompositeOperation = "destination-out"
+  context.globalCompositeOperation = "destination-out";
   context.stroke(path);
-  context.globalCompositeOperation = "source-over"
+  context.globalCompositeOperation = "source-over";
   context.fillStyle = fillStyle;
   context.fill(path);
 }
-
 
 function lenientUnion(setA, setB) {
   if (!setA) {

--- a/src/fontra/views/editor/scene-model.js
+++ b/src/fontra/views/editor/scene-model.js
@@ -1,13 +1,18 @@
-import { getAxisBaseName } from "../core/glyph-controller.js"
-import { centeredRect, isEmptyRect, offsetRect, pointInRect, sectRect, unionRect } from "../core/rectangle.js";
+import { getAxisBaseName } from "../core/glyph-controller.js";
+import {
+  centeredRect,
+  isEmptyRect,
+  offsetRect,
+  pointInRect,
+  sectRect,
+  unionRect,
+} from "../core/rectangle.js";
 import { pointInConvexPolygon, rectIntersectsPolygon } from "../core/convex-hull.js";
 import { parseSelection } from "../core/utils.js";
 import { mapForward, mapBackward } from "../core/var-model.js";
 import { difference, isEqualSet, updateSet } from "../core/set-ops.js";
 
-
 export class SceneModel {
-
   constructor(fontController, isPointInPath) {
     this.fontController = fontController;
     this.isPointInPath = isPointInPath;
@@ -18,8 +23,8 @@ export class SceneModel {
     this.selectedGlyph = undefined;
     this.selectedGlyphIsEditing = false;
     this.hoveredGlyph = undefined;
-    this._globalLocation = undefined;  // see getGlobalLocation()
-    this._localLocations = {};  // glyph name -> local location
+    this._globalLocation = undefined; // see getGlobalLocation()
+    this._localLocations = {}; // glyph name -> local location
     this.textAlignment = "center";
     this.longestLineLength = 0;
     this.usedGlyphNames = new Set();
@@ -55,9 +60,9 @@ export class SceneModel {
     }
     const [lineIndex, glyphIndex] = this.selectedGlyph.split("/");
     return {
-      "lineIndex": Number(lineIndex),
-      "glyphIndex": Number(glyphIndex),
-      "isEditing": this.selectedGlyphIsEditing,
+      lineIndex: Number(lineIndex),
+      glyphIndex: Number(glyphIndex),
+      isEditing: this.selectedGlyphIsEditing,
     };
   }
 
@@ -94,7 +99,10 @@ export class SceneModel {
 
   getLocation() {
     const glyphName = this.getSelectedGlyphName();
-    const location = {...this.getGlobalLocation(), ...this._localLocations[glyphName]};
+    const location = {
+      ...this.getGlobalLocation(),
+      ...this._localLocations[glyphName],
+    };
     return location;
   }
 
@@ -114,10 +122,14 @@ export class SceneModel {
       localLocations = {};
       for (const glyphLine of this.glyphLines) {
         for (const glyphInfo of glyphLine) {
-          if (!localLocations[glyphInfo.glyphName] && this._localLocations[glyphInfo.glyphName]) {
+          if (
+            !localLocations[glyphInfo.glyphName] &&
+            this._localLocations[glyphInfo.glyphName]
+          ) {
             const localLocation = this._localLocations[glyphInfo.glyphName];
             if (Object.keys(localLocation).length) {
-              localLocations[glyphInfo.glyphName] = this._localLocations[glyphInfo.glyphName];
+              localLocations[glyphInfo.glyphName] =
+                this._localLocations[glyphInfo.glyphName];
             }
           }
         }
@@ -130,7 +142,7 @@ export class SceneModel {
 
   async setLocation(location) {
     const glyphName = this.getSelectedGlyphName();
-    const localLocation = {...location};
+    const localLocation = { ...location };
     const globalLocation = {};
     for (const axis of this.fontController.globalAxes) {
       if (location[axis.name] !== undefined) {
@@ -156,7 +168,7 @@ export class SceneModel {
   }
 
   updateLocalLocations(localLocations) {
-    this._localLocations = {...this._localLocations, ...localLocations};
+    this._localLocations = { ...this._localLocations, ...localLocations };
   }
 
   async getSelectedSource() {
@@ -178,16 +190,18 @@ export class SceneModel {
       location[axis.name] = axis.defaultValue;
     }
     const source = glyph.sources[sourceIndex];
-    location = glyph.mapLocationLocalToGlobal({...location, ...source.location});
+    location = glyph.mapLocationLocalToGlobal({ ...location, ...source.location });
     await this.setLocation(location);
   }
 
   async getAxisInfo() {
     const allAxes = Array.from(this.fontController.globalAxes);
-    const globalAxisNames = new Set(allAxes.map(axis => axis.name));
+    const globalAxisNames = new Set(allAxes.map((axis) => axis.name));
     if (this.selectedGlyph) {
       const glyph = await this.getSelectedVariableGlyphController();
-      const glyphAxes = getAxisInfoFromGlyph(glyph).filter(axis => !globalAxisNames.has(axis.name));
+      const glyphAxes = getAxisInfoFromGlyph(glyph).filter(
+        (axis) => !globalAxisNames.has(axis.name)
+      );
       allAxes.push(...glyphAxes);
     }
     return allAxes;
@@ -204,7 +218,7 @@ export class SceneModel {
       if (!name) {
         name = `source${i}`;
       }
-      sourcesInfo.push({"sourceName": name, "sourceIndex": i})
+      sourcesInfo.push({ sourceName: name, sourceIndex: i });
     }
     return sourcesInfo;
   }
@@ -224,39 +238,43 @@ export class SceneModel {
     // Call this when the cmap changed: previously missing characters may now be
     // available, but may have a different glyph name, or a character may no longer
     // be available, in which case we set the isUndefined flag
-    this.glyphLines = this.glyphLines.map(line => line.map(glyphInfo => {
-      const glyphName = (
-        glyphInfo.character
-        ?
-        this.fontController.characterMap[glyphInfo.character.codePointAt(0)]
-        :
-        undefined
-      );
-      if (glyphInfo.isUndefined && glyphName) {
-        glyphInfo = {
-          character: glyphInfo.character,
-          glyphName: glyphName,
-          isUndefined: false,
-        };
-      } else if (!glyphName) {
-        glyphInfo = {
-          character: glyphInfo.character,
-          glyphName: glyphInfo.glyphName,
-          isUndefined: true,
-        };
-      }
-      return glyphInfo;
-    }));
+    this.glyphLines = this.glyphLines.map((line) =>
+      line.map((glyphInfo) => {
+        const glyphName = glyphInfo.character
+          ? this.fontController.characterMap[glyphInfo.character.codePointAt(0)]
+          : undefined;
+        if (glyphInfo.isUndefined && glyphName) {
+          glyphInfo = {
+            character: glyphInfo.character,
+            glyphName: glyphName,
+            isUndefined: false,
+          };
+        } else if (!glyphName) {
+          glyphInfo = {
+            character: glyphInfo.character,
+            glyphName: glyphInfo.glyphName,
+            isUndefined: true,
+          };
+        }
+        return glyphInfo;
+      })
+    );
   }
 
   async updateScene() {
     [this.positionedLines, this.longestLineLength] = await buildScene(
-      this.fontController, this.glyphLines, this.getGlobalLocation(), this._localLocations,
-      this.textAlignment,
+      this.fontController,
+      this.glyphLines,
+      this.getGlobalLocation(),
+      this._localLocations,
+      this.textAlignment
     );
 
     const usedGlyphNames = getUsedGlyphNames(this.fontController, this.positionedLines);
-    const cachedGlyphNames = difference(this.fontController.getCachedGlyphNames(), usedGlyphNames);
+    const cachedGlyphNames = difference(
+      this.fontController.getCachedGlyphNames(),
+      usedGlyphNames
+    );
 
     this._adjustSubscriptions(usedGlyphNames, this.usedGlyphNames, true);
     this._adjustSubscriptions(cachedGlyphNames, this.cachedGlyphNames, false);
@@ -272,10 +290,16 @@ export class SceneModel {
     const unsubscribeGlyphNames = difference(previousGlyphNames, currentGlyphNames);
     const subscribeGlyphNames = difference(currentGlyphNames, previousGlyphNames);
     if (unsubscribeGlyphNames.size) {
-      this.fontController.unsubscribeChanges(makeGlyphNamesPattern(unsubscribeGlyphNames), wantLiveChanges);
+      this.fontController.unsubscribeChanges(
+        makeGlyphNamesPattern(unsubscribeGlyphNames),
+        wantLiveChanges
+      );
     }
     if (subscribeGlyphNames.size) {
-      this.fontController.subscribeChanges(makeGlyphNamesPattern(subscribeGlyphNames), wantLiveChanges);
+      this.fontController.subscribeChanges(
+        makeGlyphNamesPattern(subscribeGlyphNames),
+        wantLiveChanges
+      );
     }
   }
 
@@ -284,11 +308,15 @@ export class SceneModel {
       return new Set();
     }
     const positionedGlyph = this.getSelectedPositionedGlyph();
-    const selRect = centeredRect(point.x - positionedGlyph.x, point.y - positionedGlyph.y, size);
+    const selRect = centeredRect(
+      point.x - positionedGlyph.x,
+      point.y - positionedGlyph.y,
+      size
+    );
     for (const hit of positionedGlyph.glyph.path.iterPointsInRect(selRect)) {
       // TODO: we may have to filter or sort for the case when a handle coincides with
       // its anchor, to get a consistent result despite which of the two comes first.
-      return new Set([`point/${hit.pointIndex}`])
+      return new Set([`point/${hit.pointIndex}`]);
     }
     const components = positionedGlyph.glyph.components;
     const x = point.x - positionedGlyph.x;
@@ -296,9 +324,11 @@ export class SceneModel {
     const componentHullMatches = [];
     for (let i = components.length - 1; i >= 0; i--) {
       const component = components[i];
-      if (pointInRect(x, y, component.controlBounds)
-          && pointInConvexPolygon(x, y, component.convexHull)) {
-        componentHullMatches.push({"index": i, "component": component});
+      if (
+        pointInRect(x, y, component.controlBounds) &&
+        pointInConvexPolygon(x, y, component.convexHull)
+      ) {
+        componentHullMatches.push({ index: i, component: component });
       }
     }
     switch (componentHullMatches.length) {
@@ -330,8 +360,10 @@ export class SceneModel {
     }
     const components = positionedGlyph.glyph.components;
     for (let i = 0; i < components.length; i++) {
-      if (sectRect(selRect, components[i].controlBounds)
-          && rectIntersectsPolygon(selRect, components[i].convexHull)) {
+      if (
+        sectRect(selRect, components[i].controlBounds) &&
+        rectIntersectsPolygon(selRect, components[i].convexHull)
+      ) {
         selection.add(`component/${i}`);
       }
     }
@@ -341,21 +373,34 @@ export class SceneModel {
   glyphAtPoint(point, skipEditingGlyph = true) {
     for (let i = this.positionedLines.length - 1; i >= 0; i--) {
       const positionedLine = this.positionedLines[i];
-      if (!positionedLine.bounds || !pointInRect(point.x, point.y, positionedLine.bounds)) {
+      if (
+        !positionedLine.bounds ||
+        !pointInRect(point.x, point.y, positionedLine.bounds)
+      ) {
         continue;
       }
       for (let j = positionedLine.glyphs.length - 1; j >= 0; j--) {
         const positionedGlyph = positionedLine.glyphs[j];
-        if (!positionedGlyph.bounds || !pointInRect(point.x, point.y, positionedGlyph.bounds)) {
+        if (
+          !positionedGlyph.bounds ||
+          !pointInRect(point.x, point.y, positionedGlyph.bounds)
+        ) {
           continue;
         }
-        if (positionedGlyph.isEmpty || pointInConvexPolygon(
-          point.x - positionedGlyph.x,
-          point.y - positionedGlyph.y,
-          positionedGlyph.glyph.convexHull,
-        )) {
+        if (
+          positionedGlyph.isEmpty ||
+          pointInConvexPolygon(
+            point.x - positionedGlyph.x,
+            point.y - positionedGlyph.y,
+            positionedGlyph.glyph.convexHull
+          )
+        ) {
           const foundGlyph = `${i}/${j}`;
-          if (!skipEditingGlyph || !this.selectedGlyphIsEditing || foundGlyph != this.selectedGlyph) {
+          if (
+            !skipEditingGlyph ||
+            !this.selectedGlyphIsEditing ||
+            foundGlyph != this.selectedGlyph
+          ) {
             return foundGlyph;
           }
         }
@@ -389,22 +434,22 @@ export class SceneModel {
       const instance = this.getSelectedStaticGlyphController();
       const boundses = [];
 
-      const {
-        "point": selectedPointIndices,
-        "component": selectedComponentIndices,
-      } = parseSelection(this.selection);
+      const { point: selectedPointIndices, component: selectedComponentIndices } =
+        parseSelection(this.selection);
 
-      selectedPointIndices?.forEach(pointIndex => {
+      selectedPointIndices?.forEach((pointIndex) => {
         const pt = instance.path.getPoint(pointIndex);
         boundses.push(offsetRect(centeredRect(pt.x, pt.y, 0, 0), x, y));
       });
 
-      selectedComponentIndices?.forEach(componentIndex => {
-        boundses.push(offsetRect(instance.components[componentIndex].controlBounds, x, y));
+      selectedComponentIndices?.forEach((componentIndex) => {
+        boundses.push(
+          offsetRect(instance.components[componentIndex].controlBounds, x, y)
+        );
       });
 
       if (boundses.length) {
-        bounds = unionRect(...boundses)
+        bounds = unionRect(...boundses);
       }
     }
     if (!bounds) {
@@ -416,9 +461,7 @@ export class SceneModel {
     }
     return bounds;
   }
-
 }
-
 
 function getAxisInfoFromGlyph(glyph) {
   const axisInfo = {};
@@ -427,11 +470,10 @@ function getAxisInfoFromGlyph(glyph) {
     if (axisInfo[baseName]) {
       continue;
     }
-    axisInfo[baseName] = {...axis, "name": baseName};
+    axisInfo[baseName] = { ...axis, name: baseName };
   }
   return Object.values(axisInfo);
 }
-
 
 function mergeAxisInfo(axisInfos) {
   // This returns a list of axes that is a superset of all the axis
@@ -439,44 +481,60 @@ function mergeAxisInfo(axisInfos) {
   if (!axisInfos.length) {
     return [];
   }
-  const mergedAxisInfo = {...axisInfos[0]};
+  const mergedAxisInfo = { ...axisInfos[0] };
   for (let i = 1; i < axisInfos.length; i++) {
     for (const axisInfo of Object.values(axisInfos[i])) {
       if (mergedAxisInfo[axisInfo.name] !== undefined) {
-        mergedAxisInfo[axisInfo.name].minValue = Math.min(mergedAxisInfo[axisInfo.name].minValue, axisInfo.minValue);
-        mergedAxisInfo[axisInfo.name].maxValue = Math.max(mergedAxisInfo[axisInfo.name].maxValue, axisInfo.maxValue);
+        mergedAxisInfo[axisInfo.name].minValue = Math.min(
+          mergedAxisInfo[axisInfo.name].minValue,
+          axisInfo.minValue
+        );
+        mergedAxisInfo[axisInfo.name].maxValue = Math.max(
+          mergedAxisInfo[axisInfo.name].maxValue,
+          axisInfo.maxValue
+        );
       } else {
-        mergedAxisInfo[axisInfo.name] = {...axisInfo};
+        mergedAxisInfo[axisInfo.name] = { ...axisInfo };
       }
     }
   }
   return Object.values(mergedAxisInfo);
 }
 
-
-async function buildScene(fontController, glyphLines, globalLocation, localLocations, align = "center") {
+async function buildScene(
+  fontController,
+  glyphLines,
+  globalLocation,
+  localLocations,
+  align = "center"
+) {
   let y = 0;
-  const lineDistance = 1.1 * fontController.unitsPerEm;  // TODO make factor user-configurable
+  const lineDistance = 1.1 * fontController.unitsPerEm; // TODO make factor user-configurable
   const positionedLines = [];
   let longestLineLength = 0;
   for (const glyphLine of glyphLines) {
-    const positionedLine = {"glyphs": []};
+    const positionedLine = { glyphs: [] };
     let x = 0;
     for (const glyphInfo of glyphLine) {
-      const location = {...localLocations[glyphInfo.glyphName], ...globalLocation}
-      let glyphInstance = await fontController.getGlyphInstance(glyphInfo.glyphName, location);
+      const location = { ...localLocations[glyphInfo.glyphName], ...globalLocation };
+      let glyphInstance = await fontController.getGlyphInstance(
+        glyphInfo.glyphName,
+        location
+      );
       const isUndefined = !glyphInstance;
       if (isUndefined) {
-        glyphInstance = fontController.getDummyGlyphInstanceController(glyphInfo.glyphName);
+        glyphInstance = fontController.getDummyGlyphInstanceController(
+          glyphInfo.glyphName
+        );
       }
       positionedLine.glyphs.push({
-        "x": x,
-        "y": y,
-        "glyph": glyphInstance,
-        "glyphName": glyphInfo.glyphName,
-        "character": glyphInfo.character,
-        "isUndefined": isUndefined,
-      })
+        x: x,
+        y: y,
+        glyph: glyphInstance,
+        glyphName: glyphInfo.glyphName,
+        character: glyphInfo.character,
+        isUndefined: isUndefined,
+      });
       x += glyphInstance.xAdvance;
     }
 
@@ -489,18 +547,18 @@ async function buildScene(fontController, glyphLines, globalLocation, localLocat
       offset = -x;
     }
     if (offset) {
-      positionedLine.glyphs.forEach(item => {
+      positionedLine.glyphs.forEach((item) => {
         item.x += offset;
       });
     }
 
     // Add bounding boxes
-    positionedLine.glyphs.forEach(item => {
+    positionedLine.glyphs.forEach((item) => {
       let bounds = item.glyph.controlBounds;
       if (!bounds || isEmptyRect(bounds)) {
         // Empty glyph, make up box based on advance so it can still be clickable/hoverable
         // TODO: use font's ascender/descender values
-        bounds = {"xMin": 0, "yMin": -200, "xMax": item.glyph.xAdvance, "yMax": 800};
+        bounds = { xMin: 0, yMin: -200, xMax: item.glyph.xAdvance, yMax: 800 };
         item.isEmpty = true;
       }
       item.bounds = offsetRect(bounds, item.x, item.y);
@@ -509,7 +567,7 @@ async function buildScene(fontController, glyphLines, globalLocation, localLocat
     y -= lineDistance;
     if (positionedLine.glyphs.length) {
       positionedLine.bounds = unionRect(
-        ...positionedLine.glyphs.map(glyph => glyph.bounds)
+        ...positionedLine.glyphs.map((glyph) => glyph.bounds)
       );
       positionedLines.push(positionedLine);
     }
@@ -517,23 +575,21 @@ async function buildScene(fontController, glyphLines, globalLocation, localLocat
   return [positionedLines, longestLineLength];
 }
 
-
 function getUsedGlyphNames(fontController, positionedLines) {
   const usedGlyphNames = new Set();
   for (const line of positionedLines) {
     for (const glyph of line.glyphs) {
       usedGlyphNames.add(glyph.glyph.name);
-      updateSet(usedGlyphNames, fontController.iterGlyphMadeOf(glyph.glyph.name))
+      updateSet(usedGlyphNames, fontController.iterGlyphMadeOf(glyph.glyph.name));
     }
   }
   return usedGlyphNames;
 }
-
 
 function makeGlyphNamesPattern(glyphNames) {
   const glyphsObj = {};
   for (const glyphName of glyphNames) {
     glyphsObj[glyphName] = null;
   }
-  return {"glyphs": glyphsObj};
+  return { glyphs: glyphsObj };
 }

--- a/test-js/test-change-recorder.js
+++ b/test-js/test-change-recorder.js
@@ -7,162 +7,201 @@ import { recordChanges } from "../src/fontra/client/core/change-recorder.js";
 import { enumerate } from "../src/fontra/client/core/utils.js";
 import { VarPackedPath } from "../src/fontra/client/core/var-path.js";
 
-
 const testData = [
   {
-    "testName": "object set",
-    "subject": {"a": 12},
-    "operation": subject => {
+    testName: "object set",
+    subject: { a: 12 },
+    operation: (subject) => {
       subject.a = 13;
     },
-    "expectedSubject": {"a": 13},
-    "expectedChange": {"f": "=", "a": ["a", 13]},
-    "expectedRollbackChange": {"f": "=", "a": ["a", 12]},
+    expectedSubject: { a: 13 },
+    expectedChange: { f: "=", a: ["a", 13] },
+    expectedRollbackChange: { f: "=", a: ["a", 12] },
   },
   {
-    "testName": "object delete",
-    "subject": {"a": 12},
-    "operation": subject => {
+    testName: "object delete",
+    subject: { a: 12 },
+    operation: (subject) => {
       delete subject.a;
     },
-    "expectedSubject": {},
-    "expectedChange": {"f": "d", "a": ["a"]},
-    "expectedRollbackChange": {"f": "=", "a": ["a", 12]},
+    expectedSubject: {},
+    expectedChange: { f: "d", a: ["a"] },
+    expectedRollbackChange: { f: "=", a: ["a", 12] },
   },
   {
-    "testName": "object delete error",
-    "subject": {},
-    "operation": subject => {
+    testName: "object delete error",
+    subject: {},
+    operation: (subject) => {
       delete subject.a;
     },
-    "expectedError": "can't delete undefined property",
+    expectedError: "can't delete undefined property",
   },
   {
-    "testName": "array set item",
-    "subject": [12],
-    "operation": subject => {
+    testName: "array set item",
+    subject: [12],
+    operation: (subject) => {
       subject[0] = 13;
     },
-    "expectedSubject": [13],
-    "expectedChange": {"f": "=", "a": [0, 13]},
-    "expectedRollbackChange": {"f": "=", "a": [0, 12]},
+    expectedSubject: [13],
+    expectedChange: { f: "=", a: [0, 13] },
+    expectedRollbackChange: { f: "=", a: [0, 12] },
   },
   {
-    "testName": "array push",
-    "subject": [],
-    "operation": subject => {
+    testName: "array push",
+    subject: [],
+    operation: (subject) => {
       subject.push(100);
     },
-    "expectedSubject": [100],
-    "expectedChange": {"f": "+", "a": [0, 100]},
-    "expectedRollbackChange": {"f": "-", "a": [0, 1]},
+    expectedSubject: [100],
+    expectedChange: { f: "+", a: [0, 100] },
+    expectedRollbackChange: { f: "-", a: [0, 1] },
   },
   {
-    "testName": "array push multiple",
-    "subject": [],
-    "operation": subject => {
+    testName: "array push multiple",
+    subject: [],
+    operation: (subject) => {
       subject.push(100, 200);
     },
-    "expectedSubject": [100, 200],
-    "expectedChange": {"f": "+", "a": [0, 100, 200]},
-    "expectedRollbackChange": {"f": "-", "a": [0, 2]},
+    expectedSubject: [100, 200],
+    expectedChange: { f: "+", a: [0, 100, 200] },
+    expectedRollbackChange: { f: "-", a: [0, 2] },
   },
   {
-    "testName": "array splice",
-    "subject": [5, 6, 7, 8],
-    "operation": subject => {
+    testName: "array splice",
+    subject: [5, 6, 7, 8],
+    operation: (subject) => {
       subject.splice(1, 2, 999);
     },
-    "expectedSubject": [5, 999, 8],
-    "expectedChange": {"f": ":", "a": [1, 2, 999]},
-    "expectedRollbackChange": {"f": ":", "a": [1, 1, 6, 7]},
+    expectedSubject: [5, 999, 8],
+    expectedChange: { f: ":", a: [1, 2, 999] },
+    expectedRollbackChange: { f: ":", a: [1, 1, 6, 7] },
   },
   {
-    "testName": "nested array set item",
-    "subject": [12, [6, 7, 8], 50],
-    "operation": subject => {
+    testName: "nested array set item",
+    subject: [12, [6, 7, 8], 50],
+    operation: (subject) => {
       subject[1][2] = 88;
     },
-    "expectedSubject": [12, [6, 7, 88], 50],
-    "expectedChange": {"p": [1], "f": "=", "a": [2, 88]},
-    "expectedRollbackChange": {"p": [1], "f": "=", "a": [2, 8]},
+    expectedSubject: [12, [6, 7, 88], 50],
+    expectedChange: { p: [1], f: "=", a: [2, 88] },
+    expectedRollbackChange: { p: [1], f: "=", a: [2, 8] },
   },
   {
-    "testName": "multiple changes",
-    "subject": [12, [6, 7, 8], 50],
-    "operation": subject => {
+    testName: "multiple changes",
+    subject: [12, [6, 7, 8], 50],
+    operation: (subject) => {
       subject.splice(1, 0, 77, 88);
       subject[3].splice(1, 0, -3);
     },
-    "expectedSubject": [12, 77, 88, [6, -3, 7, 8], 50],
-    "expectedChange": {"c": [{"f": ":", "a": [1, 0, 77, 88]}, {"p": [3], "f": ":", "a": [1, 0, -3]}]},
-    "expectedRollbackChange": {"c": [{"p": [3], "f": ":", "a": [1, 1]}, {"f": ":", "a": [1, 2]}]},
+    expectedSubject: [12, 77, 88, [6, -3, 7, 8], 50],
+    expectedChange: {
+      c: [
+        { f: ":", a: [1, 0, 77, 88] },
+        { p: [3], f: ":", a: [1, 0, -3] },
+      ],
+    },
+    expectedRollbackChange: {
+      c: [
+        { p: [3], f: ":", a: [1, 1] },
+        { f: ":", a: [1, 2] },
+      ],
+    },
   },
   {
-    "testName": "path add contour",
-    "subject": new VarPackedPath(),
-    "operation": subject => {
+    testName: "path add contour",
+    subject: new VarPackedPath(),
+    operation: (subject) => {
       subject.insertContour(0, emptyContour());
     },
-    "expectedSubject": VarPackedPath.fromUnpackedContours([{"points": [], "isClosed": false}]),
-    "expectedChange": {"f": "insertContour", "a": [0, {"coordinates": [], "pointTypes": [], "isClosed": false}]},
-    "expectedRollbackChange": {"f": "deleteContour", "a": [0]},
+    expectedSubject: VarPackedPath.fromUnpackedContours([
+      { points: [], isClosed: false },
+    ]),
+    expectedChange: {
+      f: "insertContour",
+      a: [0, { coordinates: [], pointTypes: [], isClosed: false }],
+    },
+    expectedRollbackChange: { f: "deleteContour", a: [0] },
   },
   {
-    "testName": "path delete contour",
-    "subject": VarPackedPath.fromUnpackedContours([{"points": [{"x": 100, "y": 200}], "isClosed": false}]),
-    "operation": subject => {
+    testName: "path delete contour",
+    subject: VarPackedPath.fromUnpackedContours([
+      { points: [{ x: 100, y: 200 }], isClosed: false },
+    ]),
+    operation: (subject) => {
       subject.deleteContour(0);
     },
-    "expectedSubject": new VarPackedPath(),
-    "expectedChange": {"f": "deleteContour", "a": [0]},
-    "expectedRollbackChange": {"f": "insertContour", "a": [0, {"coordinates": [100, 200], "pointTypes": [0], "isClosed": false}]},
+    expectedSubject: new VarPackedPath(),
+    expectedChange: { f: "deleteContour", a: [0] },
+    expectedRollbackChange: {
+      f: "insertContour",
+      a: [0, { coordinates: [100, 200], pointTypes: [0], isClosed: false }],
+    },
   },
   {
-    "testName": "path close contour",
-    "subject": VarPackedPath.fromUnpackedContours([{"points": [{"x": 100, "y": 200}], "isClosed": false}]),
-    "operation": subject => {
+    testName: "path close contour",
+    subject: VarPackedPath.fromUnpackedContours([
+      { points: [{ x: 100, y: 200 }], isClosed: false },
+    ]),
+    operation: (subject) => {
       subject.contourInfo[0].isClosed = true;
     },
-    "expectedSubject": VarPackedPath.fromUnpackedContours([{"points": [{"x": 100, "y": 200}], "isClosed": true}]),
-    "expectedChange": {"p": ["contourInfo", 0], "f": "=", "a": ["isClosed", true]},
-    "expectedRollbackChange": {"p": ["contourInfo", 0], "f": "=", "a": ["isClosed", false]},
+    expectedSubject: VarPackedPath.fromUnpackedContours([
+      { points: [{ x: 100, y: 200 }], isClosed: true },
+    ]),
+    expectedChange: { p: ["contourInfo", 0], f: "=", a: ["isClosed", true] },
+    expectedRollbackChange: { p: ["contourInfo", 0], f: "=", a: ["isClosed", false] },
   },
   {
-    "testName": "path insert point",
-    "subject": VarPackedPath.fromUnpackedContours([{"points": [{"x": 100, "y": 200}], "isClosed": false}]),
-    "operation": subject => {
-      subject.insertPoint(0, 1, {"x": 4, "y": 5});
+    testName: "path insert point",
+    subject: VarPackedPath.fromUnpackedContours([
+      { points: [{ x: 100, y: 200 }], isClosed: false },
+    ]),
+    operation: (subject) => {
+      subject.insertPoint(0, 1, { x: 4, y: 5 });
     },
-    "expectedSubject": VarPackedPath.fromUnpackedContours([{"points": [{"x": 100, "y": 200}, {"x": 4, "y": 5}], "isClosed": false}]),
-    "expectedChange": {"f": "insertPoint", "a": [0, 1, {"x": 4, "y": 5}]},
-    "expectedRollbackChange": {"f": "deletePoint", "a": [0, 1]},
+    expectedSubject: VarPackedPath.fromUnpackedContours([
+      {
+        points: [
+          { x: 100, y: 200 },
+          { x: 4, y: 5 },
+        ],
+        isClosed: false,
+      },
+    ]),
+    expectedChange: { f: "insertPoint", a: [0, 1, { x: 4, y: 5 }] },
+    expectedRollbackChange: { f: "deletePoint", a: [0, 1] },
   },
   {
-    "testName": "path delete point",
-    "subject": VarPackedPath.fromUnpackedContours([{"points": [{"x": 100, "y": 200}], "isClosed": false}]),
-    "operation": subject => {
+    testName: "path delete point",
+    subject: VarPackedPath.fromUnpackedContours([
+      { points: [{ x: 100, y: 200 }], isClosed: false },
+    ]),
+    operation: (subject) => {
       subject.deletePoint(0, 0);
     },
-    "expectedSubject": VarPackedPath.fromUnpackedContours([{"points": [], "isClosed": false}]),
-    "expectedChange": {"f": "deletePoint", "a": [0, 0]},
-    "expectedRollbackChange": {"f": "insertPoint", "a": [0, 0, {"x": 100, "y": 200}]},
+    expectedSubject: VarPackedPath.fromUnpackedContours([
+      { points: [], isClosed: false },
+    ]),
+    expectedChange: { f: "deletePoint", a: [0, 0] },
+    expectedRollbackChange: { f: "insertPoint", a: [0, 0, { x: 100, y: 200 }] },
   },
   {
-    "testName": "path set point position",
-    "subject": VarPackedPath.fromUnpackedContours([{"points": [{"x": 100, "y": 200}], "isClosed": false}]),
-    "operation": subject => {
+    testName: "path set point position",
+    subject: VarPackedPath.fromUnpackedContours([
+      { points: [{ x: 100, y: 200 }], isClosed: false },
+    ]),
+    operation: (subject) => {
       subject.setPointPosition(0, 101, 201);
     },
-    "expectedSubject": VarPackedPath.fromUnpackedContours([{"points": [{"x": 101, "y": 201}], "isClosed": false}]),
-    "expectedChange": {"f": "=xy", "a": [0, 101, 201]},
-    "expectedRollbackChange": {"f": "=xy", "a": [0, 100, 200]},
+    expectedSubject: VarPackedPath.fromUnpackedContours([
+      { points: [{ x: 101, y: 201 }], isClosed: false },
+    ]),
+    expectedChange: { f: "=xy", a: [0, 101, 201] },
+    expectedRollbackChange: { f: "=xy", a: [0, 100, 200] },
   },
 ];
 
-
 describe("recordChanges tests", () => {
-
   for (const [index, testCase] of enumerate(testData)) {
     it(`${testCase.testName} #${index}`, () => {
       const subject = copyObject(testCase.subject);
@@ -189,9 +228,7 @@ describe("recordChanges tests", () => {
       }
     });
   }
-
 });
-
 
 function copyObject(obj) {
   if (obj.copy !== undefined) {
@@ -200,7 +237,6 @@ function copyObject(obj) {
   return JSON.parse(JSON.stringify(obj));
 }
 
-
 function emptyContour() {
-  return {"coordinates": [], "pointTypes": [], "isClosed": false};
+  return { coordinates: [], pointTypes: [], isClosed: false };
 }

--- a/test-js/test-changes.js
+++ b/test-js/test-changes.js
@@ -12,21 +12,17 @@ import {
   matchChangePattern,
 } from "../src/fontra/client/core/changes.js";
 
-
-import { fileURLToPath } from 'url';
-import { dirname, join } from 'path';
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
-
 
 function getTestData(fileName) {
   const path = join(dirname(__dirname), "test-common", fileName);
   return JSON.parse(fs.readFileSync(path, "utf8"));
 }
 
-
 describe("applyChange Tests", () => {
-
   const test_data = getTestData("apply-change-test-data.json");
   const inputData = test_data["inputData"];
   const tests = test_data["tests"];
@@ -43,12 +39,9 @@ describe("applyChange Tests", () => {
       expect(subject).to.deep.equal(expectedData);
     });
   }
-
 });
 
-
 describe("matchChangePattern Tests", () => {
-
   const tests = getTestData("match-change-pattern-test-data.json");
 
   for (let i = 0; i < tests.length; i++) {
@@ -59,23 +52,20 @@ describe("matchChangePattern Tests", () => {
       expect(result).to.equal(expectedResult);
     });
   }
-
 });
 
-
 describe("matchChangePath Tests", () => {
-
   const tests = [
     [{}, [], false],
-    [{"p": ["A"]}, ["A"], true],
-    [{"p": ["A"]}, ["A", "B"], false],
-    [{"p": ["A", "B"]}, ["A"], true],
-    [{"p": ["A", "B"]}, ["A", "B"], true],
-    [{"p": ["A"]}, ["B"], false],
-    [{"c": [{"p": ["A"]}]}, ["A"], true],
-    [{"p": ["A"], "c": [{"p": ["B"]}]}, ["A", "B"], true],
-    [{"p": ["A"], "c": [{"p": ["B"]}]}, ["A", "C"], false],
-    [{"p": ["A"], "c": [{"p": ["B"]}]}, ["B", "B"], false],
+    [{ p: ["A"] }, ["A"], true],
+    [{ p: ["A"] }, ["A", "B"], false],
+    [{ p: ["A", "B"] }, ["A"], true],
+    [{ p: ["A", "B"] }, ["A", "B"], true],
+    [{ p: ["A"] }, ["B"], false],
+    [{ c: [{ p: ["A"] }] }, ["A"], true],
+    [{ p: ["A"], c: [{ p: ["B"] }] }, ["A", "B"], true],
+    [{ p: ["A"], c: [{ p: ["B"] }] }, ["A", "C"], false],
+    [{ p: ["A"], c: [{ p: ["B"] }] }, ["B", "B"], false],
   ];
 
   for (let i = 0; i < tests.length; i++) {
@@ -86,12 +76,9 @@ describe("matchChangePath Tests", () => {
       expect(result).to.equal(expectedResult);
     });
   }
-
 });
 
-
 describe("filterChangePattern Tests", () => {
-
   const tests = getTestData("filter-change-pattern-test-data.json");
 
   for (let i = 0; i < tests.length; i++) {
@@ -102,12 +89,9 @@ describe("filterChangePattern Tests", () => {
       expect(result).to.deep.equal(expectedResult);
     });
   }
-
 });
 
-
 describe("collectChangePaths Tests", () => {
-
   const tests = getTestData("collect-change-paths-test-data.json");
 
   for (let i = 0; i < tests.length; i++) {
@@ -118,172 +102,229 @@ describe("collectChangePaths Tests", () => {
       expect(paths).to.deep.equal(expectedPaths);
     });
   }
-
 });
-
 
 const consolidateChangesTestCases = [
   {
-    "testName": "no-op",
-    "changes": {"f": "=", "a": [0, 0]},
-    "prefixPath": undefined,
-    "consolidated": {"f": "=", "a": [0, 0]},
+    testName: "no-op",
+    changes: { f: "=", a: [0, 0] },
+    prefixPath: undefined,
+    consolidated: { f: "=", a: [0, 0] },
   },
   {
-    "testName": "no-op + empty p",
-    "changes": {"p": [], "f": "=", "a": [0, 0]},
-    "prefixPath": undefined,
-    "consolidated": {"f": "=", "a": [0, 0]},
+    testName: "no-op + empty p",
+    changes: { p: [], f: "=", a: [0, 0] },
+    prefixPath: undefined,
+    consolidated: { f: "=", a: [0, 0] },
   },
   {
-    "testName": "no-op + prefix",
-    "changes": {"f": "=", "a": [0, 0]},
-    "prefixPath": ["element"],
-    "consolidated": {"p": ["element"], "f": "=", "a": [0, 0]},
+    testName: "no-op + prefix",
+    changes: { f: "=", a: [0, 0] },
+    prefixPath: ["element"],
+    consolidated: { p: ["element"], f: "=", a: [0, 0] },
   },
   {
-    "testName": "prefix + p",
-    "changes": {"p": ["sub"], "f": "=", "a": [0, 0]},
-    "prefixPath": ["element"],
-    "consolidated": {"p": ["element", "sub"], "f": "=", "a": [0, 0]},
+    testName: "prefix + p",
+    changes: { p: ["sub"], f: "=", a: [0, 0] },
+    prefixPath: ["element"],
+    consolidated: { p: ["element", "sub"], f: "=", a: [0, 0] },
   },
   {
-    "testName": "single change",
-    "changes": [{"f": "=", "a": [0, 0]}],
-    "prefixPath": undefined,
-    "consolidated": {"f": "=", "a": [0, 0]},
+    testName: "single change",
+    changes: [{ f: "=", a: [0, 0] }],
+    prefixPath: undefined,
+    consolidated: { f: "=", a: [0, 0] },
   },
   {
-    "testName": "single change + prefix",
-    "changes": [{"f": "=", "a": [0, 0]}],
-    "prefixPath": ["element"],
-    "consolidated": {"p": ["element"], "f": "=", "a": [0, 0]},
+    testName: "single change + prefix",
+    changes: [{ f: "=", a: [0, 0] }],
+    prefixPath: ["element"],
+    consolidated: { p: ["element"], f: "=", a: [0, 0] },
   },
   {
-    "testName": "two changes",
-    "changes": [{"f": "=", "a": [0, 0]}, {"f": "=", "a": [1, 2]}],
-    "prefixPath": undefined,
-    "consolidated": {"c": [{"f": "=", "a": [0, 0]}, {"f": "=", "a": [1, 2]}]},
+    testName: "two changes",
+    changes: [
+      { f: "=", a: [0, 0] },
+      { f: "=", a: [1, 2] },
+    ],
+    prefixPath: undefined,
+    consolidated: {
+      c: [
+        { f: "=", a: [0, 0] },
+        { f: "=", a: [1, 2] },
+      ],
+    },
   },
   {
-    "testName": "two changes + empty p",
-    "changes": [{"p": [], "f": "=", "a": [0, 0]}, {"f": "=", "a": [1, 2]}],
-    "prefixPath": undefined,
-    "consolidated": {"c": [{"f": "=", "a": [0, 0]}, {"f": "=", "a": [1, 2]}]},
+    testName: "two changes + empty p",
+    changes: [
+      { p: [], f: "=", a: [0, 0] },
+      { f: "=", a: [1, 2] },
+    ],
+    prefixPath: undefined,
+    consolidated: {
+      c: [
+        { f: "=", a: [0, 0] },
+        { f: "=", a: [1, 2] },
+      ],
+    },
   },
   {
-    "testName": "two changes + prefix",
-    "changes": [{"f": "=", "a": [0, 0]}, {"f": "=", "a": [1, 2]}],
-    "prefixPath": ["element"],
-    "consolidated": {"p": ["element"], "c": [{"f": "=", "a": [0, 0]}, {"f": "=", "a": [1, 2]}]},
+    testName: "two changes + prefix",
+    changes: [
+      { f: "=", a: [0, 0] },
+      { f: "=", a: [1, 2] },
+    ],
+    prefixPath: ["element"],
+    consolidated: {
+      p: ["element"],
+      c: [
+        { f: "=", a: [0, 0] },
+        { f: "=", a: [1, 2] },
+      ],
+    },
   },
   {
-    "testName": "two changes + prefix + different p 1",
-    "changes": [{"f": "=", "a": [0, 0]}, {"p": ["sub2"], "f": "=", "a": [1, 2]}],
-    "prefixPath": ["element"],
-    "consolidated": {"p": ["element"], "c": [
-      {"f": "=", "a": [0, 0]},
-      {"p": ["sub2"], "f": "=", "a": [1, 2]},
-    ]},
+    testName: "two changes + prefix + different p 1",
+    changes: [
+      { f: "=", a: [0, 0] },
+      { p: ["sub2"], f: "=", a: [1, 2] },
+    ],
+    prefixPath: ["element"],
+    consolidated: {
+      p: ["element"],
+      c: [
+        { f: "=", a: [0, 0] },
+        { p: ["sub2"], f: "=", a: [1, 2] },
+      ],
+    },
   },
   {
-    "testName": "two changes + prefix + different p 1.1; delete empty p",
-    "changes": [{"p": [], "f": "=", "a": [0, 0]}, {"p": ["sub2"], "f": "=", "a": [1, 2]}],
-    "prefixPath": ["element"],
-    "consolidated": {"p": ["element"], "c": [
-      {"f": "=", "a": [0, 0]},
-      {"p": ["sub2"], "f": "=", "a": [1, 2]},
-    ]},
+    testName: "two changes + prefix + different p 1.1; delete empty p",
+    changes: [
+      { p: [], f: "=", a: [0, 0] },
+      { p: ["sub2"], f: "=", a: [1, 2] },
+    ],
+    prefixPath: ["element"],
+    consolidated: {
+      p: ["element"],
+      c: [
+        { f: "=", a: [0, 0] },
+        { p: ["sub2"], f: "=", a: [1, 2] },
+      ],
+    },
   },
   {
-    "testName": "two changes + prefix + different p 2",
-    "changes": [{"p": ["sub1"], "f": "=", "a": [0, 0]}, {"p": ["sub2"], "f": "=", "a": [1, 2]}],
-    "prefixPath": ["element"],
-    "consolidated": {"p": ["element"], "c": [
-      {"p": ["sub1"], "f": "=", "a": [0, 0]},
-      {"p": ["sub2"], "f": "=", "a": [1, 2]},
-    ]},
+    testName: "two changes + prefix + different p 2",
+    changes: [
+      { p: ["sub1"], f: "=", a: [0, 0] },
+      { p: ["sub2"], f: "=", a: [1, 2] },
+    ],
+    prefixPath: ["element"],
+    consolidated: {
+      p: ["element"],
+      c: [
+        { p: ["sub1"], f: "=", a: [0, 0] },
+        { p: ["sub2"], f: "=", a: [1, 2] },
+      ],
+    },
   },
   {
-    "testName": "two changes + prefix + same p",
-    "changes": [{"p": ["sub"], "f": "=", "a": [0, 0]}, {"p": ["sub"], "f": "=", "a": [1, 2]}],
-    "prefixPath": ["element"],
-    "consolidated": {"p": ["element", "sub"], "c": [
-      {"f": "=", "a": [0, 0]},
-      {"f": "=", "a": [1, 2]},
-    ]},
+    testName: "two changes + prefix + same p",
+    changes: [
+      { p: ["sub"], f: "=", a: [0, 0] },
+      { p: ["sub"], f: "=", a: [1, 2] },
+    ],
+    prefixPath: ["element"],
+    consolidated: {
+      p: ["element", "sub"],
+      c: [
+        { f: "=", a: [0, 0] },
+        { f: "=", a: [1, 2] },
+      ],
+    },
   },
   {
-    "testName": "two changes + prefix + same p + extra element",
-    "changes": [{"p": ["sub", "subsub"], "f": "=", "a": [0, 0]}, {"p": ["sub"], "f": "=", "a": [1, 2]}],
-    "prefixPath": ["element"],
-    "consolidated": {"p": ["element", "sub"], "c": [
-      {"p": ["subsub"], "f": "=", "a": [0, 0]},
-      {"f": "=", "a": [1, 2]},
-    ]},
+    testName: "two changes + prefix + same p + extra element",
+    changes: [
+      { p: ["sub", "subsub"], f: "=", a: [0, 0] },
+      { p: ["sub"], f: "=", a: [1, 2] },
+    ],
+    prefixPath: ["element"],
+    consolidated: {
+      p: ["element", "sub"],
+      c: [
+        { p: ["subsub"], f: "=", a: [0, 0] },
+        { f: "=", a: [1, 2] },
+      ],
+    },
   },
   {
-    "testName": "unnest single child",
-    "changes": {"c": [{"f": "=", "a": [0, 0]}]},
-    "prefixPath": undefined,
-    "consolidated": {"f": "=", "a": [0, 0]},
+    testName: "unnest single child",
+    changes: { c: [{ f: "=", a: [0, 0] }] },
+    prefixPath: undefined,
+    consolidated: { f: "=", a: [0, 0] },
   },
   {
-    "testName": "deep unnest single child",
-    "changes": {"c": [{"c": [{"f": "=", "a": [0, 0]}]}]},
-    "prefixPath": undefined,
-    "consolidated": {"f": "=", "a": [0, 0]},
+    testName: "deep unnest single child",
+    changes: { c: [{ c: [{ f: "=", a: [0, 0] }] }] },
+    prefixPath: undefined,
+    consolidated: { f: "=", a: [0, 0] },
   },
   {
-    "testName": "deep unnest single child of multiple children",
-    "changes": {"c": [{"c": [{"f": "=", "a": [0, 0]}]}, {"f": "=", "a": [1, 2]}]},
-    "prefixPath": undefined,
-    "consolidated": {"c": [{"f": "=", "a": [0, 0]}, {"f": "=", "a": [1, 2]}]},
+    testName: "deep unnest single child of multiple children",
+    changes: { c: [{ c: [{ f: "=", a: [0, 0] }] }, { f: "=", a: [1, 2] }] },
+    prefixPath: undefined,
+    consolidated: {
+      c: [
+        { f: "=", a: [0, 0] },
+        { f: "=", a: [1, 2] },
+      ],
+    },
   },
   {
-    "testName": "empty change list",
-    "changes": [],
-    "prefixPath": undefined,
-    "consolidated": {},
+    testName: "empty change list",
+    changes: [],
+    prefixPath: undefined,
+    consolidated: {},
   },
   {
-    "testName": "empty change",
-    "changes": {},
-    "prefixPath": undefined,
-    "consolidated": {},
+    testName: "empty change",
+    changes: {},
+    prefixPath: undefined,
+    consolidated: {},
   },
   {
-    "testName": "no-op change with path",
-    "changes": {"p": ["item"]},
-    "prefixPath": undefined,
-    "consolidated": {},
+    testName: "no-op change with path",
+    changes: { p: ["item"] },
+    prefixPath: undefined,
+    consolidated: {},
   },
   {
-    "testName": "no-op changes with path and empty children",
-    "changes": {"p": ["item"], "c": []},
-    "prefixPath": undefined,
-    "consolidated": {},
+    testName: "no-op changes with path and empty children",
+    changes: { p: ["item"], c: [] },
+    prefixPath: undefined,
+    consolidated: {},
   },
   {
-    "testName": "no-op changes with path and no-op children",
-    "changes": {"p": ["item"], "c": [{}, {}]},
-    "prefixPath": undefined,
-    "consolidated": {},
+    testName: "no-op changes with path and no-op children",
+    changes: { p: ["item"], c: [{}, {}] },
+    prefixPath: undefined,
+    consolidated: {},
   },
   {
-    "testName": "nested no-op changes with path",
-    "changes": {"p": ["item"], "c": [{"p": ["sub1"]}, {"p": ["sub2"]}]},
-    "prefixPath": undefined,
-    "consolidated": {},
+    testName: "nested no-op changes with path",
+    changes: { p: ["item"], c: [{ p: ["sub1"] }, { p: ["sub2"] }] },
+    prefixPath: undefined,
+    consolidated: {},
   },
   {
-    "testName": "nested no-op changes with path, no root path",
-    "changes": {"c": [{"p": ["sub1"]}, {"p": ["sub2"]}]},
-    "prefixPath": undefined,
-    "consolidated": {},
+    testName: "nested no-op changes with path, no root path",
+    changes: { c: [{ p: ["sub1"] }, { p: ["sub2"] }] },
+    prefixPath: undefined,
+    consolidated: {},
   },
 ];
-
 
 describe("consolidateChanges tests", () => {
   for (let i = 0; i < consolidateChangesTestCases.length; i++) {
@@ -295,9 +336,7 @@ describe("consolidateChanges tests", () => {
   }
 });
 
-
 describe("ChangeCollector tests", () => {
-
   it("ChangeCollector basic", () => {
     const coll = new ChangeCollector();
     expect(coll.hasChange).to.equal(false);
@@ -306,16 +345,26 @@ describe("ChangeCollector tests", () => {
     expect(coll.rollbackChange).to.deep.equal({});
 
     coll.addChange("=", 1);
-    expect(coll.change).to.deep.equal({"f": "=", "a": [1]});
+    expect(coll.change).to.deep.equal({ f: "=", a: [1] });
 
     coll.addChange("+", 2, 3);
-    expect(coll.change).to.deep.equal({"c": [{"f": "=", "a": [1]}, {"f": "+", "a": [2, 3]}]});
+    expect(coll.change).to.deep.equal({
+      c: [
+        { f: "=", a: [1] },
+        { f: "+", a: [2, 3] },
+      ],
+    });
 
     coll.addRollbackChange("+", 2);
-    expect(coll.rollbackChange).to.deep.equal({"f": "+", "a": [2]});
+    expect(coll.rollbackChange).to.deep.equal({ f: "+", a: [2] });
 
     coll.addRollbackChange(".", 3, 4);
-    expect(coll.rollbackChange).to.deep.equal({"c": [{"f": ".", "a": [3, 4]}, {"f": "+", "a": [2]}]});
+    expect(coll.rollbackChange).to.deep.equal({
+      c: [
+        { f: ".", a: [3, 4] },
+        { f: "+", a: [2] },
+      ],
+    });
   });
 
   it("ChangeCollector sub", () => {
@@ -323,22 +372,40 @@ describe("ChangeCollector tests", () => {
     const sub1 = coll.subCollector("item");
     expect(coll.change).to.deep.equal({});
     sub1.addChange("=", 1);
-    expect(coll.change).to.deep.equal({"p": ["item"], "f": "=", "a": [1]});
+    expect(coll.change).to.deep.equal({ p: ["item"], f: "=", a: [1] });
     sub1.addChange("+", 2);
-    expect(coll.change).to.deep.equal({"p": ["item"], c: [{"f": "=", "a": [1]}, {"f": "+", "a": [2]}]});
+    expect(coll.change).to.deep.equal({
+      p: ["item"],
+      c: [
+        { f: "=", a: [1] },
+        { f: "+", a: [2] },
+      ],
+    });
     const sub2 = coll.subCollector("item");
     sub2.addChange("+", 5);
-    expect(coll.change).to.deep.equal(
-      {"p": ["item"], c: [{"f": "=", "a": [1]}, {"f": "+", "a": [2]}, {"f": "+", "a": [5]}]}
-    );
+    expect(coll.change).to.deep.equal({
+      p: ["item"],
+      c: [
+        { f: "=", a: [1] },
+        { f: "+", a: [2] },
+        { f: "+", a: [5] },
+      ],
+    });
     const sub3 = coll.subCollector("sub");
     sub3.addChange("-", 6);
-    expect(coll.change).to.deep.equal(
-      {"c": [
-        {"p": ["item"], c: [{"f": "=", "a": [1]}, {"f": "+", "a": [2]}, {"f": "+", "a": [5]}]},
-        {"p": ["sub"], "f": "-", "a": [6]},
-      ]},
-    );
+    expect(coll.change).to.deep.equal({
+      c: [
+        {
+          p: ["item"],
+          c: [
+            { f: "=", a: [1] },
+            { f: "+", a: [2] },
+            { f: "+", a: [5] },
+          ],
+        },
+        { p: ["sub"], f: "-", a: [6] },
+      ],
+    });
   });
 
   it("ChangeCollector sub rollback", () => {
@@ -346,22 +413,40 @@ describe("ChangeCollector tests", () => {
     const sub1 = coll.subCollector("item");
     expect(coll.rollbackChange).to.deep.equal({});
     sub1.addRollbackChange("=", 1);
-    expect(coll.rollbackChange).to.deep.equal({"p": ["item"], "f": "=", "a": [1]});
+    expect(coll.rollbackChange).to.deep.equal({ p: ["item"], f: "=", a: [1] });
     sub1.addRollbackChange("+", 2);
-    expect(coll.rollbackChange).to.deep.equal({"p": ["item"], c: [{"f": "+", "a": [2]}, {"f": "=", "a": [1]}]});
+    expect(coll.rollbackChange).to.deep.equal({
+      p: ["item"],
+      c: [
+        { f: "+", a: [2] },
+        { f: "=", a: [1] },
+      ],
+    });
     const sub2 = coll.subCollector("item");
     sub2.addRollbackChange("+", 5);
-    expect(coll.rollbackChange).to.deep.equal(
-      {"p": ["item"], c: [{"f": "+", "a": [5]}, {"f": "+", "a": [2]}, {"f": "=", "a": [1]}]}
-    );
+    expect(coll.rollbackChange).to.deep.equal({
+      p: ["item"],
+      c: [
+        { f: "+", a: [5] },
+        { f: "+", a: [2] },
+        { f: "=", a: [1] },
+      ],
+    });
     const sub3 = coll.subCollector("sub");
     sub3.addRollbackChange("-", 6);
-    expect(coll.rollbackChange).to.deep.equal(
-      {"c": [
-        {"p": ["sub"], "f": "-", "a": [6]},
-        {"p": ["item"], c: [{"f": "+", "a": [5]}, {"f": "+", "a": [2]}, {"f": "=", "a": [1]}]},
-      ]},
-    );
+    expect(coll.rollbackChange).to.deep.equal({
+      c: [
+        { p: ["sub"], f: "-", a: [6] },
+        {
+          p: ["item"],
+          c: [
+            { f: "+", a: [5] },
+            { f: "+", a: [2] },
+            { f: "=", a: [1] },
+          ],
+        },
+      ],
+    });
   });
 
   it("ChangeCollector concat", () => {
@@ -375,18 +460,38 @@ describe("ChangeCollector tests", () => {
     coll2.addChange("-", 3);
     coll2.addRollbackChange("-", 4);
     const coll4 = coll1.concat(coll2);
-    expect(coll4.change).to.deep.equal({"c": [{"f": "+", "a": [1]}, {"f": "-", "a": [3]}]});
-    expect(coll4.rollbackChange).to.deep.equal({"c": [{"f": "-", "a": [4]}, {"f": "+", "a": [2]}]});
+    expect(coll4.change).to.deep.equal({
+      c: [
+        { f: "+", a: [1] },
+        { f: "-", a: [3] },
+      ],
+    });
+    expect(coll4.rollbackChange).to.deep.equal({
+      c: [
+        { f: "-", a: [4] },
+        { f: "+", a: [2] },
+      ],
+    });
     const coll5 = new ChangeCollector();
     coll5.addChange(":", 5);
     coll5.addRollbackChange(":", 6);
     const coll6 = coll1.concat(coll2, coll5);
-    expect(coll6.change).to.deep.equal({"c": [{"f": "+", "a": [1]}, {"f": "-", "a": [3]}, {"f": ":", "a": [5]}]});
-    expect(coll6.rollbackChange).to.deep.equal({"c": [{"f": ":", "a": [6]}, {"f": "-", "a": [4]}, {"f": "+", "a": [2]}]});
+    expect(coll6.change).to.deep.equal({
+      c: [
+        { f: "+", a: [1] },
+        { f: "-", a: [3] },
+        { f: ":", a: [5] },
+      ],
+    });
+    expect(coll6.rollbackChange).to.deep.equal({
+      c: [
+        { f: ":", a: [6] },
+        { f: "-", a: [4] },
+        { f: "+", a: [2] },
+      ],
+    });
   });
-
-})
-
+});
 
 function copyObject(obj) {
   return JSON.parse(JSON.stringify(obj));

--- a/test-js/test-cmap.js
+++ b/test-js/test-cmap.js
@@ -9,37 +9,46 @@ import {
 } from "../src/fontra/client/core/cmap.js";
 import { enumerate } from "../src/fontra/client/core/utils.js";
 
-
 describe("characterMap tests", () => {
-
   const makeGlyphMapFromCharacterMap_testData = [
     [{}, {}],
-    [{1: "one"}, {"one": [1]}],
-    [{1: "one", 2: "two"}, {"one": [1], "two": [2]}],
-    [{1: "double", 2: "double"}, {"double": [1, 2]}],
-    [{2: "double", 1: "double"}, {"double": [1, 2]}],
+    [{ 1: "one" }, { one: [1] }],
+    [
+      { 1: "one", 2: "two" },
+      { one: [1], two: [2] },
+    ],
+    [{ 1: "double", 2: "double" }, { double: [1, 2] }],
+    [{ 2: "double", 1: "double" }, { double: [1, 2] }],
   ];
 
-  for (const [i, [characterMap, expectedGlyphMap]] of enumerate(makeGlyphMapFromCharacterMap_testData)) {
+  for (const [i, [characterMap, expectedGlyphMap]] of enumerate(
+    makeGlyphMapFromCharacterMap_testData
+  )) {
     it(`makeGlyphMapFromCharacterMap test ${i}`, () => {
-      expect(makeGlyphMapFromCharacterMap(characterMap)).to.deep.equal(expectedGlyphMap);
+      expect(makeGlyphMapFromCharacterMap(characterMap)).to.deep.equal(
+        expectedGlyphMap
+      );
     });
   }
 
   const makeCharacterMapFromGlyphMap_testData = [
     [{}, {}, true, null],
-    [{"one": [1]}, {1: "one"}, true, null],
-    [{"one": [1], "two": [2]}, {1: "one", 2: "two"}, true, null],
-    [{"double": [1, 2]}, {1: "double", 2: "double"}, true, null],
-    [{"one": [1], "two": [1]}, null, true, "duplicate code point"],
-    [{"one": [1], "two": [1]}, {1: "one"}, false, null],
-    [{"two": [1], "one": [1]}, {1: "one"}, false, null],
+    [{ one: [1] }, { 1: "one" }, true, null],
+    [{ one: [1], two: [2] }, { 1: "one", 2: "two" }, true, null],
+    [{ double: [1, 2] }, { 1: "double", 2: "double" }, true, null],
+    [{ one: [1], two: [1] }, null, true, "duplicate code point"],
+    [{ one: [1], two: [1] }, { 1: "one" }, false, null],
+    [{ two: [1], one: [1] }, { 1: "one" }, false, null],
   ];
 
-  for (const [i, [glyphMap, expectedCharacterMap, strict, error]] of enumerate(makeCharacterMapFromGlyphMap_testData)) {
+  for (const [i, [glyphMap, expectedCharacterMap, strict, error]] of enumerate(
+    makeCharacterMapFromGlyphMap_testData
+  )) {
     it(`makeCharacterMapFromGlyphMap test ${i}`, () => {
       if (!error) {
-        expect(makeCharacterMapFromGlyphMap(glyphMap, strict)).to.deep.equal(expectedCharacterMap);
+        expect(makeCharacterMapFromGlyphMap(glyphMap, strict)).to.deep.equal(
+          expectedCharacterMap
+        );
       } else {
         expect(() => makeCharacterMapFromGlyphMap(glyphMap, strict)).to.throw(error);
       }
@@ -59,39 +68,39 @@ describe("characterMap tests", () => {
     glyphMap["space"] = [32];
     glyphMap["double"] = [33, 34];
 
-    expect(characterMap).to.deep.equal({"32": "space", "33": "double", "34": "double"});
-    expect(glyphMapData).to.deep.equal({"space": [32], "double": [33, 34]});
+    expect(characterMap).to.deep.equal({ 32: "space", 33: "double", 34: "double" });
+    expect(glyphMapData).to.deep.equal({ space: [32], double: [33, 34] });
   });
 
   it("getGlyphMapProxy replace items", () => {
-    const characterMap = {"32": "space", "33": "test"};
+    const characterMap = { 32: "space", 33: "test" };
     const glyphMapData = makeGlyphMapFromCharacterMap(characterMap);
     const glyphMap = getGlyphMapProxy(glyphMapData, characterMap);
 
     glyphMap["space"] = [32, 34];
-    expect(characterMap).to.deep.equal({"32": "space", "33": "test", "34": "space"});
-    expect(glyphMap).to.deep.equal({"space": [32, 34], "test": [33]});
+    expect(characterMap).to.deep.equal({ 32: "space", 33: "test", 34: "space" });
+    expect(glyphMap).to.deep.equal({ space: [32, 34], test: [33] });
   });
 
   it("getGlyphMapProxy replace items with same", () => {
-    const characterMap = {"32": "space", "33": "test"};
+    const characterMap = { 32: "space", 33: "test" };
     const glyphMapData = makeGlyphMapFromCharacterMap(characterMap);
     const glyphMap = getGlyphMapProxy(glyphMapData, characterMap);
 
     glyphMap["space"] = [32];
     glyphMap["test"] = [33];
-    expect(characterMap).to.deep.equal({"32": "space", "33": "test"});
-    expect(glyphMap).to.deep.equal({"space": [32], "test": [33]});
+    expect(characterMap).to.deep.equal({ 32: "space", 33: "test" });
+    expect(glyphMap).to.deep.equal({ space: [32], test: [33] });
   });
 
   it("getGlyphMapProxy delete items", () => {
-    const characterMap = {"32": "space", "33": "test"};
+    const characterMap = { 32: "space", 33: "test" };
     const glyphMapData = makeGlyphMapFromCharacterMap(characterMap);
     const glyphMap = getGlyphMapProxy(glyphMapData, characterMap);
 
     delete glyphMap["space"];
-    expect(characterMap).to.deep.equal({"33": "test"});
-    expect(glyphMap).to.deep.equal({"test": [33]});
+    expect(characterMap).to.deep.equal({ 33: "test" });
+    expect(glyphMap).to.deep.equal({ test: [33] });
 
     delete glyphMap["test"];
     expect(characterMap).to.deep.equal({});
@@ -106,44 +115,48 @@ describe("characterMap tests", () => {
     characterMap[32] = "space";
     characterMap[33] = "double";
     characterMap[34] = "double";
-    expect(characterMapData).to.deep.equal({"32": "space", "33": "double", "34": "double"});
-    expect(glyphMap).to.deep.equal({"space": [32], "double": [33, 34]});
+    expect(characterMapData).to.deep.equal({ 32: "space", 33: "double", 34: "double" });
+    expect(glyphMap).to.deep.equal({ space: [32], double: [33, 34] });
   });
 
   it("getCharacterMapProxy replace items", () => {
-    const characterMapData = {"32": "space", "33": "double", "34": "double"};
+    const characterMapData = { 32: "space", 33: "double", 34: "double" };
     const glyphMap = makeGlyphMapFromCharacterMap(characterMapData);
     const characterMap = getCharacterMapProxy(characterMapData, glyphMap);
 
     characterMap[32] = "spacey";
     characterMap[34] = "doubly";
-    expect(characterMapData).to.deep.equal({"32": "spacey", "33": "double", "34": "doubly"});
-    expect(glyphMap).to.deep.equal({"spacey": [32], "double": [33], "doubly": [34]});
+    expect(characterMapData).to.deep.equal({
+      32: "spacey",
+      33: "double",
+      34: "doubly",
+    });
+    expect(glyphMap).to.deep.equal({ spacey: [32], double: [33], doubly: [34] });
   });
 
   it("getCharacterMapProxy replace items with same", () => {
-    const characterMapData = {"32": "space", "33": "double", "34": "double"};
+    const characterMapData = { 32: "space", 33: "double", 34: "double" };
     const glyphMap = makeGlyphMapFromCharacterMap(characterMapData);
     const characterMap = getCharacterMapProxy(characterMapData, glyphMap);
 
     characterMap[32] = "space";
     characterMap[34] = "double";
-    expect(characterMapData).to.deep.equal({"32": "space", "33": "double", "34": "double"});
-    expect(glyphMap).to.deep.equal({"space": [32], "double": [33, 34]});
+    expect(characterMapData).to.deep.equal({ 32: "space", 33: "double", 34: "double" });
+    expect(glyphMap).to.deep.equal({ space: [32], double: [33, 34] });
   });
 
   it("getCharacterMapProxy delete items", () => {
-    const characterMapData = {"32": "space", "33": "double", "34": "double"};
+    const characterMapData = { 32: "space", 33: "double", 34: "double" };
     const glyphMap = makeGlyphMapFromCharacterMap(characterMapData);
     const characterMap = getCharacterMapProxy(characterMapData, glyphMap);
 
     delete characterMap[32];
-    expect(characterMapData).to.deep.equal({"33": "double", "34": "double"});
-    expect(glyphMap).to.deep.equal({"double": [33, 34]});
+    expect(characterMapData).to.deep.equal({ 33: "double", 34: "double" });
+    expect(glyphMap).to.deep.equal({ double: [33, 34] });
 
     delete characterMap[33];
-    expect(characterMapData).to.deep.equal({"34": "double"});
-    expect(glyphMap).to.deep.equal({"double": [34]});
+    expect(characterMapData).to.deep.equal({ 34: "double" });
+    expect(glyphMap).to.deep.equal({ double: [34] });
 
     delete characterMap[34];
     expect(characterMapData).to.deep.equal({});
@@ -156,12 +169,15 @@ describe("characterMap tests", () => {
     const characterMap = getCharacterMapProxy(characterMapData, glyphMap);
 
     characterMap[35] = "double";
-    expect(glyphMap).to.deep.equal({"double": [35]});
+    expect(glyphMap).to.deep.equal({ double: [35] });
     characterMap[33] = "double";
-    expect(glyphMap).to.deep.equal({"double": [33, 35]});
+    expect(glyphMap).to.deep.equal({ double: [33, 35] });
     characterMap[34] = "double";
-    expect(glyphMap).to.deep.equal({"double": [33, 34, 35]});
-    expect(characterMapData).to.deep.equal({"33": "double", "34": "double", "35": "double"});
+    expect(glyphMap).to.deep.equal({ double: [33, 34, 35] });
+    expect(characterMapData).to.deep.equal({
+      33: "double",
+      34: "double",
+      35: "double",
+    });
   });
-
 });

--- a/test-js/test-lru-cache.js
+++ b/test-js/test-lru-cache.js
@@ -3,9 +3,7 @@ const expect = chai.expect;
 
 import { LRUCache } from "../src/fontra/client/core/lru-cache.js";
 
-
 describe("LRUCache Tests", () => {
-
   it("empty", () => {
     const lru = new LRUCache(4);
     expect(lru.size).to.equal(0);
@@ -30,7 +28,7 @@ describe("LRUCache Tests", () => {
     expect(lru.get("b")).to.equal(2);
     expect(lru.get("c")).to.equal(3);
     deletedKey = lru.put("e", 4);
-    expect(deletedKey).to.deep.equal({"key": 'd', "value": 4});
+    expect(deletedKey).to.deep.equal({ key: "d", value: 4 });
     expect(lru.get("d")).to.equal(undefined);
     expect(lru.get("a")).to.equal(1);
     lru.put("f", 5);
@@ -66,5 +64,4 @@ describe("LRUCache Tests", () => {
     expect(lru._dllKeys()).to.deep.equal([]);
     expect(lru._dllLength()).to.equal(0);
   });
-
 });

--- a/test-js/test-path-changes.js
+++ b/test-js/test-path-changes.js
@@ -5,15 +5,17 @@ import fs from "fs";
 import { applyChange } from "../src/fontra/client/core/changes.js";
 import { VarPackedPath } from "../src/fontra/client/core/var-path.js";
 
-import { fileURLToPath } from 'url'
-import { dirname, join } from 'path'
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = dirname(__filename)
-
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
 describe("Path Changes Tests", () => {
-
-  const test_data_path = join(dirname(__dirname), "test-common", "path-change-test-data.json");
+  const test_data_path = join(
+    dirname(__dirname),
+    "test-common",
+    "path-change-test-data.json"
+  );
   const test_data = JSON.parse(fs.readFileSync(test_data_path, "utf8"));
   const inputPaths = test_data["inputPaths"];
   const tests = test_data["tests"];
@@ -24,15 +26,15 @@ describe("Path Changes Tests", () => {
     const inputPathName = test["inputPathName"];
     const expectedPath = VarPackedPath.fromUnpackedContours(test["expectedPath"]);
 
-    const subject = VarPackedPath.fromUnpackedContours(copyObject(inputPaths[inputPathName]));
+    const subject = VarPackedPath.fromUnpackedContours(
+      copyObject(inputPaths[inputPathName])
+    );
     it(`Apply Path Changes test #${i} -- ${testName}`, () => {
       applyChange(subject, test["change"]);
       expect(subject).to.deep.equal(expectedPath);
     });
   }
-
 });
-
 
 function copyObject(obj) {
   return JSON.parse(JSON.stringify(obj));

--- a/test-js/test-queue-iterator.js
+++ b/test-js/test-queue-iterator.js
@@ -1,12 +1,9 @@
 import chai from "chai";
 const expect = chai.expect;
 
-
 import { QueueIterator } from "../src/fontra/client/core/queue-iterator.js";
 
-
 describe("QueueIterator Tests", () => {
-
   it("immediate item, immediate done", async () => {
     const queue = new QueueIterator();
     queue.put(111);
@@ -119,5 +116,4 @@ describe("QueueIterator Tests", () => {
     queue.done();
     expect(() => queue.put(112)).to.throw("can't put item: queue is done");
   });
-
 });

--- a/test-js/test-svg-glyph.js
+++ b/test-js/test-svg-glyph.js
@@ -1,12 +1,9 @@
 import chai from "chai";
 const expect = chai.expect;
 
-
 import { SVGPath2D } from "../src/fontra/client/core/svg-glyph.js";
 
-
 describe("SVGPath2D tests", () => {
-
   it("empty path", () => {
     const p = new SVGPath2D();
     expect(p.getPath()).to.equal("");
@@ -85,7 +82,7 @@ describe("SVGPath2D tests", () => {
   });
 
   it("scale 1/3", () => {
-    const p = new SVGPath2D(1/3);
+    const p = new SVGPath2D(1 / 3);
     p.moveTo(0, 0);
     p.lineTo(0, 100);
     p.lineTo(100, 100);
@@ -94,7 +91,7 @@ describe("SVGPath2D tests", () => {
   });
 
   it("scale 1/3 precision 3 digits", () => {
-    const p = new SVGPath2D(1/3, 3);
+    const p = new SVGPath2D(1 / 3, 3);
     p.moveTo(0, 0);
     p.lineTo(0, 100);
     p.lineTo(100, 100);
@@ -119,5 +116,4 @@ describe("SVGPath2D tests", () => {
     p.lineTo(100, 0);
     expect(p.getPath()).to.equal("M20,30L20,230L220,230L220,30");
   });
-
 });

--- a/test-js/test-transform.js
+++ b/test-js/test-transform.js
@@ -3,9 +3,7 @@ const expect = chai.expect;
 
 import { Transform } from "../src/fontra/client/core/transform.js";
 
-
 describe("transform tests", () => {
-
   it("identity", () => {
     const t = new Transform();
     expect(t.toArray()).to.deep.equal([1, 0, 0, 1, 0, 0]);
@@ -41,13 +39,19 @@ describe("transform tests", () => {
 
   it("skew", () => {
     const t = new Transform();
-    expect(t.skew(Math.PI / 4).toArray()).to.deep.equal([1, 0, 0.9999999999999999, 1, 0, 0]);
+    expect(t.skew(Math.PI / 4).toArray()).to.deep.equal([
+      1, 0, 0.9999999999999999, 1, 0, 0,
+    ]);
   });
 
   it("transform", () => {
     const t = new Transform(2, 0, 0, 3, 1, 6);
-    expect(t.transform({xx:4, xy:3, yx:2, yy:1, dx:5, dy:6}).toArray()).to.deep.equal([8, 9, 4, 3, 11, 24]);
-    expect(t.transform([4, 3, 2, 1, 5, 6]).toArray()).to.deep.equal([8, 9, 4, 3, 11, 24]);
+    expect(
+      t.transform({ xx: 4, xy: 3, yx: 2, yy: 1, dx: 5, dy: 6 }).toArray()
+    ).to.deep.equal([8, 9, 4, 3, 11, 24]);
+    expect(t.transform([4, 3, 2, 1, 5, 6]).toArray()).to.deep.equal([
+      8, 9, 4, 3, 11, 24,
+    ]);
   });
 
   it("reverseTransform", () => {
@@ -62,8 +66,7 @@ describe("transform tests", () => {
   it("inverse", () => {
     const t = new Transform().translate(2, 3).scale(4, 5);
     expect(t.transformPoint(10, 20)).to.deep.equal([42, 103]);
-    const it = t.inverse()
+    const it = t.inverse();
     expect(it.transformPoint(42, 103)).to.deep.equal([10, 20]);
   });
-
 });

--- a/test-js/test-value-controller.js
+++ b/test-js/test-value-controller.js
@@ -1,28 +1,25 @@
 import chai from "chai";
 const expect = chai.expect;
 
-
 import { ValueController } from "../src/fontra/client/core/value-controller.js";
 
-
 describe("ValueController Tests", () => {
-
   it("basic tests", async () => {
     const vc = new ValueController();
     const result1 = [];
     const result2 = [];
     const result3 = [];
-    vc.addObserver("obs1", value => result1.push(value));
-    vc.addObserver("obs2", value => result2.push(value));
-    vc.addObserver("obs3", value => result3.push(value));
+    vc.addObserver("obs1", (value) => result1.push(value));
+    vc.addObserver("obs2", (value) => result2.push(value));
+    vc.addObserver("obs3", (value) => result3.push(value));
     vc.set(100, "obs1");
 
     expect(vc.value).to.equal(100);
-    expect(() => vc.value = 123).to.throw("Cannot set property value");
+    expect(() => (vc.value = 123)).to.throw("Cannot set property value");
 
     vc.set(200, "obs2");
     vc.set(300);
-    await asyncTimeout(0);  // Give the event loop time to handle the events
+    await asyncTimeout(0); // Give the event loop time to handle the events
     expect(result1).to.deep.equal([200, 300]);
     expect(result2).to.deep.equal([100, 300]);
     expect(result3).to.deep.equal([100, 200, 300]);
@@ -30,7 +27,7 @@ describe("ValueController Tests", () => {
     vc.removeObserver("obs1");
     vc.set(20, "obs2");
     vc.set(30);
-    await asyncTimeout(0);  // Give the event loop time to handle the events
+    await asyncTimeout(0); // Give the event loop time to handle the events
 
     expect(result1).to.deep.equal([200, 300]);
     expect(result2).to.deep.equal([100, 300, 30]);
@@ -43,7 +40,9 @@ describe("ValueController Tests", () => {
     const vc = new ValueController();
     expect(() => vc.addObserver()).to.throw("missing/falsey observerID argument");
     expect(() => vc.addObserver(null)).to.throw("missing/falsey observerID argument");
-    expect(() => vc.addObserver(undefined)).to.throw("missing/falsey observerID argument");
+    expect(() => vc.addObserver(undefined)).to.throw(
+      "missing/falsey observerID argument"
+    );
     expect(() => vc.addObserver("")).to.throw("missing/falsey observerID argument");
   });
 
@@ -52,10 +51,8 @@ describe("ValueController Tests", () => {
     const obs1 = vc.addObserver("obs1");
     expect(() => vc.addObserver("obs1")).to.throw("observerID must be unique");
   });
-
 });
 
-
 function asyncTimeout(ms) {
-    return new Promise(resolve => setTimeout(resolve, ms));
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/test-js/test-var-array.js
+++ b/test-js/test-var-array.js
@@ -3,42 +3,41 @@ const expect = chai.expect;
 
 import VarArray from "../src/fontra/client/core/var-array.js";
 
-
 describe("VarArray Tests", () => {
   const a1 = new VarArray(1, 2, 3, 4),
-        a2 = new VarArray(5, 6, 7, 8);
+    a2 = new VarArray(5, 6, 7, 8);
 
   it("copy", () => {
     const a3 = a1.copy();
     a3[1] = 1000;
     expect(a1).to.deep.equal([1, 2, 3, 4]);
     expect(a3).to.deep.equal([1, 1000, 3, 4]);
-  })
+  });
 
   it("addItemwise", () => {
     expect(a1.addItemwise(a2)).to.deep.equal([6, 8, 10, 12]);
-  })
+  });
 
   it("addItemwise Array", () => {
     expect(a1.addItemwise([5, 6, 7, 8])).to.deep.equal([6, 8, 10, 12]);
-  })
+  });
 
   it("subItemwise", () => {
     expect(a1.subItemwise(a2)).to.deep.equal([-4, -4, -4, -4]);
-  })
+  });
 
   it("mulScalar", () => {
     expect(a1.mulScalar(3)).to.deep.equal([3, 6, 9, 12]);
-  })
+  });
 
   it("throws addItemwise", () => {
     expect(() => {
       a1.addItemwise([1, 2, 3]);
     }).to.throw("arrays have different lengths: 4 vs. 3");
-  })
+  });
 
   it("VarArray.from", () => {
     const a = VarArray.from([1, 2, 3, 4]);
     expect(a).to.deep.equal([1, 2, 3, 4]);
-  })
-})
+  });
+});

--- a/test-js/test-var-funcs.js
+++ b/test-js/test-var-funcs.js
@@ -1,202 +1,221 @@
 import chai from "chai";
 const expect = chai.expect;
 
-
 import VarArray from "../src/fontra/client/core/var-array.js";
-import { addItemwise, subItemwise, mulScalar } from "../src/fontra/client/core/var-funcs.js";
-
+import {
+  addItemwise,
+  subItemwise,
+  mulScalar,
+} from "../src/fontra/client/core/var-funcs.js";
 
 describe("var-funcs tests", () => {
-
   describe("testing addition", () => {
-
     it("add arrays of ints", () => {
       const result = addItemwise([1, 2, 3], [4, 5, 6]);
       expect(result).to.deep.equal([5, 7, 9]);
-    })
+    });
 
     it("add incompatible arrays of ints", () => {
-      expect(() => addItemwise([1, 2, 3], [4, 5]))
-        .to.throw("arrays have incompatible lengths: 3 != 2");
-    })
+      expect(() => addItemwise([1, 2, 3], [4, 5])).to.throw(
+        "arrays have incompatible lengths: 3 != 2"
+      );
+    });
 
     it("add arrays of strings", () => {
       const result = addItemwise(["1", "2"], ["1", "2"]);
       expect(result).to.deep.equal(["1", "2"]);
-    })
+    });
 
     it("add incompatible arrays of strings", () => {
-      expect(() => addItemwise(["a", "b"], ["a", "c"]))
-        .to.throw("unexpected different strings: b != c");
-    })
+      expect(() => addItemwise(["a", "b"], ["a", "c"])).to.throw(
+        "unexpected different strings: b != c"
+      );
+    });
 
     it("add objects", () => {
-      const result = addItemwise({a: 1, b: 2}, {b: 2, a: 1});
-      expect(result).to.deep.equal({a: 2, b: 4});
-    })
+      const result = addItemwise({ a: 1, b: 2 }, { b: 2, a: 1 });
+      expect(result).to.deep.equal({ a: 2, b: 4 });
+    });
 
     it("add incompatible objects", () => {
-      expect(() => addItemwise({a: 1, b: 2}, {b: 2}))
-        .to.throw("objects have incompatible number of entries: 2 != 1");
-    })
+      expect(() => addItemwise({ a: 1, b: 2 }, { b: 2 })).to.throw(
+        "objects have incompatible number of entries: 2 != 1"
+      );
+    });
 
     it("add incompatible objects", () => {
-      expect(() => addItemwise({a: 1, b: 2}, {b: 2, c: 3}))
-        .to.throw("objects have incompatible key sets: a,b != b,c");
-    })
+      expect(() => addItemwise({ a: 1, b: 2 }, { b: 2, c: 3 })).to.throw(
+        "objects have incompatible key sets: a,b != b,c"
+      );
+    });
 
     it("add nested objects", () => {
-      const result = addItemwise({a: {x: 10}, b: 2}, {b: 2, a: {x: 20}});
-      expect(result).to.deep.equal({a: {x: 30}, b: 4});
-    })
+      const result = addItemwise({ a: { x: 10 }, b: 2 }, { b: 2, a: { x: 20 } });
+      expect(result).to.deep.equal({ a: { x: 30 }, b: 4 });
+    });
 
     it("add nested arrays", () => {
       const result = addItemwise([[1, 2], 3, 4], [[5, 6], 7, 8]);
       expect(result).to.deep.equal([[6, 8], 10, 12]);
-    })
+    });
 
     it("add array of objects", () => {
-      const result = addItemwise([{x: 10}, 2], [{x: 20}, 5]);
-      expect(result).to.deep.equal([{x: 30}, 7]);
-    })
+      const result = addItemwise([{ x: 10 }, 2], [{ x: 20 }, 5]);
+      expect(result).to.deep.equal([{ x: 30 }, 7]);
+    });
 
     it("add VarArray", () => {
       const result = addItemwise(new VarArray(1, 2, 3), new VarArray(1, 2, 3));
       expect(result).to.deep.equal([2, 4, 6]);
       expect(result).to.be.an.instanceof(VarArray);
-    })
+    });
 
     it("add undefined", () => {
-      expect(() => addItemwise(123, undefined)).to.throw("incompatible object types: typeof 123 != typeof undefined");
-      expect(() => addItemwise(undefined, 123)).to.throw("incompatible object types: typeof undefined != typeof 123");
+      expect(() => addItemwise(123, undefined)).to.throw(
+        "incompatible object types: typeof 123 != typeof undefined"
+      );
+      expect(() => addItemwise(undefined, 123)).to.throw(
+        "incompatible object types: typeof undefined != typeof 123"
+      );
       expect(addItemwise(undefined, undefined)).to.equal(undefined);
-    })
+    });
 
     it("add null", () => {
-      expect(() => addItemwise(123, null)).to.throw("incompatible object types: typeof 123 != typeof null");
-      expect(() => addItemwise(null, 123)).to.throw("incompatible object types: typeof null != typeof 123");
+      expect(() => addItemwise(123, null)).to.throw(
+        "incompatible object types: typeof 123 != typeof null"
+      );
+      expect(() => addItemwise(null, 123)).to.throw(
+        "incompatible object types: typeof null != typeof 123"
+      );
       expect(addItemwise(null, null)).to.equal(null);
-    })
-
+    });
   });
 
   describe("testing subtraction", () => {
-
     it("sub arrays of ints", () => {
       const result = subItemwise([1, 2, 3], [4, 5, 6]);
       expect(result).to.deep.equal([-3, -3, -3]);
-    })
+    });
 
     it("sub incompatible arrays of ints", () => {
-      expect(() => subItemwise([1, 2, 3], [4, 5]))
-        .to.throw("arrays have incompatible lengths: 3 != 2");
-    })
+      expect(() => subItemwise([1, 2, 3], [4, 5])).to.throw(
+        "arrays have incompatible lengths: 3 != 2"
+      );
+    });
 
     it("sub arrays of strings", () => {
       const result = subItemwise(["1", "2"], ["1", "2"]);
       expect(result).to.deep.equal(["1", "2"]);
-    })
+    });
 
     it("sub incompatible arrays of strings", () => {
-      expect(() => subItemwise(["a", "b"], ["a", "c"]))
-        .to.throw("unexpected different strings: b != c");
-    })
+      expect(() => subItemwise(["a", "b"], ["a", "c"])).to.throw(
+        "unexpected different strings: b != c"
+      );
+    });
 
     it("sub objects", () => {
-      const result = subItemwise({a: 10, b: 20}, {b: 2, a: 1});
-      expect(result).to.deep.equal({a: 9, b: 18});
-    })
+      const result = subItemwise({ a: 10, b: 20 }, { b: 2, a: 1 });
+      expect(result).to.deep.equal({ a: 9, b: 18 });
+    });
 
     it("sub incompatible objects", () => {
-      expect(() => subItemwise({a: 1, b: 2}, {b: 2}))
-        .to.throw("objects have incompatible number of entries: 2 != 1");
-    })
+      expect(() => subItemwise({ a: 1, b: 2 }, { b: 2 })).to.throw(
+        "objects have incompatible number of entries: 2 != 1"
+      );
+    });
 
     it("sub incompatible objects", () => {
-      expect(() => subItemwise({a: 1, b: 2}, {b: 2, c: 3}))
-        .to.throw("objects have incompatible key sets: a,b != b,c");
-    })
+      expect(() => subItemwise({ a: 1, b: 2 }, { b: 2, c: 3 })).to.throw(
+        "objects have incompatible key sets: a,b != b,c"
+      );
+    });
 
     it("sub nested objects", () => {
-      const result = subItemwise({a: {x: 10}, b: 2}, {b: 2, a: {x: 20}});
-      expect(result).to.deep.equal({a: {x: -10}, b: 0});
-    })
+      const result = subItemwise({ a: { x: 10 }, b: 2 }, { b: 2, a: { x: 20 } });
+      expect(result).to.deep.equal({ a: { x: -10 }, b: 0 });
+    });
 
     it("sub nested arrays", () => {
       const result = subItemwise([[1, 2], 3, 4], [[5, 6], 7, 8]);
       expect(result).to.deep.equal([[-4, -4], -4, -4]);
-    })
+    });
 
     it("sub array of objects", () => {
-      const result = subItemwise([{x: 10}, 2], [{x: 20}, 5]);
-      expect(result).to.deep.equal([{x: -10}, -3]);
-    })
+      const result = subItemwise([{ x: 10 }, 2], [{ x: 20 }, 5]);
+      expect(result).to.deep.equal([{ x: -10 }, -3]);
+    });
 
     it("sub VarArray", () => {
       const result = subItemwise(new VarArray(1, 2, 3), new VarArray(1, 2, 3));
       expect(result).to.deep.equal([0, 0, 0]);
       expect(result).to.be.an.instanceof(VarArray);
-    })
+    });
 
     it("sub undefined", () => {
-      expect(() => subItemwise(123, undefined)).to.throw("incompatible object types: typeof 123 != typeof undefined");
-      expect(() => subItemwise(undefined, 123)).to.throw("incompatible object types: typeof undefined != typeof 123");
+      expect(() => subItemwise(123, undefined)).to.throw(
+        "incompatible object types: typeof 123 != typeof undefined"
+      );
+      expect(() => subItemwise(undefined, 123)).to.throw(
+        "incompatible object types: typeof undefined != typeof 123"
+      );
       expect(subItemwise(undefined, undefined)).to.equal(undefined);
-    })
+    });
 
     it("sub null", () => {
-      expect(() => subItemwise(123, null)).to.throw("incompatible object types: typeof 123 != typeof null");
-      expect(() => subItemwise(null, 123)).to.throw("incompatible object types: typeof null != typeof 123");
+      expect(() => subItemwise(123, null)).to.throw(
+        "incompatible object types: typeof 123 != typeof null"
+      );
+      expect(() => subItemwise(null, 123)).to.throw(
+        "incompatible object types: typeof null != typeof 123"
+      );
       expect(subItemwise(null, null)).to.equal(null);
-    })
-
+    });
   });
 
   describe("testing multiplication", () => {
-
     it("mul arrays of ints", () => {
       const result = mulScalar([1, 2, 3], 10);
       expect(result).to.deep.equal([10, 20, 30]);
-    })
+    });
 
     it("mul arrays of strings", () => {
       const result = mulScalar(["1", "2"], 3);
       expect(result).to.deep.equal(["1", "2"]);
-    })
+    });
 
     it("mul objects", () => {
-      const result = mulScalar({a: 1, b: 2}, 3);
-      expect(result).to.deep.equal({a: 3, b: 6});
-    })
+      const result = mulScalar({ a: 1, b: 2 }, 3);
+      expect(result).to.deep.equal({ a: 3, b: 6 });
+    });
 
     it("mul nested objects", () => {
-      const result = mulScalar({a: {x: 10}, b: 2}, 100);
-      expect(result).to.deep.equal({a: {x: 1000}, b: 200});
-    })
+      const result = mulScalar({ a: { x: 10 }, b: 2 }, 100);
+      expect(result).to.deep.equal({ a: { x: 1000 }, b: 200 });
+    });
 
     it("mul nested arrays", () => {
       const result = mulScalar([[1, 2], 3, 4], 10);
       expect(result).to.deep.equal([[10, 20], 30, 40]);
-    })
+    });
 
     it("mul array of objects", () => {
-      const result = mulScalar([{x: 10}, 2], 5);
-      expect(result).to.deep.equal([{x: 50}, 10]);
-    })
+      const result = mulScalar([{ x: 10 }, 2], 5);
+      expect(result).to.deep.equal([{ x: 50 }, 10]);
+    });
 
     it("mul VarArray", () => {
       const result = mulScalar(new VarArray(1, 2, 3), 5);
       expect(result).to.deep.equal([5, 10, 15]);
       expect(result).to.be.an.instanceof(VarArray);
-    })
+    });
 
     it("mul undefined", () => {
       expect(mulScalar(undefined, 3)).to.equal(undefined);
-    })
+    });
 
     it("mul null", () => {
       expect(mulScalar(null, 3)).to.equal(null);
-    })
-
+    });
   });
 });

--- a/test-js/test-var-model.js
+++ b/test-js/test-var-model.js
@@ -13,34 +13,31 @@ import {
   supportScalar,
 } from "../src/fontra/client/core/var-model.js";
 
-
 describe("var-model tests", () => {
-
   describe("VariationModel tests", () => {
-
     it("basic", () => {
       const locations = [
-        {'wght':100},
-        {'wght':-100},
-        {'wght':-180},
-        {'wdth':+.3},
-        {'wght':+120,'wdth':.3},
-        {'wght':+120,'wdth':.2},
+        { wght: 100 },
+        { wght: -100 },
+        { wght: -180 },
+        { wdth: +0.3 },
+        { wght: +120, wdth: 0.3 },
+        { wght: +120, wdth: 0.2 },
         {},
-        {'wght':+180,'wdth':.3},
-        {'wght':+180},
+        { wght: +180, wdth: 0.3 },
+        { wght: +180 },
       ];
-      const model = new VariationModel(locations, ['wght']);
+      const model = new VariationModel(locations, ["wght"]);
       const sortedLocations = [
         {},
-        {'wght': -100},
-        {'wght': -180},
-        {'wght': 100},
-        {'wght': 180},
-        {'wdth': 0.3},
-        {'wdth': 0.3, 'wght': 180},
-        {'wdth': 0.3, 'wght': 120},
-        {'wdth': 0.2, 'wght': 120},
+        { wght: -100 },
+        { wght: -180 },
+        { wght: 100 },
+        { wght: 180 },
+        { wdth: 0.3 },
+        { wdth: 0.3, wght: 180 },
+        { wdth: 0.3, wght: 120 },
+        { wdth: 0.2, wght: 120 },
       ];
       expect(model.locations).to.deep.equal(sortedLocations);
       expect(model.mapping).to.deep.equal([3, 1, 2, 5, 7, 8, 0, 6, 4]);
@@ -54,21 +51,31 @@ describe("var-model tests", () => {
         new Map([[0, 1.0]]),
         new Map([[0, 1.0]]),
         new Map([[0, 1.0]]),
-        new Map([[0, 1.0], [4, 1.0], [5, 1.0]]),
-        new Map([[0, 1.0], [3, 0.75], [4, 0.25], [5, 1.0], [6, 0.6666666666666666]]),
-        new Map([[0, 1.0],
-         [3, 0.75],
-         [4, 0.25],
-         [5, 0.6666666666666667],
-         [6, 0.4444444444444445],
-         [7, 0.6666666666666667]]),
+        new Map([
+          [0, 1.0],
+          [4, 1.0],
+          [5, 1.0],
+        ]),
+        new Map([
+          [0, 1.0],
+          [3, 0.75],
+          [4, 0.25],
+          [5, 1.0],
+          [6, 0.6666666666666666],
+        ]),
+        new Map([
+          [0, 1.0],
+          [3, 0.75],
+          [4, 0.25],
+          [5, 0.6666666666666667],
+          [6, 0.4444444444444445],
+          [7, 0.6666666666666667],
+        ]),
       ]);
-
     });
 
     it("deltas and interpolation", () => {
-
-      const locations = [{}, {"wght": 1}, {"wdth": 1}, {"wght": 1, "wdth": 1}];
+      const locations = [{}, { wght: 1 }, { wdth: 1 }, { wght: 1, wdth: 1 }];
       const model = new VariationModel(locations);
       const masterValues = [1, 2.5, 3.25, 5.25];
       const deltas = model.getDeltas(masterValues);
@@ -76,31 +83,46 @@ describe("var-model tests", () => {
       const testValues = [
         // loc, expectedValue
         [{}, 1.0],
-        [{'wght': 1}, 2.5],
-        [{'wdth': 1}, 3.25],
-        [{'wght': 0.5}, 1.75],
-        [{'wdth': 0.5}, 2.125],
-        [{'wght': 1, 'wdth': 1}, 5.25],
-        [{'wght': 0.5, 'wdth': 0.5}, 3.0],
+        [{ wght: 1 }, 2.5],
+        [{ wdth: 1 }, 3.25],
+        [{ wght: 0.5 }, 1.75],
+        [{ wdth: 0.5 }, 2.125],
+        [{ wght: 1, wdth: 1 }, 5.25],
+        [{ wght: 0.5, wdth: 0.5 }, 3.0],
       ];
       for (const [loc, expectedValue] of testValues) {
-        const result = model.interpolateFromDeltas(loc, deltas)
+        const result = model.interpolateFromDeltas(loc, deltas);
         expect(result).to.equal(expectedValue);
       }
     });
 
     it("throw missing base master", () => {
-      new VariationModel([{}]);  // should not throw
-      expect(() => new VariationModel([])).to.throw("locations must contain {} default");
-      expect(() => new VariationModel([{a:100}])).to.throw("locations must contain {} default");
+      new VariationModel([{}]); // should not throw
+      expect(() => new VariationModel([])).to.throw(
+        "locations must contain {} default"
+      );
+      expect(() => new VariationModel([{ a: 100 }])).to.throw(
+        "locations must contain {} default"
+      );
     });
 
     it("throw non-unique locations", () => {
-      expect(() => new VariationModel([{},{}])).to.throw("locations must be unique");
-      expect(() => new VariationModel([{a:1,b:2},{b:2,a:1}])).to.throw("locations must be unique");
-      expect(() => new VariationModel([{a:1,b:2},{a:1,b:2.0}])).to.throw("locations must be unique");
+      expect(() => new VariationModel([{}, {}])).to.throw("locations must be unique");
+      expect(
+        () =>
+          new VariationModel([
+            { a: 1, b: 2 },
+            { b: 2, a: 1 },
+          ])
+      ).to.throw("locations must be unique");
+      expect(
+        () =>
+          new VariationModel([
+            { a: 1, b: 2 },
+            { a: 1, b: 2.0 },
+          ])
+      ).to.throw("locations must be unique");
     });
-
   });
 
   describe("normalizeValue test", () => {
@@ -115,56 +137,65 @@ describe("var-model tests", () => {
 
   describe("normalizeLocation tests", () => {
     it("-1,0,1", () => {
-      const axes = [{"name": "wght", "minValue": 100, "defaultValue": 400, "maxValue": 900}];
-      expect(normalizeLocation({"wght": 400}, axes)).to.deep.equal({'wght': 0.0});
-      expect(normalizeLocation({"wght": 100}, axes)).to.deep.equal({'wght': -1.0});
-      expect(normalizeLocation({"wght": 900}, axes)).to.deep.equal({'wght': 1.0});
-      expect(normalizeLocation({"wght": 650}, axes)).to.deep.equal({'wght': 0.5});
-      expect(normalizeLocation({"wght": 1000}, axes)).to.deep.equal({'wght': 1.0});
-      expect(normalizeLocation({"wght": 0}, axes)).to.deep.equal({'wght': -1.0});
+      const axes = [{ name: "wght", minValue: 100, defaultValue: 400, maxValue: 900 }];
+      expect(normalizeLocation({ wght: 400 }, axes)).to.deep.equal({ wght: 0.0 });
+      expect(normalizeLocation({ wght: 100 }, axes)).to.deep.equal({ wght: -1.0 });
+      expect(normalizeLocation({ wght: 900 }, axes)).to.deep.equal({ wght: 1.0 });
+      expect(normalizeLocation({ wght: 650 }, axes)).to.deep.equal({ wght: 0.5 });
+      expect(normalizeLocation({ wght: 1000 }, axes)).to.deep.equal({ wght: 1.0 });
+      expect(normalizeLocation({ wght: 0 }, axes)).to.deep.equal({ wght: -1.0 });
     });
 
     it("0,0,1", () => {
-      const axes = [{"name": "wght", "minValue": 0, "defaultValue": 0, "maxValue": 1000}];
-      expect(normalizeLocation({"wght": 0}, axes)).to.deep.equal({'wght': 0.0});
-      expect(normalizeLocation({"wght": -1}, axes)).to.deep.equal({'wght': 0.0});
-      expect(normalizeLocation({"wght": 1000}, axes)).to.deep.equal({'wght': 1.0});
-      expect(normalizeLocation({"wght": 500}, axes)).to.deep.equal({'wght': 0.5});
-      expect(normalizeLocation({"wght": 1001}, axes)).to.deep.equal({'wght': 1.0});
+      const axes = [{ name: "wght", minValue: 0, defaultValue: 0, maxValue: 1000 }];
+      expect(normalizeLocation({ wght: 0 }, axes)).to.deep.equal({ wght: 0.0 });
+      expect(normalizeLocation({ wght: -1 }, axes)).to.deep.equal({ wght: 0.0 });
+      expect(normalizeLocation({ wght: 1000 }, axes)).to.deep.equal({ wght: 1.0 });
+      expect(normalizeLocation({ wght: 500 }, axes)).to.deep.equal({ wght: 0.5 });
+      expect(normalizeLocation({ wght: 1001 }, axes)).to.deep.equal({ wght: 1.0 });
     });
 
     it("0,1,1", () => {
-      const axes = [{"name": "wght", "minValue": 0, "defaultValue": 1000, "maxValue": 1000}];
-      expect(normalizeLocation({"wght": 0}, axes)).to.deep.equal({'wght': -1.0});
-      expect(normalizeLocation({"wght": -1}, axes)).to.deep.equal({'wght': -1.0});
-      expect(normalizeLocation({"wght": 500}, axes)).to.deep.equal({'wght': -0.5});
-      expect(normalizeLocation({"wght": 1000}, axes)).to.deep.equal({'wght': 0.0});
-      expect(normalizeLocation({"wght": 1001}, axes)).to.deep.equal({'wght': 0.0});
+      const axes = [{ name: "wght", minValue: 0, defaultValue: 1000, maxValue: 1000 }];
+      expect(normalizeLocation({ wght: 0 }, axes)).to.deep.equal({ wght: -1.0 });
+      expect(normalizeLocation({ wght: -1 }, axes)).to.deep.equal({ wght: -1.0 });
+      expect(normalizeLocation({ wght: 500 }, axes)).to.deep.equal({ wght: -0.5 });
+      expect(normalizeLocation({ wght: 1000 }, axes)).to.deep.equal({ wght: 0.0 });
+      expect(normalizeLocation({ wght: 1001 }, axes)).to.deep.equal({ wght: 0.0 });
     });
-
   });
 
   describe("supportScalar tests", () => {
-
     it("supportScalar", () => {
       expect(supportScalar({}, {})).to.equal(1.0);
-      expect(supportScalar({'wght':.2}, {})).to.equal(1.0);
-      expect(supportScalar({'wght':.2}, {'wght':[0,2,3]})).to.equal(0.1);
-      expect(supportScalar({'wght':2.5}, {'wght':[0,2,4]})).to.equal(0.75);
-      expect(supportScalar({'wght':2.5, 'wdth':0}, {'wght':[0,2,4], 'wdth':[-1,0,+1]})).to.equal(0.75);
-      expect(supportScalar({'wght':2.5, 'wdth':.5}, {'wght':[0,2,4], 'wdth':[-1,0,+1]}, false)).to.equal(0.375);
-      expect(supportScalar({'wght':2.5, 'wdth':0}, {'wght':[0,2,4], 'wdth':[-1,0,+1]})).to.equal(0.75);
-      expect(supportScalar({'wght':2.5, 'wdth':.5}, {'wght':[0,2,4], 'wdth':[-1,0,+1]})).to.equal(0.75);
+      expect(supportScalar({ wght: 0.2 }, {})).to.equal(1.0);
+      expect(supportScalar({ wght: 0.2 }, { wght: [0, 2, 3] })).to.equal(0.1);
+      expect(supportScalar({ wght: 2.5 }, { wght: [0, 2, 4] })).to.equal(0.75);
+      expect(
+        supportScalar({ wght: 2.5, wdth: 0 }, { wght: [0, 2, 4], wdth: [-1, 0, +1] })
+      ).to.equal(0.75);
+      expect(
+        supportScalar(
+          { wght: 2.5, wdth: 0.5 },
+          { wght: [0, 2, 4], wdth: [-1, 0, +1] },
+          false
+        )
+      ).to.equal(0.375);
+      expect(
+        supportScalar({ wght: 2.5, wdth: 0 }, { wght: [0, 2, 4], wdth: [-1, 0, +1] })
+      ).to.equal(0.75);
+      expect(
+        supportScalar({ wght: 2.5, wdth: 0.5 }, { wght: [0, 2, 4], wdth: [-1, 0, +1] })
+      ).to.equal(0.75);
     });
-
   });
 
   describe("locationToString tests", () => {
     it("empty location", () => {
       expect(locationToString({})).to.equal("{}");
-      expect(locationToString({a:1, b:2})).to.equal('{"a":1,"b":2}');
-      expect(locationToString({b:2, a:1})).to.equal('{"a":1,"b":2}');
-    })
+      expect(locationToString({ a: 1, b: 2 })).to.equal('{"a":1,"b":2}');
+      expect(locationToString({ b: 2, a: 1 })).to.equal('{"a":1,"b":2}');
+    });
   });
 
   describe("deepCompare tests", () => {
@@ -205,9 +236,15 @@ describe("var-model tests", () => {
       expect(deepCompare([1, 2], [1, 3])).to.equal(-1);
       expect(deepCompare([1, 4], [1, 3])).to.equal(1);
       expect(deepCompare([2, 2], [1, 3])).to.equal(1);
-      const l = [[1, 2, 3], [1, 2]];
+      const l = [
+        [1, 2, 3],
+        [1, 2],
+      ];
       l.sort(deepCompare);
-      expect(l).to.deep.equal([[1, 2], [1, 2, 3]]);
+      expect(l).to.deep.equal([
+        [1, 2],
+        [1, 2, 3],
+      ]);
     });
 
     it("deepCompare nested numeric array", () => {
@@ -220,11 +257,9 @@ describe("var-model tests", () => {
       expect(() => deepCompare({}, [])).to.throw(TypeError);
       expect(() => deepCompare(123, "123")).to.throw(TypeError);
     });
-
   });
 
   describe("piecewiseLinearMap tests", () => {
-
     it("undefined mapping", () => {
       expect(piecewiseLinearMap(10, undefined)).to.equal(10);
     });
@@ -234,66 +269,76 @@ describe("var-model tests", () => {
     });
 
     it("low mapping", () => {
-      expect(piecewiseLinearMap(9, {10: 100, 20: 200})).to.equal(99);
+      expect(piecewiseLinearMap(9, { 10: 100, 20: 200 })).to.equal(99);
     });
 
     it("high mapping", () => {
-      expect(piecewiseLinearMap(21, {10: 100, 20: 200})).to.equal(201);
+      expect(piecewiseLinearMap(21, { 10: 100, 20: 200 })).to.equal(201);
     });
 
     it("one segment mapping", () => {
-      expect(piecewiseLinearMap(15, {10: 100, 20: 200})).to.equal(150);
+      expect(piecewiseLinearMap(15, { 10: 100, 20: 200 })).to.equal(150);
     });
 
     it("multi segment mapping", () => {
-      expect(piecewiseLinearMap(15, {10: 100, 20: 200, 30: 1000})).to.equal(150);
-      expect(piecewiseLinearMap(25, {10: 100, 20: 200, 30: 1000})).to.equal(600);
+      expect(piecewiseLinearMap(15, { 10: 100, 20: 200, 30: 1000 })).to.equal(150);
+      expect(piecewiseLinearMap(25, { 10: 100, 20: 200, 30: 1000 })).to.equal(600);
     });
-
   });
 
   describe("mapForward tests", () => {
-
     it("undefined map", () => {
-      const axes = [{"name": "weight"}];
-      const location = {"weight": 10};
-      expect(mapForward(location, axes)).to.deep.equal({"weight": 10});
+      const axes = [{ name: "weight" }];
+      const location = { weight: 10 };
+      expect(mapForward(location, axes)).to.deep.equal({ weight: 10 });
     });
 
     it("empty map", () => {
-      const axes = [{"name": "weight", "mapping": []}];
-      const location = {"weight": 10};
-      expect(mapForward(location, axes)).to.deep.equal({"weight": 10});
+      const axes = [{ name: "weight", mapping: [] }];
+      const location = { weight: 10 };
+      expect(mapForward(location, axes)).to.deep.equal({ weight: 10 });
     });
 
     it("simple map", () => {
-      const axes = [{"name": "weight", "mapping": [[0, 100], [20, 200]]}];
-      const location = {"weight": 10, "width": 100};
-      expect(mapForward(location, axes)).to.deep.equal({"weight": 150, "width": 100});
+      const axes = [
+        {
+          name: "weight",
+          mapping: [
+            [0, 100],
+            [20, 200],
+          ],
+        },
+      ];
+      const location = { weight: 10, width: 100 };
+      expect(mapForward(location, axes)).to.deep.equal({ weight: 150, width: 100 });
     });
-
   });
 
   describe("mapBackward tests", () => {
-
     it("undefined map", () => {
-      const axes = [{"name": "weight"}];
-      const location = {"weight": 10};
-      expect(mapBackward(location, axes)).to.deep.equal({"weight": 10});
+      const axes = [{ name: "weight" }];
+      const location = { weight: 10 };
+      expect(mapBackward(location, axes)).to.deep.equal({ weight: 10 });
     });
 
     it("empty map", () => {
-      const axes = [{"name": "weight", "mapping": []}];
-      const location = {"weight": 10};
-      expect(mapBackward(location, axes)).to.deep.equal({"weight": 10});
+      const axes = [{ name: "weight", mapping: [] }];
+      const location = { weight: 10 };
+      expect(mapBackward(location, axes)).to.deep.equal({ weight: 10 });
     });
 
     it("simple map", () => {
-      const axes = [{"name": "weight", "mapping": [[0, 100], [20, 200]]}];
-      const location = {"weight": 150, "width": 100};
-      expect(mapBackward(location, axes)).to.deep.equal({"weight": 10, "width": 100});
+      const axes = [
+        {
+          name: "weight",
+          mapping: [
+            [0, 100],
+            [20, 200],
+          ],
+        },
+      ];
+      const location = { weight: 150, width: 100 };
+      expect(mapBackward(location, axes)).to.deep.equal({ weight: 10, width: 100 });
     });
-
   });
-
 });

--- a/test-js/test-var-path.js
+++ b/test-js/test-var-path.js
@@ -10,50 +10,76 @@ import VarArray from "../src/fontra/client/core/var-array.js";
 import { Transform } from "../src/fontra/client/core/transform.js";
 import { enumerate } from "../src/fontra/client/core/utils.js";
 
-
 class MockPath2D {
   constructor() {
     this.items = [];
   }
   moveTo(x, y) {
-    this.items.push({op: "moveTo", args: [x, y]})
+    this.items.push({ op: "moveTo", args: [x, y] });
   }
   lineTo(x, y) {
-    this.items.push({op: "lineTo", args: [x, y]})
+    this.items.push({ op: "lineTo", args: [x, y] });
   }
   bezierCurveTo(x1, y1, x2, y2, x3, y3) {
-    this.items.push({op: "bezierCurveTo", args: [x1, y1, x2, y2, x3, y3]})
+    this.items.push({ op: "bezierCurveTo", args: [x1, y1, x2, y2, x3, y3] });
   }
   quadraticCurveTo(x1, y1, x2, y2) {
-    this.items.push({op: "quadraticCurveTo", args: [x1, y1, x2, y2]})
+    this.items.push({ op: "quadraticCurveTo", args: [x1, y1, x2, y2] });
   }
   closePath() {
-    this.items.push({op: "closePath", args: []});
+    this.items.push({ op: "closePath", args: [] });
   }
 }
 
-
-function simpleTestPath(isClosed=true) {
+function simpleTestPath(isClosed = true) {
   return new VarPackedPath(
     new VarArray(0, 0, 0, 100, 100, 100, 100, 0),
-    [VarPackedPath.ON_CURVE, VarPackedPath.ON_CURVE, VarPackedPath.ON_CURVE, VarPackedPath.ON_CURVE],
-    [{endPoint: 3, isClosed: isClosed}],
+    [
+      VarPackedPath.ON_CURVE,
+      VarPackedPath.ON_CURVE,
+      VarPackedPath.ON_CURVE,
+      VarPackedPath.ON_CURVE,
+    ],
+    [{ endPoint: 3, isClosed: isClosed }]
   );
 }
 
-
 function complexTestPath() {
   const p = new VarPackedPath();
-  p.coordinates = new VarArray(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19);
+  p.coordinates = new VarArray(
+    0,
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    9,
+    10,
+    11,
+    12,
+    13,
+    14,
+    15,
+    16,
+    17,
+    18,
+    19
+  );
   const on = VarPackedPath.ON_CURVE;
   const off = VarPackedPath.OFF_CURVE_QUAD;
   p.pointTypes = [on, off, on, on, on, on, on, off, off, on];
-  p.contourInfo = [{endPoint: 2, isClosed: true}, {endPoint: 5, isClosed: true}, {endPoint: 9, isClosed: true}];
+  p.contourInfo = [
+    { endPoint: 2, isClosed: true },
+    { endPoint: 5, isClosed: true },
+    { endPoint: 9, isClosed: true },
+  ];
   return p;
 }
 
 describe("VarPackedPath Tests", () => {
-  
   it("empty copy", () => {
     const p = new VarPackedPath();
     expect(p.unpackedContours()).to.deep.equal([]);
@@ -62,295 +88,341 @@ describe("VarPackedPath Tests", () => {
     expect(p2.pointTypes).to.deep.equal([]);
     expect(p2.contourInfo).to.deep.equal([]);
     expect(p2.unpackedContours()).to.deep.equal([]);
-  })
+  });
 
   it("constructor", () => {
     const p = simpleTestPath();
     expect(p.coordinates).to.deep.equal([0, 0, 0, 100, 100, 100, 100, 0]);
-    expect(p.pointTypes).to.deep.equal([VarPackedPath.ON_CURVE, VarPackedPath.ON_CURVE, VarPackedPath.ON_CURVE, VarPackedPath.ON_CURVE]);
-    expect(p.contourInfo).to.deep.equal([{endPoint: 3, isClosed: true}]);
-  })
+    expect(p.pointTypes).to.deep.equal([
+      VarPackedPath.ON_CURVE,
+      VarPackedPath.ON_CURVE,
+      VarPackedPath.ON_CURVE,
+      VarPackedPath.ON_CURVE,
+    ]);
+    expect(p.contourInfo).to.deep.equal([{ endPoint: 3, isClosed: true }]);
+  });
 
   it("copy", () => {
     const p = simpleTestPath();
     const p2 = p.copy();
     // modify original
     p.coordinates[0] = 1000;
-    p.pointTypes[0] = VarPackedPath.OFF_CURVE_QUAD
+    p.pointTypes[0] = VarPackedPath.OFF_CURVE_QUAD;
     p.contourInfo[0].isClosed = false;
     expect(p2.coordinates).to.deep.equal([0, 0, 0, 100, 100, 100, 100, 0]);
-    expect(p2.pointTypes).to.deep.equal([VarPackedPath.ON_CURVE, VarPackedPath.ON_CURVE, VarPackedPath.ON_CURVE, VarPackedPath.ON_CURVE]);
-    expect(p2.contourInfo).to.deep.equal([{endPoint: 3, isClosed: true}]);
-  })
+    expect(p2.pointTypes).to.deep.equal([
+      VarPackedPath.ON_CURVE,
+      VarPackedPath.ON_CURVE,
+      VarPackedPath.ON_CURVE,
+      VarPackedPath.ON_CURVE,
+    ]);
+    expect(p2.contourInfo).to.deep.equal([{ endPoint: 3, isClosed: true }]);
+  });
 
   it("draw", () => {
     const p = simpleTestPath();
     expect(p.unpackedContours()).to.deep.equal([
       {
-        "points": [
-          {"x": 0, "y": 0},
-          {"x": 0, "y": 100},
-          {"x": 100, "y": 100},
-          {"x": 100, "y": 0},
+        points: [
+          { x: 0, y: 0 },
+          { x: 0, y: 100 },
+          { x: 100, y: 100 },
+          { x: 100, y: 0 },
         ],
-        "isClosed": true,
-      }
+        isClosed: true,
+      },
     ]);
-  })
+  });
 
   it("open path", () => {
     const p = simpleTestPath(false);
     expect(p.unpackedContours()).to.deep.equal([
       {
-        "points": [
-          {"x": 0, "y": 0},
-          {"x": 0, "y": 100},
-          {"x": 100, "y": 100},
-          {"x": 100, "y": 0},
+        points: [
+          { x: 0, y: 0 },
+          { x: 0, y: 100 },
+          { x: 100, y: 100 },
+          { x: 100, y: 0 },
         ],
-        "isClosed": false,
-      }
+        isClosed: false,
+      },
     ]);
-  })
+  });
 
   it("closed path dangling off curves", () => {
     const p = new VarPackedPath(
       new VarArray(0, 0, 0, 100, 100, 100, 100, 0),
-      [VarPackedPath.OFF_CURVE_QUAD, VarPackedPath.ON_CURVE, VarPackedPath.OFF_CURVE_QUAD, VarPackedPath.ON_CURVE],
-      [{endPoint: 3, isClosed: true}],
+      [
+        VarPackedPath.OFF_CURVE_QUAD,
+        VarPackedPath.ON_CURVE,
+        VarPackedPath.OFF_CURVE_QUAD,
+        VarPackedPath.ON_CURVE,
+      ],
+      [{ endPoint: 3, isClosed: true }]
     );
     expect(p.unpackedContours()).to.deep.equal([
       {
-        "points": [
-          {"x": 0, "y": 0, "type": "quad"},
-          {"x": 0, "y": 100},
-          {"x": 100, "y": 100, "type": "quad"},
-          {"x": 100, "y": 0},
+        points: [
+          { x: 0, y: 0, type: "quad" },
+          { x: 0, y: 100 },
+          { x: 100, y: 100, type: "quad" },
+          { x: 100, y: 0 },
         ],
-        "isClosed": true,
-      }
+        isClosed: true,
+      },
     ]);
-  })
+  });
 
   it("open path dangling off curves", () => {
     const p = new VarPackedPath(
       new VarArray(0, 0, 0, 100, 100, 100, 100, 0),
-      [VarPackedPath.OFF_CURVE_QUAD, VarPackedPath.ON_CURVE, VarPackedPath.OFF_CURVE_QUAD, VarPackedPath.ON_CURVE],
-      [{endPoint: 3, isClosed: false}],
+      [
+        VarPackedPath.OFF_CURVE_QUAD,
+        VarPackedPath.ON_CURVE,
+        VarPackedPath.OFF_CURVE_QUAD,
+        VarPackedPath.ON_CURVE,
+      ],
+      [{ endPoint: 3, isClosed: false }]
     );
 
     expect(p.unpackedContours()).to.deep.equal([
       {
-        "points": [
-          {"x": 0, "y": 0, "type": "quad"},
-          {"x": 0, "y": 100},
-          {"x": 100, "y": 100, "type": "quad"},
-          {"x": 100, "y": 0},
+        points: [
+          { x: 0, y: 0, type: "quad" },
+          { x: 0, y: 100 },
+          { x: 100, y: 100, type: "quad" },
+          { x: 100, y: 0 },
         ],
-        "isClosed": false,
-      }
+        isClosed: false,
+      },
     ]);
-  })
+  });
 
   it("quad", () => {
     const p = new VarPackedPath(
       new VarArray(0, 0, 0, 100, 100, 100, 100, 0),
-      [VarPackedPath.ON_CURVE, VarPackedPath.OFF_CURVE_QUAD, VarPackedPath.OFF_CURVE_QUAD, VarPackedPath.OFF_CURVE_QUAD],
-      [{endPoint: 3, isClosed: true}],
+      [
+        VarPackedPath.ON_CURVE,
+        VarPackedPath.OFF_CURVE_QUAD,
+        VarPackedPath.OFF_CURVE_QUAD,
+        VarPackedPath.OFF_CURVE_QUAD,
+      ],
+      [{ endPoint: 3, isClosed: true }]
     );
 
     expect(p.unpackedContours()).to.deep.equal([
       {
-        "points": [
-          {"x": 0, "y": 0},
-          {"x": 0, "y": 100, "type": "quad"},
-          {"x": 100, "y": 100, "type": "quad"},
-          {"x": 100, "y": 0, "type": "quad"},
+        points: [
+          { x: 0, y: 0 },
+          { x: 0, y: 100, type: "quad" },
+          { x: 100, y: 100, type: "quad" },
+          { x: 100, y: 0, type: "quad" },
         ],
-        "isClosed": true,
-      }
+        isClosed: true,
+      },
     ]);
 
     const mp = new MockPath2D();
     p.drawToPath2d(mp);
-    expect(mp.items).to.deep.equal(
-      [
-        {"args": [0, 0], "op": "moveTo"},
-        {"args": [0, 100, 50, 100], "op": "quadraticCurveTo"},
-        {"args": [100, 100, 100, 50], "op": "quadraticCurveTo"},
-        {"args": [100, 0, 0, 0], "op": "quadraticCurveTo"},
-        {"args": [], "op": "closePath"},
-      ],
-    );
-  })
+    expect(mp.items).to.deep.equal([
+      { args: [0, 0], op: "moveTo" },
+      { args: [0, 100, 50, 100], op: "quadraticCurveTo" },
+      { args: [100, 100, 100, 50], op: "quadraticCurveTo" },
+      { args: [100, 0, 0, 0], op: "quadraticCurveTo" },
+      { args: [], op: "closePath" },
+    ]);
+  });
 
   it("quad blob", () => {
     const p = new VarPackedPath(
       new VarArray(0, 0, 0, 100, 100, 100, 100, 0),
-      [VarPackedPath.OFF_CURVE_QUAD, VarPackedPath.OFF_CURVE_QUAD, VarPackedPath.OFF_CURVE_QUAD, VarPackedPath.OFF_CURVE_QUAD],
-      [{endPoint: 3, isClosed: true}],
+      [
+        VarPackedPath.OFF_CURVE_QUAD,
+        VarPackedPath.OFF_CURVE_QUAD,
+        VarPackedPath.OFF_CURVE_QUAD,
+        VarPackedPath.OFF_CURVE_QUAD,
+      ],
+      [{ endPoint: 3, isClosed: true }]
     );
 
     expect(p.unpackedContours()).to.deep.equal([
       {
-        "points": [
-          {"x": 0, "y": 0, "type": "quad"},
-          {"x": 0, "y": 100, "type": "quad"},
-          {"x": 100, "y": 100, "type": "quad"},
-          {"x": 100, "y": 0, "type": "quad"},
+        points: [
+          { x: 0, y: 0, type: "quad" },
+          { x: 0, y: 100, type: "quad" },
+          { x: 100, y: 100, type: "quad" },
+          { x: 100, y: 0, type: "quad" },
         ],
-        "isClosed": true,
-      }
+        isClosed: true,
+      },
     ]);
 
     const mp = new MockPath2D();
     p.drawToPath2d(mp);
-    expect(mp.items).to.deep.equal(
-      [
-        {"args": [50, 0], "op": "moveTo"},
-        {"args": [0, 0, 0, 50], "op": "quadraticCurveTo"},
-        {"args": [0, 100, 50, 100], "op": "quadraticCurveTo"},
-        {"args": [100, 100, 100, 50], "op": "quadraticCurveTo"},
-        {"args": [100, 0, 50, 0], "op": "quadraticCurveTo"},
-        {"args": [], "op": "closePath"},
-      ],
-    );
-  })
+    expect(mp.items).to.deep.equal([
+      { args: [50, 0], op: "moveTo" },
+      { args: [0, 0, 0, 50], op: "quadraticCurveTo" },
+      { args: [0, 100, 50, 100], op: "quadraticCurveTo" },
+      { args: [100, 100, 100, 50], op: "quadraticCurveTo" },
+      { args: [100, 0, 50, 0], op: "quadraticCurveTo" },
+      { args: [], op: "closePath" },
+    ]);
+  });
 
   it("cubic", () => {
     const p = new VarPackedPath(
       new VarArray(0, 0, 0, 100, 100, 100, 100, 0),
-      [VarPackedPath.ON_CURVE, VarPackedPath.OFF_CURVE_CUBIC, VarPackedPath.OFF_CURVE_CUBIC, VarPackedPath.ON_CURVE],
-      [{endPoint: 3, isClosed: true}],
+      [
+        VarPackedPath.ON_CURVE,
+        VarPackedPath.OFF_CURVE_CUBIC,
+        VarPackedPath.OFF_CURVE_CUBIC,
+        VarPackedPath.ON_CURVE,
+      ],
+      [{ endPoint: 3, isClosed: true }]
     );
 
     expect(p.unpackedContours()).to.deep.equal([
       {
-        "points": [
-          {"x": 0, "y": 0},
-          {"x": 0, "y": 100, "type": "cubic"},
-          {"x": 100, "y": 100, "type": "cubic"},
-          {"x": 100, "y": 0},
+        points: [
+          { x: 0, y: 0 },
+          { x: 0, y: 100, type: "cubic" },
+          { x: 100, y: 100, type: "cubic" },
+          { x: 100, y: 0 },
         ],
-        "isClosed": true,
-      }
+        isClosed: true,
+      },
     ]);
 
     const mp = new MockPath2D();
     p.drawToPath2d(mp);
-    expect(mp.items).to.deep.equal(
-      [
-        {"args": [0, 0], "op": "moveTo"},
-        {"args": [0, 100, 100, 100, 100, 0], "op": "bezierCurveTo"},
-        {"args": [0, 0], "op": "lineTo"},
-        {"args": [], "op": "closePath"},
-      ],
-    );
-  })
+    expect(mp.items).to.deep.equal([
+      { args: [0, 0], op: "moveTo" },
+      { args: [0, 100, 100, 100, 100, 0], op: "bezierCurveTo" },
+      { args: [0, 0], op: "lineTo" },
+      { args: [], op: "closePath" },
+    ]);
+  });
 
   it("cubic 1 off-curve point", () => {
     const p = new VarPackedPath(
       new VarArray(0, 0, 0, 100, 100, 0),
       [VarPackedPath.ON_CURVE, VarPackedPath.OFF_CURVE_CUBIC, VarPackedPath.ON_CURVE],
-      [{endPoint: 2, isClosed: true}],
+      [{ endPoint: 2, isClosed: true }]
     );
     expect(p._checkIntegrity()).to.equal(false);
     const mp = new MockPath2D();
     p.drawToPath2d(mp);
-    expect(mp.items).to.deep.equal(
-      [
-        {"args": [0, 0], "op": "moveTo"},
-        {"args": [0, 100, 100, 0], "op": "quadraticCurveTo"},
-        {"args": [0, 0], "op": "lineTo"},
-        {"args": [], "op": "closePath"},
-      ],
-    );
-  })
+    expect(mp.items).to.deep.equal([
+      { args: [0, 0], op: "moveTo" },
+      { args: [0, 100, 100, 0], op: "quadraticCurveTo" },
+      { args: [0, 0], op: "lineTo" },
+      { args: [], op: "closePath" },
+    ]);
+  });
 
   it("cubic 3 off-curve points", () => {
     const p = new VarPackedPath(
       new VarArray(0, 0, 0, 100, 55, 55, 100, 100, 100, 0),
-      [VarPackedPath.ON_CURVE, VarPackedPath.OFF_CURVE_CUBIC, VarPackedPath.OFF_CURVE_CUBIC, VarPackedPath.OFF_CURVE_CUBIC, VarPackedPath.ON_CURVE],
-      [{endPoint: 4, isClosed: true}],
+      [
+        VarPackedPath.ON_CURVE,
+        VarPackedPath.OFF_CURVE_CUBIC,
+        VarPackedPath.OFF_CURVE_CUBIC,
+        VarPackedPath.OFF_CURVE_CUBIC,
+        VarPackedPath.ON_CURVE,
+      ],
+      [{ endPoint: 4, isClosed: true }]
     );
     expect(p._checkIntegrity()).to.equal(false);
     const mp = new MockPath2D();
     p.drawToPath2d(mp);
-    expect(mp.items).to.deep.equal(
-      [
-        {"args": [0, 0], "op": "moveTo"},
-        {"args": [0, 100, 100, 100, 100, 0], "op": "bezierCurveTo"},
-        {"args": [0, 0], "op": "lineTo"},
-        {"args": [], "op": "closePath"},
-      ],
-    );
-  })
+    expect(mp.items).to.deep.equal([
+      { args: [0, 0], op: "moveTo" },
+      { args: [0, 100, 100, 100, 100, 0], op: "bezierCurveTo" },
+      { args: [0, 0], op: "lineTo" },
+      { args: [], op: "closePath" },
+    ]);
+  });
 
   it("add", () => {
     const p1 = new VarPackedPath(
       new VarArray(0, 0, 0, 100, 100, 100, 100, 0),
-      [VarPackedPath.ON_CURVE, VarPackedPath.OFF_CURVE_CUBIC, VarPackedPath.OFF_CURVE_CUBIC, VarPackedPath.ON_CURVE],
-      [{endPoint: 3, isClosed: true}],
+      [
+        VarPackedPath.ON_CURVE,
+        VarPackedPath.OFF_CURVE_CUBIC,
+        VarPackedPath.OFF_CURVE_CUBIC,
+        VarPackedPath.ON_CURVE,
+      ],
+      [{ endPoint: 3, isClosed: true }]
     );
     const p2 = p1.copy();
     const p3 = p1.addItemwise(p2);
 
     expect(p3.unpackedContours()).to.deep.equal([
       {
-        "points": [
-          {"x": 0, "y": 0},
-          {"x": 0, "y": 200, "type": "cubic"},
-          {"x": 200, "y": 200, "type": "cubic"},
-          {"x": 200, "y": 0},
+        points: [
+          { x: 0, y: 0 },
+          { x: 0, y: 200, type: "cubic" },
+          { x: 200, y: 200, type: "cubic" },
+          { x: 200, y: 0 },
         ],
-        "isClosed": true,
-      }
+        isClosed: true,
+      },
     ]);
-  })
+  });
 
   it("sub", () => {
     const p1 = new VarPackedPath(
       new VarArray(0, 0, 0, 100, 100, 100, 100, 0),
-      [VarPackedPath.ON_CURVE, VarPackedPath.OFF_CURVE_CUBIC, VarPackedPath.OFF_CURVE_CUBIC, VarPackedPath.ON_CURVE],
-      [{endPoint: 3, isClosed: true}],
+      [
+        VarPackedPath.ON_CURVE,
+        VarPackedPath.OFF_CURVE_CUBIC,
+        VarPackedPath.OFF_CURVE_CUBIC,
+        VarPackedPath.ON_CURVE,
+      ],
+      [{ endPoint: 3, isClosed: true }]
     );
     const p2 = p1.copy();
     const p3 = p1.subItemwise(p2);
 
     expect(p3.unpackedContours()).to.deep.equal([
       {
-        "points": [
-          {"x": 0, "y": 0},
-          {"x": 0, "y": 0, "type": "cubic"},
-          {"x": 0, "y": 0, "type": "cubic"},
-          {"x": 0, "y": 0},
+        points: [
+          { x: 0, y: 0 },
+          { x: 0, y: 0, type: "cubic" },
+          { x: 0, y: 0, type: "cubic" },
+          { x: 0, y: 0 },
         ],
-        "isClosed": true,
-      }
+        isClosed: true,
+      },
     ]);
-  })
+  });
 
   it("mul", () => {
     const p = new VarPackedPath(
       new VarArray(0, 0, 0, 100, 100, 100, 100, 0),
-      [VarPackedPath.ON_CURVE, VarPackedPath.OFF_CURVE_CUBIC, VarPackedPath.OFF_CURVE_CUBIC, VarPackedPath.ON_CURVE],
-      [{endPoint: 3, isClosed: true}],
+      [
+        VarPackedPath.ON_CURVE,
+        VarPackedPath.OFF_CURVE_CUBIC,
+        VarPackedPath.OFF_CURVE_CUBIC,
+        VarPackedPath.ON_CURVE,
+      ],
+      [{ endPoint: 3, isClosed: true }]
     );
     const mp = new MockPath2D();
     const p2 = p.mulScalar(2);
 
     expect(p2.unpackedContours()).to.deep.equal([
       {
-        "points": [
-          {"x": 0, "y": 0},
-          {"x": 0, "y": 200, "type": "cubic"},
-          {"x": 200, "y": 200, "type": "cubic"},
-          {"x": 200, "y": 0},
+        points: [
+          { x: 0, y: 0 },
+          { x: 0, y: 200, type: "cubic" },
+          { x: 200, y: 200, type: "cubic" },
+          { x: 200, y: 0 },
         ],
-        "isClosed": true,
-      }
+        isClosed: true,
+      },
     ]);
-  })
+  });
 
   it("pen-ish methods", () => {
     const p = new VarPackedPath();
@@ -361,51 +433,57 @@ describe("VarPackedPath Tests", () => {
     p.quadraticCurveTo(130, 70, 130, 30, 100, 0);
     p.closePath();
     p.drawToPath2d(mp);
-    expect(mp.items).to.deep.equal(
-      [
-        {"args": [0, 0], "op": "moveTo"},
-        {"args": [0, 100], "op": "lineTo"},
-        {"args": [30, 130, 70, 130, 100, 100], "op": "bezierCurveTo"},
-        {"args": [130, 70, 130, 50], "op": "quadraticCurveTo"},
-        {"args": [130, 30, 100, 0], "op": "quadraticCurveTo"},
-        {"args": [0, 0], "op": "lineTo"},
-        {"args": [], "op": "closePath"},
-      ],
-    );
-  })
+    expect(mp.items).to.deep.equal([
+      { args: [0, 0], op: "moveTo" },
+      { args: [0, 100], op: "lineTo" },
+      { args: [30, 130, 70, 130, 100, 100], op: "bezierCurveTo" },
+      { args: [130, 70, 130, 50], op: "quadraticCurveTo" },
+      { args: [130, 30, 100, 0], op: "quadraticCurveTo" },
+      { args: [0, 0], op: "lineTo" },
+      { args: [], op: "closePath" },
+    ]);
+  });
 
   it("iterPoints", () => {
     const p = new VarPackedPath(
       new VarArray(0, 0, 0, 100, 100, 100, 100, 0),
-      [VarPackedPath.ON_CURVE, VarPackedPath.OFF_CURVE_CUBIC, VarPackedPath.OFF_CURVE_CUBIC, VarPackedPath.ON_CURVE],
-      [{endPoint: 3, isClosed: true}],
+      [
+        VarPackedPath.ON_CURVE,
+        VarPackedPath.OFF_CURVE_CUBIC,
+        VarPackedPath.OFF_CURVE_CUBIC,
+        VarPackedPath.ON_CURVE,
+      ],
+      [{ endPoint: 3, isClosed: true }]
     );
     const points = [];
     for (const pt of p.iterPoints()) {
-      points.push(pt)
+      points.push(pt);
     }
-    expect(points).to.deep.equal(
-      [
-        {x: 0, y: 0},
-        {x: 0, y: 100, type: "cubic"},
-        {x: 100, y: 100, type: "cubic"},
-        {x: 100, y: 0},
-      ],
-    );
-  })
+    expect(points).to.deep.equal([
+      { x: 0, y: 0 },
+      { x: 0, y: 100, type: "cubic" },
+      { x: 100, y: 100, type: "cubic" },
+      { x: 100, y: 0 },
+    ]);
+  });
 
   const iterPointsInRectTestData = [
-    [{"xMin": -100, "yMin": -100, "xMax": 200, "yMax": 200}, [0, 1, 2, 3]],
-    [{"xMin": 50, "yMin": -100, "xMax": 200, "yMax": 200}, [2, 3]],
-    [{"xMin": -100, "yMin": 50, "xMax": 200, "yMax": 200}, [1, 2]],
-    [{"xMin": 50, "yMin": 50, "xMax": 200, "yMax": 200}, [2]],
-    [{"xMin": 150, "yMin": 150, "xMax": 200, "yMax": 200}, []],
-  ]
+    [{ xMin: -100, yMin: -100, xMax: 200, yMax: 200 }, [0, 1, 2, 3]],
+    [{ xMin: 50, yMin: -100, xMax: 200, yMax: 200 }, [2, 3]],
+    [{ xMin: -100, yMin: 50, xMax: 200, yMax: 200 }, [1, 2]],
+    [{ xMin: 50, yMin: 50, xMax: 200, yMax: 200 }, [2]],
+    [{ xMin: 150, yMin: 150, xMax: 200, yMax: 200 }, []],
+  ];
 
   const iterPointsInRectTestPath = new VarPackedPath(
     new VarArray(0, 0, 0, 100, 100, 100, 100, 0),
-    [VarPackedPath.ON_CURVE, VarPackedPath.OFF_CURVE_CUBIC, VarPackedPath.OFF_CURVE_CUBIC, VarPackedPath.ON_CURVE],
-    [{endPoint: 3, isClosed: true}],
+    [
+      VarPackedPath.ON_CURVE,
+      VarPackedPath.OFF_CURVE_CUBIC,
+      VarPackedPath.OFF_CURVE_CUBIC,
+      VarPackedPath.ON_CURVE,
+    ],
+    [{ endPoint: 3, isClosed: true }]
   );
 
   const iterPointsInRectTestPoints = Array.from(iterPointsInRectTestPath.iterPoints());
@@ -429,14 +507,12 @@ describe("VarPackedPath Tests", () => {
     const p = simpleTestPath(false);
     const mp = new MockPath2D();
     p.transformed(t).drawToPath2d(mp);
-    expect(mp.items).to.deep.equal(
-      [
-        {"args": [0, 0], "op": "moveTo"},
-        {"args": [0, 200], "op": "lineTo"},
-        {"args": [200, 200], "op": "lineTo"},
-        {"args": [200, 0], "op": "lineTo"},
-      ],
-    );
+    expect(mp.items).to.deep.equal([
+      { args: [0, 0], op: "moveTo" },
+      { args: [0, 200], op: "lineTo" },
+      { args: [200, 200], op: "lineTo" },
+      { args: [200, 0], op: "lineTo" },
+    ]);
   });
 
   it("concat", () => {
@@ -445,22 +521,22 @@ describe("VarPackedPath Tests", () => {
     const p3 = p1.concat(p2);
     expect(p3.unpackedContours()).to.deep.equal([
       {
-        "points": [
-          {"x": 0, "y": 0},
-          {"x": 0, "y": 100},
-          {"x": 100, "y": 100},
-          {"x": 100, "y": 0},
+        points: [
+          { x: 0, y: 0 },
+          { x: 0, y: 100 },
+          { x: 100, y: 100 },
+          { x: 100, y: 0 },
         ],
-        "isClosed": true,
+        isClosed: true,
       },
       {
-        "points": [
-          {"x": 0, "y": 0},
-          {"x": 0, "y": 100},
-          {"x": 100, "y": 100},
-          {"x": 100, "y": 0},
+        points: [
+          { x: 0, y: 0 },
+          { x: 0, y: 100 },
+          { x: 100, y: 100 },
+          { x: 100, y: 0 },
         ],
-        "isClosed": true,
+        isClosed: true,
       },
     ]);
   });
@@ -468,21 +544,21 @@ describe("VarPackedPath Tests", () => {
   it("getPoint", () => {
     const p = simpleTestPath();
     expect(p.getPoint(-1)).to.deep.equal(undefined);
-    expect(p.getPoint(0)).to.deep.equal({"x": 0, "y": 0});
-    expect(p.getPoint(3)).to.deep.equal({"x": 100, "y": 0});
+    expect(p.getPoint(0)).to.deep.equal({ x: 0, y: 0 });
+    expect(p.getPoint(3)).to.deep.equal({ x: 100, y: 0 });
     expect(p.getPoint(4)).to.deep.equal(undefined);
   });
 
   it("getContourIndex", () => {
     const p = new VarPackedPath(
-      new VarArray(),  // dummy
-      [],  // dummy
+      new VarArray(), // dummy
+      [], // dummy
       [
-        {endPoint: 3, isClosed: true},
-        {endPoint: 13, isClosed: true},
-        {endPoint: 15, isClosed: true},
-        {endPoint: 20, isClosed: true},
-      ],
+        { endPoint: 3, isClosed: true },
+        { endPoint: 13, isClosed: true },
+        { endPoint: 15, isClosed: true },
+        { endPoint: 20, isClosed: true },
+      ]
     );
     expect(p.getContourIndex(-1)).to.equal(undefined);
     expect(p.getContourIndex(0)).to.equal(0);
@@ -504,11 +580,13 @@ describe("VarPackedPath Tests", () => {
     expect(u.isClosed).to.equal(true);
     const pts = u.points;
     expect(pts.length).to.equal(4);
-    expect(pts[0]).to.deep.equal({"x": 0, "y": 0, "smooth": true});
-    expect(pts[3]).to.deep.equal({"x": 100, "y": 0});
-    expect(pts[3]).to.deep.equal({"x": 100, "y": 0});
+    expect(pts[0]).to.deep.equal({ x: 0, y: 0, smooth: true });
+    expect(pts[3]).to.deep.equal({ x: 100, y: 0 });
+    expect(pts[3]).to.deep.equal({ x: 100, y: 0 });
     expect(p.getUnpackedContour(-1).points.length).to.equal(4);
-    expect(() => {p.getUnpackedContour(1)}).to.throw("contourIndex out of bounds: 1");
+    expect(() => {
+      p.getUnpackedContour(1);
+    }).to.throw("contourIndex out of bounds: 1");
   });
 
   it("getControlBounds", () => {
@@ -519,8 +597,18 @@ describe("VarPackedPath Tests", () => {
     p.closePath();
     const t = new Transform().scale(1.5, 2);
     const p2 = p.transformed(t);
-    expect(p.getControlBounds()).to.deep.equal({"xMin": 0, "yMin": 0, "xMax": 100, "yMax": 100});
-    expect(p2.getControlBounds()).to.deep.equal({"xMin": 0, "yMin": 0, "xMax": 150, "yMax": 200});
+    expect(p.getControlBounds()).to.deep.equal({
+      xMin: 0,
+      yMin: 0,
+      xMax: 100,
+      yMax: 100,
+    });
+    expect(p2.getControlBounds()).to.deep.equal({
+      xMin: 0,
+      yMin: 0,
+      xMax: 150,
+      yMax: 200,
+    });
   });
 
   it("empty getControlBounds", () => {
@@ -542,14 +630,14 @@ describe("VarPackedPath Tests", () => {
     const mp = new MockPath2D();
     p2.drawToPath2d(mp);
     expect(mp.items).to.deep.equal([
-      {"op": "moveTo", "args": [100, 100]},
-      {"op": "lineTo", "args": [100, 0]},
-      {"op": "bezierCurveTo", "args": [0, 0, 0, 100, 100, 100]},
-      {"op": "closePath", "args": []},
-      {"op": "moveTo", "args": [0, 0]},
-      {"op": "bezierCurveTo", "args": [0, 100, 100, 100, 100, 0]},
-      {"op": "lineTo", "args": [0, 0]},
-      {"op": "closePath", "args": []},
+      { op: "moveTo", args: [100, 100] },
+      { op: "lineTo", args: [100, 0] },
+      { op: "bezierCurveTo", args: [0, 0, 0, 100, 100, 100] },
+      { op: "closePath", args: [] },
+      { op: "moveTo", args: [0, 0] },
+      { op: "bezierCurveTo", args: [0, 100, 100, 100, 100, 0] },
+      { op: "lineTo", args: [0, 0] },
+      { op: "closePath", args: [] },
     ]);
   });
 
@@ -557,78 +645,78 @@ describe("VarPackedPath Tests", () => {
     const p1 = simpleTestPath();
     const mp = new MockPath2D();
     p1.setPointPosition(1, 23, 45);
-    p1.setPoint(2, {"x": 65, "y": 43, "type": POINT_TYPE_OFF_CURVE_QUAD});
+    p1.setPoint(2, { x: 65, y: 43, type: POINT_TYPE_OFF_CURVE_QUAD });
     p1.drawToPath2d(mp);
     expect(mp.items).to.deep.equal([
-      {"args": [0, 0], "op": "moveTo"},
-      {"args": [23, 45], "op": "lineTo"},
-      {"args": [65, 43, 100, 0], "op": "quadraticCurveTo"},
-      {"args": [0, 0], "op": "lineTo"},
-      {"args": [], "op": "closePath"},
+      { args: [0, 0], op: "moveTo" },
+      { args: [23, 45], op: "lineTo" },
+      { args: [65, 43, 100, 0], op: "quadraticCurveTo" },
+      { args: [0, 0], op: "lineTo" },
+      { args: [], op: "closePath" },
     ]);
   });
 
   it("test insertPoint 0", () => {
     const p1 = simpleTestPath();
-    p1.insertPoint(-1, 0, {"x": 12, "y": 13});
+    p1.insertPoint(-1, 0, { x: 12, y: 13 });
     const mp = new MockPath2D();
     p1.drawToPath2d(mp);
     expect(mp.items).to.deep.equal([
-      {"args": [12, 13], "op": "moveTo"},
-      {"args": [0, 0], "op": "lineTo"},
-      {"args": [0, 100], "op": "lineTo"},
-      {"args": [100, 100], "op": "lineTo"},
-      {"args": [100, 0], "op": "lineTo"},
-      {"args": [12, 13], "op": "lineTo"},
-      {"args": [], "op": "closePath"},
+      { args: [12, 13], op: "moveTo" },
+      { args: [0, 0], op: "lineTo" },
+      { args: [0, 100], op: "lineTo" },
+      { args: [100, 100], op: "lineTo" },
+      { args: [100, 0], op: "lineTo" },
+      { args: [12, 13], op: "lineTo" },
+      { args: [], op: "closePath" },
     ]);
   });
 
   it("test insertPoint 1", () => {
     const p1 = simpleTestPath();
-    p1.insertPoint(-1, 1, {"x": 12, "y": 13});
+    p1.insertPoint(-1, 1, { x: 12, y: 13 });
     const mp = new MockPath2D();
     p1.drawToPath2d(mp);
     expect(mp.items).to.deep.equal([
-      {"args": [0, 0], "op": "moveTo"},
-      {"args": [12, 13], "op": "lineTo"},
-      {"args": [0, 100], "op": "lineTo"},
-      {"args": [100, 100], "op": "lineTo"},
-      {"args": [100, 0], "op": "lineTo"},
-      {"args": [0, 0], "op": "lineTo"},
-      {"args": [], "op": "closePath"},
+      { args: [0, 0], op: "moveTo" },
+      { args: [12, 13], op: "lineTo" },
+      { args: [0, 100], op: "lineTo" },
+      { args: [100, 100], op: "lineTo" },
+      { args: [100, 0], op: "lineTo" },
+      { args: [0, 0], op: "lineTo" },
+      { args: [], op: "closePath" },
     ]);
   });
 
   it("test appendPoint", () => {
     const p1 = simpleTestPath();
-    p1.appendPoint(-1, {"x": 12, "y": 13});
+    p1.appendPoint(-1, { x: 12, y: 13 });
     const mp = new MockPath2D();
     p1.drawToPath2d(mp);
     expect(mp.items).to.deep.equal([
-      {"args": [0, 0], "op": "moveTo"},
-      {"args": [0, 100], "op": "lineTo"},
-      {"args": [100, 100], "op": "lineTo"},
-      {"args": [100, 0], "op": "lineTo"},
-      {"args": [12, 13], "op": "lineTo"},
-      {"args": [0, 0], "op": "lineTo"},
-      {"args": [], "op": "closePath"},
+      { args: [0, 0], op: "moveTo" },
+      { args: [0, 100], op: "lineTo" },
+      { args: [100, 100], op: "lineTo" },
+      { args: [100, 0], op: "lineTo" },
+      { args: [12, 13], op: "lineTo" },
+      { args: [0, 0], op: "lineTo" },
+      { args: [], op: "closePath" },
     ]);
   });
 
   it("test appendPoint via insertPoint", () => {
     const p1 = simpleTestPath();
-    p1.insertPoint(-1, 4, {"x": 12, "y": 13});
+    p1.insertPoint(-1, 4, { x: 12, y: 13 });
     const mp = new MockPath2D();
     p1.drawToPath2d(mp);
     expect(mp.items).to.deep.equal([
-      {"args": [0, 0], "op": "moveTo"},
-      {"args": [0, 100], "op": "lineTo"},
-      {"args": [100, 100], "op": "lineTo"},
-      {"args": [100, 0], "op": "lineTo"},
-      {"args": [12, 13], "op": "lineTo"},
-      {"args": [0, 0], "op": "lineTo"},
-      {"args": [], "op": "closePath"},
+      { args: [0, 0], op: "moveTo" },
+      { args: [0, 100], op: "lineTo" },
+      { args: [100, 100], op: "lineTo" },
+      { args: [100, 0], op: "lineTo" },
+      { args: [12, 13], op: "lineTo" },
+      { args: [0, 0], op: "lineTo" },
+      { args: [], op: "closePath" },
     ]);
   });
 
@@ -637,29 +725,31 @@ describe("VarPackedPath Tests", () => {
     const t = new Transform().translate(10, 10).scale(2);
     const p2 = simpleTestPath().transformed(t);
     const p3 = p1.concat(p2);
-    p3.appendPoint(1, {"x": 12, "y": 13});
+    p3.appendPoint(1, { x: 12, y: 13 });
     const mp = new MockPath2D();
     p3.drawToPath2d(mp);
     expect(mp.items).to.deep.equal([
-      {"args": [0, 0], "op": "moveTo"},
-      {"args": [0, 100], "op": "lineTo"},
-      {"args": [100, 100], "op": "lineTo"},
-      {"args": [100, 0], "op": "lineTo"},
-      {"args": [0, 0], "op": "lineTo"},
-      {"args": [], "op": "closePath"},
-      {"args": [10, 10], "op": "moveTo"},
-      {"args": [10, 210], "op": "lineTo"},
-      {"args": [210, 210], "op": "lineTo"},
-      {"args": [210, 10], "op": "lineTo"},
-      {"args": [12, 13], "op": "lineTo"},
-      {"args": [10, 10], "op": "lineTo"},
-      {"args": [], "op": "closePath"},
+      { args: [0, 0], op: "moveTo" },
+      { args: [0, 100], op: "lineTo" },
+      { args: [100, 100], op: "lineTo" },
+      { args: [100, 0], op: "lineTo" },
+      { args: [0, 0], op: "lineTo" },
+      { args: [], op: "closePath" },
+      { args: [10, 10], op: "moveTo" },
+      { args: [10, 210], op: "lineTo" },
+      { args: [210, 210], op: "lineTo" },
+      { args: [210, 10], op: "lineTo" },
+      { args: [12, 13], op: "lineTo" },
+      { args: [10, 10], op: "lineTo" },
+      { args: [], op: "closePath" },
     ]);
   });
 
   it("test appendPoint index error", () => {
     const p1 = simpleTestPath();
-    expect(() => {p1.appendPoint(1, {"x": 12, "y": 13})}).to.throw("contourIndex out of bounds: 1");
+    expect(() => {
+      p1.appendPoint(1, { x: 12, y: 13 });
+    }).to.throw("contourIndex out of bounds: 1");
   });
 
   it("test deletePoint", () => {
@@ -669,17 +759,21 @@ describe("VarPackedPath Tests", () => {
     const mp = new MockPath2D();
     p1.drawToPath2d(mp);
     expect(mp.items).to.deep.equal([
-      {"args": [0, 0], "op": "moveTo"},
-      {"args": [100, 100], "op": "lineTo"},
-      {"args": [100, 0, 0, 0], "op": "quadraticCurveTo"},
-      {"args": [], "op": "closePath"},
+      { args: [0, 0], op: "moveTo" },
+      { args: [100, 100], op: "lineTo" },
+      { args: [100, 0, 0, 0], op: "quadraticCurveTo" },
+      { args: [], op: "closePath" },
     ]);
   });
 
   it("test deletePoint index error", () => {
     const p1 = simpleTestPath();
-    expect(() => {p1.deletePoint(0, 4)}).to.throw("contourPointIndex out of bounds: 4");
-    expect(() => {p1.deletePoint(0, 5)}).to.throw("contourPointIndex out of bounds: 5");
+    expect(() => {
+      p1.deletePoint(0, 4);
+    }).to.throw("contourPointIndex out of bounds: 4");
+    expect(() => {
+      p1.deletePoint(0, 5);
+    }).to.throw("contourPointIndex out of bounds: 5");
   });
 
   it("test deleteContour", () => {
@@ -690,25 +784,29 @@ describe("VarPackedPath Tests", () => {
 
     expect(p1.unpackedContours()).to.deep.equal([
       {
-        "points": [
-          {"x": 0, "y": 1},
-          {"x": 2, "y": 3, "type": "quad"},
-          {"x": 4, "y": 5},
+        points: [
+          { x: 0, y: 1 },
+          { x: 2, y: 3, type: "quad" },
+          { x: 4, y: 5 },
         ],
-        "isClosed": true,
+        isClosed: true,
       },
       {
-        "points": [{"x": 6, "y": 7}, {"x": 8, "y": 9}, {"x": 10, "y": 11}],
-        "isClosed": true,
+        points: [
+          { x: 6, y: 7 },
+          { x: 8, y: 9 },
+          { x: 10, y: 11 },
+        ],
+        isClosed: true,
       },
       {
-        "points": [
-          {"x": 12, "y": 13},
-          {"x": 14, "y": 15, "type": "quad"},
-          {"x": 16, "y": 17, "type": "quad"},
-          {"x": 18, "y": 19},
+        points: [
+          { x: 12, y: 13 },
+          { x: 14, y: 15, type: "quad" },
+          { x: 16, y: 17, type: "quad" },
+          { x: 18, y: 19 },
         ],
-        "isClosed": true,
+        isClosed: true,
       },
     ]);
 
@@ -717,17 +815,21 @@ describe("VarPackedPath Tests", () => {
     expect(p1._checkIntegrity()).to.equal(false);
     expect(p1.unpackedContours()).to.deep.equal([
       {
-        "points": [{"x": 6, "y": 7}, {"x": 8, "y": 9}, {"x": 10, "y": 11}],
-        "isClosed": true,
+        points: [
+          { x: 6, y: 7 },
+          { x: 8, y: 9 },
+          { x: 10, y: 11 },
+        ],
+        isClosed: true,
       },
       {
-        "points": [
-          {"x": 12, "y": 13},
-          {"x": 14, "y": 15, "type": "quad"},
-          {"x": 16, "y": 17, "type": "quad"},
-          {"x": 18, "y": 19},
+        points: [
+          { x: 12, y: 13 },
+          { x: 14, y: 15, type: "quad" },
+          { x: 16, y: 17, type: "quad" },
+          { x: 18, y: 19 },
         ],
-        "isClosed": true,
+        isClosed: true,
       },
     ]);
 
@@ -737,21 +839,21 @@ describe("VarPackedPath Tests", () => {
 
     expect(p1.unpackedContours()).to.deep.equal([
       {
-        "points": [
-          {"x": 0, "y": 1},
-          {"x": 2, "y": 3, "type": "quad"},
-          {"x": 4, "y": 5},
+        points: [
+          { x: 0, y: 1 },
+          { x: 2, y: 3, type: "quad" },
+          { x: 4, y: 5 },
         ],
-        "isClosed": true,
+        isClosed: true,
       },
       {
-        "points": [
-          {"x": 12, "y": 13},
-          {"x": 14, "y": 15, "type": "quad"},
-          {"x": 16, "y": 17, "type": "quad"},
-          {"x": 18, "y": 19},
+        points: [
+          { x: 12, y: 13 },
+          { x: 14, y: 15, type: "quad" },
+          { x: 16, y: 17, type: "quad" },
+          { x: 18, y: 19 },
         ],
-        "isClosed": true,
+        isClosed: true,
       },
     ]);
 
@@ -760,16 +862,20 @@ describe("VarPackedPath Tests", () => {
     expect(p1._checkIntegrity()).to.equal(false);
     expect(p1.unpackedContours()).to.deep.equal([
       {
-        "points": [
-          {"x": 0, "y": 1},
-          {"x": 2, "y": 3, "type": "quad"},
-          {"x": 4, "y": 5},
+        points: [
+          { x: 0, y: 1 },
+          { x: 2, y: 3, type: "quad" },
+          { x: 4, y: 5 },
         ],
-        "isClosed": true,
+        isClosed: true,
       },
       {
-        "points": [{"x": 6, "y": 7}, {"x": 8, "y": 9}, {"x": 10, "y": 11}],
-        "isClosed": true,
+        points: [
+          { x: 6, y: 7 },
+          { x: 8, y: 9 },
+          { x: 10, y: 11 },
+        ],
+        isClosed: true,
       },
     ]);
 
@@ -779,8 +885,12 @@ describe("VarPackedPath Tests", () => {
     expect(p1._checkIntegrity()).to.equal(false);
     expect(p1.unpackedContours()).to.deep.equal([
       {
-        "points": [{"x": 6, "y": 7}, {"x": 8, "y": 9}, {"x": 10, "y": 11}],
-        "isClosed": true,
+        points: [
+          { x: 6, y: 7 },
+          { x: 8, y: 9 },
+          { x: 10, y: 11 },
+        ],
+        isClosed: true,
       },
     ]);
 
@@ -791,34 +901,45 @@ describe("VarPackedPath Tests", () => {
     expect(p1._checkIntegrity()).to.equal(false);
     expect(p1.unpackedContours()).to.deep.equal([]);
     expect(p1.numContours).to.equal(0);
-
   });
 
   it("test getContour", () => {
     const p = complexTestPath();
-    expect(p.getContour(0)).to.deep.equal(
-      {"coordinates":[0,1,2,3,4,5],"pointTypes":[0,1,0],"isClosed":true}
-    );
-    expect(p.getContour(1)).to.deep.equal(
-      {"coordinates":[6,7,8,9,10,11],"pointTypes":[0,0,0],"isClosed":true}
-    );
-    expect(p.getContour(2)).to.deep.equal(
-      {"coordinates":[12,13,14,15,16,17,18,19],"pointTypes":[0,1,1,0],"isClosed":true}
-    );
+    expect(p.getContour(0)).to.deep.equal({
+      coordinates: [0, 1, 2, 3, 4, 5],
+      pointTypes: [0, 1, 0],
+      isClosed: true,
+    });
+    expect(p.getContour(1)).to.deep.equal({
+      coordinates: [6, 7, 8, 9, 10, 11],
+      pointTypes: [0, 0, 0],
+      isClosed: true,
+    });
+    expect(p.getContour(2)).to.deep.equal({
+      coordinates: [12, 13, 14, 15, 16, 17, 18, 19],
+      pointTypes: [0, 1, 1, 0],
+      isClosed: true,
+    });
   });
 
   it("test setContour", () => {
     const p = complexTestPath();
     p.setContour(1, p.getContour(0));
-    expect(p.getContour(0)).to.deep.equal(
-      {"coordinates":[0,1,2,3,4,5],"pointTypes":[0,1,0],"isClosed":true}
-    );
-    expect(p.getContour(1)).to.deep.equal(
-      {"coordinates":[0,1,2,3,4,5],"pointTypes":[0,1,0],"isClosed":true}
-    );
-    expect(p.getContour(2)).to.deep.equal(
-      {"coordinates":[12,13,14,15,16,17,18,19],"pointTypes":[0,1,1,0],"isClosed":true}
-    );
+    expect(p.getContour(0)).to.deep.equal({
+      coordinates: [0, 1, 2, 3, 4, 5],
+      pointTypes: [0, 1, 0],
+      isClosed: true,
+    });
+    expect(p.getContour(1)).to.deep.equal({
+      coordinates: [0, 1, 2, 3, 4, 5],
+      pointTypes: [0, 1, 0],
+      isClosed: true,
+    });
+    expect(p.getContour(2)).to.deep.equal({
+      coordinates: [12, 13, 14, 15, 16, 17, 18, 19],
+      pointTypes: [0, 1, 1, 0],
+      isClosed: true,
+    });
     expect(p.numContours).to.equal(3);
     expect(p._checkIntegrity()).to.equal(false);
   });
@@ -826,18 +947,26 @@ describe("VarPackedPath Tests", () => {
   it("test insertContour", () => {
     const p = complexTestPath();
     p.insertContour(0, p.getContour(-1));
-    expect(p.getContour(0)).to.deep.equal(
-      {"coordinates":[12,13,14,15,16,17,18,19],"pointTypes":[0,1,1,0],"isClosed":true}
-    );
-    expect(p.getContour(1)).to.deep.equal(
-      {"coordinates":[0,1,2,3,4,5],"pointTypes":[0,1,0],"isClosed":true}
-    );
-    expect(p.getContour(2)).to.deep.equal(
-      {"coordinates":[6,7,8,9,10,11],"pointTypes":[0,0,0],"isClosed":true}
-    );
-    expect(p.getContour(3)).to.deep.equal(
-      {"coordinates":[12,13,14,15,16,17,18,19],"pointTypes":[0,1,1,0],"isClosed":true}
-    );
+    expect(p.getContour(0)).to.deep.equal({
+      coordinates: [12, 13, 14, 15, 16, 17, 18, 19],
+      pointTypes: [0, 1, 1, 0],
+      isClosed: true,
+    });
+    expect(p.getContour(1)).to.deep.equal({
+      coordinates: [0, 1, 2, 3, 4, 5],
+      pointTypes: [0, 1, 0],
+      isClosed: true,
+    });
+    expect(p.getContour(2)).to.deep.equal({
+      coordinates: [6, 7, 8, 9, 10, 11],
+      pointTypes: [0, 0, 0],
+      isClosed: true,
+    });
+    expect(p.getContour(3)).to.deep.equal({
+      coordinates: [12, 13, 14, 15, 16, 17, 18, 19],
+      pointTypes: [0, 1, 1, 0],
+      isClosed: true,
+    });
     expect(p.numContours).to.equal(4);
     expect(p._checkIntegrity()).to.equal(false);
   });
@@ -845,18 +974,26 @@ describe("VarPackedPath Tests", () => {
   it("test insertContour 1", () => {
     const p = complexTestPath();
     p.insertContour(1, p.getContour(-1));
-    expect(p.getContour(0)).to.deep.equal(
-      {"coordinates":[0,1,2,3,4,5],"pointTypes":[0,1,0],"isClosed":true}
-    );
-    expect(p.getContour(1)).to.deep.equal(
-      {"coordinates":[12,13,14,15,16,17,18,19],"pointTypes":[0,1,1,0],"isClosed":true}
-    );
-    expect(p.getContour(2)).to.deep.equal(
-      {"coordinates":[6,7,8,9,10,11],"pointTypes":[0,0,0],"isClosed":true}
-    );
-    expect(p.getContour(3)).to.deep.equal(
-      {"coordinates":[12,13,14,15,16,17,18,19],"pointTypes":[0,1,1,0],"isClosed":true}
-    );
+    expect(p.getContour(0)).to.deep.equal({
+      coordinates: [0, 1, 2, 3, 4, 5],
+      pointTypes: [0, 1, 0],
+      isClosed: true,
+    });
+    expect(p.getContour(1)).to.deep.equal({
+      coordinates: [12, 13, 14, 15, 16, 17, 18, 19],
+      pointTypes: [0, 1, 1, 0],
+      isClosed: true,
+    });
+    expect(p.getContour(2)).to.deep.equal({
+      coordinates: [6, 7, 8, 9, 10, 11],
+      pointTypes: [0, 0, 0],
+      isClosed: true,
+    });
+    expect(p.getContour(3)).to.deep.equal({
+      coordinates: [12, 13, 14, 15, 16, 17, 18, 19],
+      pointTypes: [0, 1, 1, 0],
+      isClosed: true,
+    });
     expect(p.numContours).to.equal(4);
     expect(p._checkIntegrity()).to.equal(false);
   });
@@ -864,18 +1001,26 @@ describe("VarPackedPath Tests", () => {
   it("test appendContour", () => {
     const p = complexTestPath();
     p.appendContour(p.getContour(1));
-    expect(p.getContour(0)).to.deep.equal(
-      {"coordinates":[0,1,2,3,4,5],"pointTypes":[0,1,0],"isClosed":true}
-    );
-    expect(p.getContour(1)).to.deep.equal(
-      {"coordinates":[6,7,8,9,10,11],"pointTypes":[0,0,0],"isClosed":true}
-    );
-    expect(p.getContour(2)).to.deep.equal(
-      {"coordinates":[12,13,14,15,16,17,18,19],"pointTypes":[0,1,1,0],"isClosed":true}
-    );
-    expect(p.getContour(3)).to.deep.equal(
-      {"coordinates":[6,7,8,9,10,11],"pointTypes":[0,0,0],"isClosed":true}
-    );
+    expect(p.getContour(0)).to.deep.equal({
+      coordinates: [0, 1, 2, 3, 4, 5],
+      pointTypes: [0, 1, 0],
+      isClosed: true,
+    });
+    expect(p.getContour(1)).to.deep.equal({
+      coordinates: [6, 7, 8, 9, 10, 11],
+      pointTypes: [0, 0, 0],
+      isClosed: true,
+    });
+    expect(p.getContour(2)).to.deep.equal({
+      coordinates: [12, 13, 14, 15, 16, 17, 18, 19],
+      pointTypes: [0, 1, 1, 0],
+      isClosed: true,
+    });
+    expect(p.getContour(3)).to.deep.equal({
+      coordinates: [6, 7, 8, 9, 10, 11],
+      pointTypes: [0, 0, 0],
+      isClosed: true,
+    });
     expect(p.numContours).to.equal(4);
     expect(p._checkIntegrity()).to.equal(false);
   });
@@ -884,15 +1029,21 @@ describe("VarPackedPath Tests", () => {
     const p = complexTestPath();
     p.pointTypes[2] |= VarPackedPath.SMOOTH_FLAG;
     p.setUnpackedContour(1, p.getUnpackedContour(0));
-    expect(p.getContour(0)).to.deep.equal(
-      {"coordinates":[0,1,2,3,4,5],"pointTypes":[0,1,8],"isClosed":true}
-    );
-    expect(p.getContour(1)).to.deep.equal(
-      {"coordinates":[0,1,2,3,4,5],"pointTypes":[0,1,8],"isClosed":true}
-    );
-    expect(p.getContour(2)).to.deep.equal(
-      {"coordinates":[12,13,14,15,16,17,18,19],"pointTypes":[0,1,1,0],"isClosed":true}
-    );
+    expect(p.getContour(0)).to.deep.equal({
+      coordinates: [0, 1, 2, 3, 4, 5],
+      pointTypes: [0, 1, 8],
+      isClosed: true,
+    });
+    expect(p.getContour(1)).to.deep.equal({
+      coordinates: [0, 1, 2, 3, 4, 5],
+      pointTypes: [0, 1, 8],
+      isClosed: true,
+    });
+    expect(p.getContour(2)).to.deep.equal({
+      coordinates: [12, 13, 14, 15, 16, 17, 18, 19],
+      pointTypes: [0, 1, 1, 0],
+      isClosed: true,
+    });
     expect(p.numContours).to.equal(3);
     expect(p._checkIntegrity()).to.equal(false);
   });
@@ -916,7 +1067,9 @@ describe("VarPackedPath Tests", () => {
     expect(p.getContourAndPointIndex(7)).to.deep.equal([2, 1]);
     expect(p.getContourAndPointIndex(8)).to.deep.equal([2, 2]);
     expect(p.getContourAndPointIndex(9)).to.deep.equal([2, 3]);
-    expect(() => p.getContourAndPointIndex(10)).to.throw("pointIndex out of bounds: 10");
+    expect(() => p.getContourAndPointIndex(10)).to.throw(
+      "pointIndex out of bounds: 10"
+    );
   });
 
   it("test getNumPointsOfContour", () => {
@@ -927,5 +1080,4 @@ describe("VarPackedPath Tests", () => {
     expect(p.getNumPointsOfContour(2)).to.equal(4);
     expect(() => p.getNumPointsOfContour(3)).to.throw("contourIndex out of bounds: 3");
   });
-
-})
+});


### PR DESCRIPTION
Format all .html,.css,.js files with Prettier and exclude views/editor/edit-behaviour.js

This supersedes #241 and fixes #233 

Once the project is cloned and Prettier is set up in the extension, 
you can run `npx prettier --write "**/*.{html,css,js}"` to format all files in the directory.

@fabiocaccamo It takes currently 4.3074s to run this script.