### PR TITLE
Add shortcuts labels to the context menu items

### DIFF
--- a/src/fontra/client/core/context-menu.js
+++ b/src/fontra/client/core/context-menu.js
@@ -21,10 +21,9 @@ export class ContextMenu {
         this.element.appendChild(dividerElement);
       } else {
         const itemElement = document.createElement("div");
-        const itemTitle = this.buildTitle(item);
         itemElement.classList.add("context-menu-item");
         itemElement.classList.toggle("enabled", !!item.enabled());
-        itemElement.append(itemTitle);
+        itemElement.append(this.buildTitle(item));
         itemElement.onmouseenter = (event) => this.selectItem(itemElement);
         itemElement.onmousemove = (event) => {
           if (!itemElement.classList.contains("selected")) {

--- a/src/fontra/client/core/context-menu.js
+++ b/src/fontra/client/core/context-menu.js
@@ -1,4 +1,4 @@
-import { reversed } from "./utils.js";
+import { reversed, buildShortcut } from "./utils.js";
 
 export const MenuItemDivider = { title: "-" };
 
@@ -134,9 +134,9 @@ export class ContextMenu {
     const titleWrapper = document.createElement("div");
     const title = document.createElement("span");
     title.innerText = typeof item.title === "function" ? item.title() : item.title;
+
     const shortCut = document.createElement("span");
-    shortCut.innerText = item.shortCut ? item.shortCut.keysOrCodes : "";
-    // console.log(item.shortCut.keysOrCodes);
+    shortCut.innerHTML = buildShortcut(item.shortCut);
     titleWrapper.append(title, shortCut);
     return titleWrapper;
   }

--- a/src/fontra/client/core/context-menu.js
+++ b/src/fontra/client/core/context-menu.js
@@ -1,4 +1,4 @@
-import { reversed, buildShortcut } from "./utils.js";
+import { reversed } from "./utils.js";
 
 export const MenuItemDivider = { title: "-" };
 
@@ -136,9 +136,29 @@ export class ContextMenu {
     title.innerText = typeof item.title === "function" ? item.title() : item.title;
 
     const shortCut = document.createElement("span");
-    shortCut.innerHTML = buildShortcut(item.shortCut);
+    shortCut.innerHTML = this.buildShortCutString(item.shortCut);
     titleWrapper.append(title, shortCut);
     return titleWrapper;
+  }
+
+  buildShortCutString(shortCutDefinition) {
+    let shorcutCommand = "";
+
+    if (shortCutDefinition) {
+      const isMac = navigator.platform.toLowerCase().indexOf("mac") >= 0;
+
+      if (shortCutDefinition.shiftKey) {
+        shorcutCommand += isMac ? "&#8679;" : "Shift+"; // ⇧ or Shift
+      }
+      if (shortCutDefinition.metaKey) {
+        shorcutCommand += isMac ? "&#8984;" : "Ctrl+"; // ⌘ or Ctrl
+      }
+      if (shortCutDefinition.keysOrCodes) {
+        shorcutCommand += shortCutDefinition.keysOrCodes.toUpperCase();
+      }
+    }
+
+    return shorcutCommand;
   }
 }
 

--- a/src/fontra/client/core/context-menu.js
+++ b/src/fontra/client/core/context-menu.js
@@ -21,10 +21,10 @@ export class ContextMenu {
         this.element.appendChild(dividerElement);
       } else {
         const itemElement = document.createElement("div");
-        const itemTitle = typeof item.title === "function" ? item.title() : item.title;
+        const itemTitle = this.buildTitle(item);
         itemElement.classList.add("context-menu-item");
         itemElement.classList.toggle("enabled", !!item.enabled());
-        itemElement.innerText = itemTitle;
+        itemElement.append(itemTitle);
         itemElement.onmouseenter = (event) => this.selectItem(itemElement);
         itemElement.onmousemove = (event) => {
           if (!itemElement.classList.contains("selected")) {
@@ -128,6 +128,17 @@ export class ContextMenu {
         }
       }
     }
+  }
+
+  buildTitle(item) {
+    const titleWrapper = document.createElement("div");
+    const title = document.createElement("span");
+    title.innerText = typeof item.title === "function" ? item.title() : item.title;
+    const shortCut = document.createElement("span");
+    shortCut.innerText = item.shortCut ? item.shortCut.keysOrCodes : "";
+    // console.log(item.shortCut.keysOrCodes);
+    titleWrapper.append(title, shortCut);
+    return titleWrapper;
   }
 }
 

--- a/src/fontra/client/core/utils.js
+++ b/src/fontra/client/core/utils.js
@@ -221,3 +221,23 @@ export function makeUPlusStringFromCodePoint(codePoint) {
     ? "U+" + codePoint.toString(16).toUpperCase().padStart(4, "0")
     : "";
 }
+
+export function buildShortcut(shorCutRegister) {
+  let shorcutCommand = "";
+
+  if (shorCutRegister) {
+    const isMac = navigator.platform.toLowerCase().indexOf("mac") >= 0;
+
+    if (shorCutRegister.shiftKey) {
+      shorcutCommand += isMac ? "&#8679;" : "Shift+"; // ⇧ or Shift
+    }
+    if (shorCutRegister.metaKey) {
+      shorcutCommand += isMac ? "&#8984;" : "Ctrl+"; // ⌘ or Ctrl
+    }
+    if (shorCutRegister.keysOrCodes) {
+      shorcutCommand += shorCutRegister.keysOrCodes.toUpperCase();
+    }
+  }
+
+  return shorcutCommand;
+}

--- a/src/fontra/client/core/utils.js
+++ b/src/fontra/client/core/utils.js
@@ -221,23 +221,3 @@ export function makeUPlusStringFromCodePoint(codePoint) {
     ? "U+" + codePoint.toString(16).toUpperCase().padStart(4, "0")
     : "";
 }
-
-export function buildShortcut(shorCutRegister) {
-  let shorcutCommand = "";
-
-  if (shorCutRegister) {
-    const isMac = navigator.platform.toLowerCase().indexOf("mac") >= 0;
-
-    if (shorCutRegister.shiftKey) {
-      shorcutCommand += isMac ? "&#8679;" : "Shift+"; // ⇧ or Shift
-    }
-    if (shorCutRegister.metaKey) {
-      shorcutCommand += isMac ? "&#8984;" : "Ctrl+"; // ⌘ or Ctrl
-    }
-    if (shorCutRegister.keysOrCodes) {
-      shorcutCommand += shorCutRegister.keysOrCodes.toUpperCase();
-    }
-  }
-
-  return shorcutCommand;
-}

--- a/src/fontra/client/css/context-menu.css
+++ b/src/fontra/client/css/context-menu.css
@@ -99,3 +99,8 @@
   background-color: var(--context-menu-background-active-color-light);
   cursor: pointer;
 }
+
+.context-menu-item > div {
+  display: flex;
+  justify-content: space-between;
+}

--- a/src/fontra/client/css/context-menu.css
+++ b/src/fontra/client/css/context-menu.css
@@ -86,7 +86,7 @@
 }
 
 .context-menu-item {
-  padding: 0.2em 1.5em 0.2em 1em; /* top, right, bottom, left */
+  padding: 0.2em 0.8em 0.2em 1em; /* top, right, bottom, left */
   color: #808080a0;
 }
 
@@ -102,5 +102,6 @@
 
 .context-menu-item > div {
   display: flex;
+  gap: 0.5em;
   justify-content: space-between;
 }


### PR DESCRIPTION
Fixes #255 
It adds shortcuts combinations to the items in the context menus if they exist. I haven't tested it on Windows but the code it's written, it should work properly replacing `⌘` with `Ctrl+` and so on.

Here are all possibilities for shortcut modifiers:
https://apple.stackexchange.com/a/55729/452817