### PR TITLE
Use 'representations' mechanism for cached properties

### DIFF
--- a/src/fontra/client/core/representation-cache.js
+++ b/src/fontra/client/core/representation-cache.js
@@ -1,0 +1,33 @@
+//
+// A general Cached Representation mechanism
+//
+
+export function registerRepresentationFactory(classObject, representationKey, func) {
+  let factories = classObject._representationFactories;
+  if (!factories) {
+    factories = {};
+    classObject._representationFactories = factories;
+  }
+  factories[representationKey] = func;
+}
+
+export function getRepresentation(obj, representationKey) {
+  let representation = obj._representationCache?.[representationKey];
+  if (representation === undefined) {
+    if (!obj._representationCache) {
+      obj._representationCache = {};
+    }
+    const classObject = obj.constructor;
+    const factory = classObject._representationFactories[representationKey];
+    if (!factory) {
+      throw new Error(`Can't find representation factory for '${representationKey}'`);
+    }
+    representation = factory(obj);
+    obj._representationCache[representationKey] = representation;
+  }
+  return representation;
+}
+
+export function clearRepresentationCache(obj) {
+  obj._representationCache = {};
+}


### PR DESCRIPTION
Use a general 'representation' mechanism for representations derived from the StaticGlyphController.

This makes it easier to (externally) add new kinds of representations for the StaticGlyphController, and simplifies the existing code.

(This is a simplified form of "representations" as used in [defcon](https://github.com/robotools/defcon/blob/2498713448294d9210adc1b0cd44f650672e7d24/Lib/defcon/__init__.py#L37), which were inspired by something I came up with before defcon was written.)