### PR TITLE
Add layer preferences with Lit.js web component

### DIFF
--- a/src/fontra/client/web-components/options-list.js
+++ b/src/fontra/client/web-components/options-list.js
@@ -1,0 +1,151 @@
+import { html, css, LitElement } from "https://cdn.jsdelivr.net/npm/lit@2.6.1/+esm";
+
+export class OptionsList extends LitElement {
+  static styles = css`
+    .tree {
+      --spacing: 1.5rem;
+      --radius: 10px;
+    }
+
+    .tree li {
+      display: block;
+      position: relative;
+      padding-left: calc(2 * var(--spacing) - var(--radius) - 2px);
+    }
+
+    .tree ul {
+      margin-left: calc(var(--radius) - var(--spacing));
+      padding-left: 0;
+    }
+
+    .tree ul li {
+      border-left: 2px solid #ddd;
+    }
+
+    .tree ul li:last-child {
+      border-color: transparent;
+    }
+
+    .tree ul li::before {
+      content: "";
+      display: block;
+      position: absolute;
+      top: calc(var(--spacing) / -2);
+      left: -2px;
+      width: calc(var(--spacing) + 2px);
+      height: calc(var(--spacing) + 1px);
+      border: solid #ddd;
+      border-width: 0 0 2px 2px;
+    }
+
+    .tree summary {
+      display: block;
+      cursor: pointer;
+    }
+
+    .tree summary::marker,
+    .tree summary::-webkit-details-marker {
+      display: none;
+    }
+
+    .tree summary:focus {
+      outline: none;
+    }
+
+    .tree summary:focus-visible {
+      outline: 1px dotted #000;
+    }
+
+    .tree li::after,
+    .tree summary::before {
+      content: "";
+      display: block;
+      position: absolute;
+      top: calc(var(--spacing) / 2 - var(--radius));
+      left: calc(var(--spacing) - var(--radius) - 1px);
+      width: calc(2 * var(--radius));
+      height: calc(2 * var(--radius));
+      border-radius: 50%;
+      background: #ddd;
+    }
+
+    .tree summary::before {
+      content: "+";
+      z-index: 1;
+      background: #222;
+      color: #fff;
+      line-height: calc(2 * var(--radius) - 2px);
+      text-align: center;
+    }
+
+    .tree details[open] > summary::before {
+      content: "−";
+    }
+
+    label {
+      text-transform: capitalize;
+    }
+  `;
+
+  static properties = {
+    options: { type: Array },
+  };
+
+  constructor() {
+    super();
+    this.options = [];
+  }
+
+  optionsList() {
+    let listHTML = "";
+
+    if (this.options) {
+      listHTML = this.options.map((options) => {
+        return html`<li>
+          <details .open=${options.defaultOpen}>
+            <summary>${options.name}</summary>
+            ${options.items.map(
+              (option) =>
+                html`<div>
+                  <input
+                    type="checkbox"
+                    id="${option.name}"
+                    name="${option.name}"
+                    .checked=${option.isChecked}
+                    @change=${(option) => this.updateOptions(option)}
+                  />
+                  <label for="${option.name}">${option.name}</label>
+                </div>`
+            )}
+          </details>
+        </li>`;
+      });
+    }
+
+    return listHTML;
+  }
+
+  render() {
+    return html`
+      <ul class="tree">
+        ${this.optionsList()}
+      </ul>
+    `;
+  }
+
+  updateOptions(e) {
+    let updatedOptions = null;
+    this.options.forEach((option) => {
+      if (updatedOptions) return;
+
+      updatedOptions = option.items.find(
+        (optionItem) => optionItem.name === e.target.name
+      );
+    });
+
+    updatedOptions.isChecked = e.target.checked;
+    console.log(this.options);
+  }
+}
+
+customElements.define("options-list", OptionsList);

--- a/src/fontra/client/web-components/options-list.js
+++ b/src/fontra/client/web-components/options-list.js
@@ -3,8 +3,20 @@ import { html, css, LitElement } from "../third-party/lit.js";
 export class OptionsList extends LitElement {
   static styles = css`
     ul {
+      padding: 0;
       list-style: none;
     }
+
+    summary {
+      font-size: 1em;
+      font-weight: bold;
+      margin-bottom: 1rem;
+    }
+
+    details > div {
+      padding-left: 0.55rem;
+    }
+
     label {
       text-transform: capitalize;
     }

--- a/src/fontra/client/web-components/options-list.js
+++ b/src/fontra/client/web-components/options-list.js
@@ -1,4 +1,4 @@
-import { html, css, LitElement } from "https://cdn.jsdelivr.net/npm/lit@2.6.1/+esm";
+import { html, css, LitElement } from "../third-party/lit.js";
 
 export class OptionsList extends LitElement {
   static styles = css`

--- a/src/fontra/client/web-components/options-list.js
+++ b/src/fontra/client/web-components/options-list.js
@@ -2,86 +2,9 @@ import { html, css, LitElement } from "https://cdn.jsdelivr.net/npm/lit@2.6.1/+e
 
 export class OptionsList extends LitElement {
   static styles = css`
-    .tree {
-      --spacing: 1.5rem;
-      --radius: 10px;
+    ul {
+      list-style: none;
     }
-
-    .tree li {
-      display: block;
-      position: relative;
-      padding-left: calc(2 * var(--spacing) - var(--radius) - 2px);
-    }
-
-    .tree ul {
-      margin-left: calc(var(--radius) - var(--spacing));
-      padding-left: 0;
-    }
-
-    .tree ul li {
-      border-left: 2px solid #ddd;
-    }
-
-    .tree ul li:last-child {
-      border-color: transparent;
-    }
-
-    .tree ul li::before {
-      content: "";
-      display: block;
-      position: absolute;
-      top: calc(var(--spacing) / -2);
-      left: -2px;
-      width: calc(var(--spacing) + 2px);
-      height: calc(var(--spacing) + 1px);
-      border: solid #ddd;
-      border-width: 0 0 2px 2px;
-    }
-
-    .tree summary {
-      display: block;
-      cursor: pointer;
-    }
-
-    .tree summary::marker,
-    .tree summary::-webkit-details-marker {
-      display: none;
-    }
-
-    .tree summary:focus {
-      outline: none;
-    }
-
-    .tree summary:focus-visible {
-      outline: 1px dotted #000;
-    }
-
-    .tree li::after,
-    .tree summary::before {
-      content: "";
-      display: block;
-      position: absolute;
-      top: calc(var(--spacing) / 2 - var(--radius));
-      left: calc(var(--spacing) - var(--radius) - 1px);
-      width: calc(2 * var(--radius));
-      height: calc(2 * var(--radius));
-      border-radius: 50%;
-      background: #ddd;
-    }
-
-    .tree summary::before {
-      content: "+";
-      z-index: 1;
-      background: #222;
-      color: #fff;
-      line-height: calc(2 * var(--radius) - 2px);
-      text-align: center;
-    }
-
-    .tree details[open] > summary::before {
-      content: "−";
-    }
-
     label {
       text-transform: capitalize;
     }
@@ -99,7 +22,7 @@ export class OptionsList extends LitElement {
   optionsList() {
     let listHTML = "";
 
-    if (this.options) {
+    if (this.options.length > 0) {
       listHTML = this.options.map((options) => {
         return html`<li>
           <details .open=${options.defaultOpen}>
@@ -127,7 +50,7 @@ export class OptionsList extends LitElement {
 
   render() {
     return html`
-      <ul class="tree">
+      <ul>
         ${this.optionsList()}
       </ul>
     `;

--- a/src/fontra/client/web-components/options-list.js
+++ b/src/fontra/client/web-components/options-list.js
@@ -12,7 +12,6 @@ export class OptionsList extends LitElement {
 
   static properties = {
     options: { type: Array },
-    onChange: { type: Function },
   };
 
   constructor() {
@@ -68,7 +67,12 @@ export class OptionsList extends LitElement {
     });
 
     updatedOptions.isChecked = e.target.checked;
-    this.onChange();
+
+    const event = new CustomEvent("change", {
+      bubbles: false,
+      detail: this.options,
+    });
+    this.dispatchEvent(event);
   }
 }
 

--- a/src/fontra/client/web-components/options-list.js
+++ b/src/fontra/client/web-components/options-list.js
@@ -32,7 +32,7 @@ export class OptionsList extends LitElement {
                 html`<div>
                   <input
                     type="checkbox"
-                    id="${option.name}"
+                    id="${option.id}"
                     name="${option.name}"
                     .checked=${option.isChecked}
                     @change=${(option) => this.updateOptions(option)}
@@ -70,7 +70,7 @@ export class OptionsList extends LitElement {
 
     const event = new CustomEvent("change", {
       bubbles: false,
-      detail: this.options,
+      detail: e.target,
     });
     this.dispatchEvent(event);
   }

--- a/src/fontra/client/web-components/options-list.js
+++ b/src/fontra/client/web-components/options-list.js
@@ -49,7 +49,7 @@ export class OptionsList extends LitElement {
                     .checked=${option.isChecked}
                     @change=${(option) => this.updateOptions(option)}
                   />
-                  <label for="${option.name}">${option.name}</label>
+                  <label for="${option.id}">${option.name}</label>
                 </div>`
             )}
           </details>

--- a/src/fontra/client/web-components/options-list.js
+++ b/src/fontra/client/web-components/options-list.js
@@ -12,6 +12,7 @@ export class OptionsList extends LitElement {
 
   static properties = {
     options: { type: Array },
+    onChange: { type: Function },
   };
 
   constructor() {
@@ -67,6 +68,7 @@ export class OptionsList extends LitElement {
     });
 
     updatedOptions.isChecked = e.target.checked;
+    this.onChange();
   }
 }
 

--- a/src/fontra/client/web-components/options-list.js
+++ b/src/fontra/client/web-components/options-list.js
@@ -144,7 +144,6 @@ export class OptionsList extends LitElement {
     });
 
     updatedOptions.isChecked = e.target.checked;
-    console.log(this.options);
   }
 }
 

--- a/src/fontra/views/editor/editor.html
+++ b/src/fontra/views/editor/editor.html
@@ -299,14 +299,6 @@
   <body>
     <div id="ui-dialog-container">
       <!-- <div id="ui-dialog-content" tabindex="1"></div> -->
-
-      <div class="sidebar-content" data-sidebar-name="layers">
-        <div class="sidebar-layer-preferences">
-          <div class="layer-preferences" id="layer-preferences">
-            <!-- contents will be filled dynamically -->
-          </div>
-        </div>
-      </div>
     </div>
 
     <div id="global-loader-spinner"></div>
@@ -316,6 +308,7 @@
         <div class="sidebar-content" data-sidebar-name="text-entry">
           <div class="sidebar-text-entry">
             <textarea rows="1" wrap="off" id="text-entry-textarea"></textarea>
+
             <div id="text-align-menu">
               <div>alignleft</div>
               <div class="selected">aligncenter</div>
@@ -358,6 +351,10 @@
             <div class="settings" id="settings">
               <!-- contents will be filled dynamically -->
               <general-settings />
+            </div>
+          </div>
+        </div>
+
         <div class="sidebar-content" data-sidebar-name="layers">
           <div class="sidebar-layer-preferences">
             <div class="layer-preferences" id="layer-preferences">

--- a/src/fontra/views/editor/editor.html
+++ b/src/fontra/views/editor/editor.html
@@ -278,7 +278,8 @@
       box-sizing: border-box;
     }
 
-    .sidebar-settings {
+    .sidebar-settings,
+    .sidebar-layer-preferences {
       box-sizing: border-box;
       height: 100%;
       display: grid;

--- a/src/fontra/views/editor/editor.html
+++ b/src/fontra/views/editor/editor.html
@@ -304,7 +304,6 @@
         <div class="sidebar-layer-preferences">
           <div class="layer-preferences" id="layer-preferences">
             <!-- contents will be filled dynamically -->
-            <options-list id="layer-preferences-list"></options-list>
           </div>
         </div>
       </div>

--- a/src/fontra/views/editor/editor.html
+++ b/src/fontra/views/editor/editor.html
@@ -166,7 +166,7 @@
       animation-name: tab-slide-in-animation;
     }
 
-    <<<<<<< HEAD .tab-overlay-container.left > .sidebar-tab {
+    .tab-overlay-container.left > .sidebar-tab {
       border-radius: 0 0.4em 0.4em 0;
       text-align: right;
     }
@@ -299,7 +299,7 @@
   <body>
     <div id="ui-dialog-container">
       <!-- <div id="ui-dialog-content" tabindex="1"></div> -->
-      =======
+
       <div class="sidebar-content" data-sidebar-name="layers">
         <div class="sidebar-layer-preferences">
           <div class="layer-preferences" id="layer-preferences">
@@ -307,8 +307,6 @@
           </div>
         </div>
       </div>
-      >>>>>>> ad03f492 (render web component on the canvas and dynamically populate it
-      with options)
     </div>
 
     <div id="global-loader-spinner"></div>
@@ -318,7 +316,6 @@
         <div class="sidebar-content" data-sidebar-name="text-entry">
           <div class="sidebar-text-entry">
             <textarea rows="1" wrap="off" id="text-entry-textarea"></textarea>
-
             <div id="text-align-menu">
               <div>alignleft</div>
               <div class="selected">aligncenter</div>

--- a/src/fontra/views/editor/editor.html
+++ b/src/fontra/views/editor/editor.html
@@ -9,6 +9,7 @@
     <link href="/css/core.css" rel="stylesheet" />
     <link href="/editor/editor.css" rel="stylesheet" />
     <script type="module" src="/web-components/general-settings.js"></script>
+    <script type="module" src="/web-components/options-list.js"></script>
   </head>
 
   <style type="text/css">
@@ -165,7 +166,7 @@
       animation-name: tab-slide-in-animation;
     }
 
-    .tab-overlay-container.left > .sidebar-tab {
+    <<<<<<< HEAD .tab-overlay-container.left > .sidebar-tab {
       border-radius: 0 0.4em 0.4em 0;
       text-align: right;
     }
@@ -298,6 +299,17 @@
   <body>
     <div id="ui-dialog-container">
       <!-- <div id="ui-dialog-content" tabindex="1"></div> -->
+      =======
+      <div class="sidebar-content" data-sidebar-name="layers">
+        <div class="sidebar-layer-preferences">
+          <div class="layer-preferences" id="layer-preferences">
+            <!-- contents will be filled dynamically -->
+            <options-list id="layer-preferences-list"></options-list>
+          </div>
+        </div>
+      </div>
+      >>>>>>> ad03f492 (render web component on the canvas and dynamically populate it
+      with options)
     </div>
 
     <div id="global-loader-spinner"></div>
@@ -371,7 +383,7 @@
             <div class="sidebar-tab" data-sidebar-name="designspace-sliders">
               sliders
             </div>
-            <!-- <div class="sidebar-tab" data-sidebar-name="layers">layers</div> -->
+            <div class="sidebar-tab" data-sidebar-name="layers">layers</div>
             <div class="sidebar-tab" data-sidebar-name="settings">gear</div>
           </div>
 

--- a/src/fontra/views/editor/editor.html
+++ b/src/fontra/views/editor/editor.html
@@ -358,6 +358,11 @@
             <div class="settings" id="settings">
               <!-- contents will be filled dynamically -->
               <general-settings />
+        <div class="sidebar-content" data-sidebar-name="layers">
+          <div class="sidebar-layer-preferences">
+            <div class="layer-preferences" id="layer-preferences">
+              <!-- attributes will be set dynamically -->
+              <options-list class="options-list"></options-list>
             </div>
           </div>
         </div>

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -288,29 +288,28 @@ export class EditorController {
 
   initLayers() {
     const optionsList = document.querySelector(".options-list");
-    const layersOptions = [
-      {
-        name: "Path Options",
-        defaultOpen: true,
-        items: [
-          { name: "fill", isChecked: true },
-          { name: "stroke", isChecked: false },
-          { name: "metrics", isChecked: true },
-        ],
-      },
-      {
-        name: "Canvas Options",
-        items: [
-          { name: "guidelines", isChecked: true },
-          { name: "measurements", isChecked: true },
-          { name: "grid", isChecked: false },
-        ],
-      },
-    ]; // this should come from somewhere dynamically
+    const userSwitchableLayers = this.visualizationLayers.definitions.filter(
+      (layer) => layer.userSwitchable
+    );
 
-    optionsList.options = layersOptions;
+    const glyphDisplayLayersItems = userSwitchableLayers.reduce((array, layer) => {
+      let isChecked = this.visualizationLayersSettings[layer.identifier];
+      array.push({ id: layer.identifier, name: layer.name, isChecked: isChecked });
+      return array;
+    }, []);
+
+    optionsList.options = [
+      {
+        name: "Glyph display layers",
+        defaultOpen: true,
+        items: glyphDisplayLayersItems,
+      },
+    ];
+
     optionsList.addEventListener("change", (event) => {
-      console.log(event.detail);
+      const layerIdentifier = event.detail.id;
+      const layerChecked = event.detail.checked;
+      this.visualizationLayersSettings[layerIdentifier] = layerChecked;
     });
   }
 

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -309,6 +309,10 @@ export class EditorController {
       },
     ]; // this should come from somewhere dynamically
     optionsList.setAttribute("options", JSON.stringify(layersOptions));
+    optionsList.addEventListener("click", (e) => {
+      console.dir(e.target.options);
+    });
+
     layerPreferencesContainer.appendChild(optionsList);
   }
 

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -292,11 +292,10 @@ export class EditorController {
       (layer) => layer.userSwitchable
     );
 
-    const glyphDisplayLayersItems = userSwitchableLayers.reduce((array, layer) => {
-      let isChecked = this.visualizationLayersSettings[layer.identifier];
-      array.push({ id: layer.identifier, name: layer.name, isChecked: isChecked });
-      return array;
-    }, []);
+    const glyphDisplayLayersItems = userSwitchableLayers.map((layer) => {
+      let isLayerVisible = this.visualizationLayersSettings[layer.identifier];
+      return { id: layer.identifier, name: layer.name, isChecked: isLayerVisible };
+    });
 
     optionsList.options = [
       {

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -287,8 +287,7 @@ export class EditorController {
   }
 
   initLayers() {
-    const layerPreferencesContainer = document.getElementById("layer-preferences");
-    const optionsList = document.createElement("options-list");
+    const optionsList = document.querySelector(".options-list");
     const layersOptions = [
       {
         name: "Path Options",
@@ -308,12 +307,10 @@ export class EditorController {
         ],
       },
     ]; // this should come from somewhere dynamically
-    optionsList.setAttribute("options", JSON.stringify(layersOptions));
-    optionsList.addEventListener("click", (e) => {
-      console.dir(e.target.options);
-    });
-
-    layerPreferencesContainer.appendChild(optionsList);
+    optionsList.options = layersOptions;
+    optionsList.onChange = () => {
+      console.log(optionsList.options);
+    };
   }
 
   initTools() {

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -307,10 +307,11 @@ export class EditorController {
         ],
       },
     ]; // this should come from somewhere dynamically
+
     optionsList.options = layersOptions;
-    optionsList.onChange = () => {
-      console.log(optionsList.options);
-    };
+    optionsList.addEventListener("change", (event) => {
+      console.log(event.detail);
+    });
   }
 
   initTools() {

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -214,6 +214,7 @@ export class EditorController {
     await this.fontController.subscribeChanges(rootSubscriptionPattern, false);
     await this.initGlyphNames();
     await this.initSliders();
+    this.initLayerPreferences();
     this.initTools();
     this.initSourcesList();
     await this.setupFromWindowLocation();
@@ -283,6 +284,13 @@ export class EditorController {
         this.autoViewBox = false;
       })
     );
+  }
+
+  initLayerPreferences() {
+    const layerPreferencesContainer = document.getElementById("layer-preferences");
+    const preferences = document.createElement("div");
+    preferences.innerHTML = "Preferences";
+    layerPreferencesContainer.append(preferences);
   }
 
   initTools() {

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -214,7 +214,7 @@ export class EditorController {
     await this.fontController.subscribeChanges(rootSubscriptionPattern, false);
     await this.initGlyphNames();
     await this.initSliders();
-    this.initLayerPreferences();
+    this.initLayers();
     this.initTools();
     this.initSourcesList();
     await this.setupFromWindowLocation();
@@ -286,11 +286,30 @@ export class EditorController {
     );
   }
 
-  initLayerPreferences() {
+  initLayers() {
     const layerPreferencesContainer = document.getElementById("layer-preferences");
-    const preferences = document.createElement("div");
-    preferences.innerHTML = "Preferences";
-    layerPreferencesContainer.append(preferences);
+    const optionsList = document.createElement("options-list");
+    const layersOptions = [
+      {
+        name: "Path Options",
+        defaultOpen: true,
+        items: [
+          { name: "fill", isChecked: true },
+          { name: "stroke", isChecked: false },
+          { name: "metrics", isChecked: true },
+        ],
+      },
+      {
+        name: "Canvas Options",
+        items: [
+          { name: "guidelines", isChecked: true },
+          { name: "measurements", isChecked: true },
+          { name: "grid", isChecked: false },
+        ],
+      },
+    ]; // this should come from somewhere dynamically
+    optionsList.setAttribute("options", JSON.stringify(layersOptions));
+    layerPreferencesContainer.appendChild(optionsList);
   }
 
   initTools() {

--- a/src/fontra/views/editor/visualization-layers.js
+++ b/src/fontra/views/editor/visualization-layers.js
@@ -52,7 +52,7 @@ export class VisualizationLayers {
     if (onOff) {
       this._visibleLayerIds.add(layerID);
     } else {
-      this._visibleLayerIds.remove(layerID);
+      this._visibleLayerIds.delete(layerID);
     }
     this.setNeedsUpdate();
   }


### PR DESCRIPTION
Fixes #254 
After Vizualisation Layers have been added, we can now manage to control those easily through the UI. 
At the moment only one 'section' or 'header' (Glyph display header) exists but more can be added easily.

![Screenshot 2023-03-22 at 16 25 32](https://user-images.githubusercontent.com/11830669/226935316-5b933be0-2587-441e-a2fa-a115b36a8519.png)
![Screenshot 2023-03-22 at 16 26 01](https://user-images.githubusercontent.com/11830669/226935306-e0d50a0f-c746-4dc8-ae34-aa99de53b3d0.png)

Updated styling to match other sidebar panels:

![Screenshot 2023-03-22 at 16 50 02](https://user-images.githubusercontent.com/11830669/226942830-b2d4d417-dbbc-4712-9d29-2f981a2dcd6b.png)



