### PR TITLE
Read variable components from TTF

### DIFF
--- a/src/fontra/core/packedpath.py
+++ b/src/fontra/core/packedpath.py
@@ -258,6 +258,7 @@ class PackedPathPointPen:
     ):
         from .classes import Component, Transformation
 
+        # TODO: https://github.com/googlefonts/fontra/issues/245
         transformation = Transformation(**asdict(transformation))
         self.components.append(Component(glyphName, transformation, location))
 

--- a/src/fontra/core/packedpath.py
+++ b/src/fontra/core/packedpath.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from enum import IntEnum
 import logging
 import math
@@ -252,6 +252,14 @@ class PackedPathPointPen:
         )
 
         self.components.append(Component(glyphName, transformation))
+
+    def addVarComponent(
+        self, glyphName, transformation, location, identifier=None, **kwargs
+    ):
+        from .classes import Component, Transformation
+
+        transformation = Transformation(**asdict(transformation))
+        self.components.append(Component(glyphName, transformation, location))
 
 
 def decomposeTwoByTwo(twoByTwo):


### PR DESCRIPTION
Fixes #228.

- Add support for the new optional addVarComponent method, so we can read variable components from binary files.

Requires https://github.com/fonttools/fonttools/pull/2958