### PR TITLE
Add basic edit commands to the context menu

### DIFF
--- a/src/fontra/client/core/context-menu.js
+++ b/src/fontra/client/core/context-menu.js
@@ -153,7 +153,7 @@ export class ContextMenu {
         shorcutCommand += isMac ? "&#8984;" : "Ctrl+"; // ⌘ or Ctrl
       }
       if (shortCutDefinition.keysOrCodes) {
-        shorcutCommand += shortCutDefinition.keysOrCodes.toUpperCase();
+        shorcutCommand += getShortCutKey(shortCutDefinition);
       }
     }
 
@@ -184,4 +184,49 @@ function normalizedPosition(container, contextMenu, mouseX, mouseY) {
   }
 
   return [normalizedX, normalizedY];
+}
+
+function getShortCutKey(shortCutDefinition) {
+  //
+  // Get a shortcut key from the shortCutDefinition Object
+  //
+  // It provides us with an easy mapping for the shortcuts
+  // 'specialChar' are all the symbols that we see on keyboards, such as ⌘, ↑, etc.
+  // 'fallbackChar' gives us an html entity character as a fallback
+  //
+
+  const shortCutAliases = [
+    {
+      key: "ArrowUp",
+      specialChar: "↑",
+      fallbackChar: "&#8593;",
+    },
+    {
+      key: "Backspace",
+      specialChar: "⌫",
+      fallbackChar: "&#9003;",
+    },
+    {
+      key: "Home",
+      specialChar: "",
+      fallbackChar: "Home",
+    },
+  ];
+
+  // Compare all alises with all key codes of a shortcut definition
+  const shortCutKey = shortCutAliases.find((shortCut) => {
+    if (typeof shortCutDefinition.keysOrCodes === "object") {
+      let validKey;
+      for (const keyCode of shortCutDefinition.keysOrCodes) {
+        validKey = shortCut.key.toLowerCase() === keyCode.toLowerCase();
+      }
+      return validKey;
+    }
+  });
+
+  if (shortCutKey) {
+    return shortCutKey.specialChar ? shortCutKey.specialChar : shortCutKey.fallbackChar;
+  } else {
+    return shortCutDefinition.keysOrCodes.charAt(0).toUpperCase();
+  }
 }

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -677,6 +677,46 @@ export class EditorController {
         shortCut: { keysOrCodes: "z", metaKey: true, shiftKey: isRedo },
       });
     }
+    this.basicContextMenuItems.push(MenuItemDivider);
+
+    const basicEditCommands = [
+      {
+        title: "Cut",
+        enabled: () => this.canCut(),
+        callback: () => this.doCut(),
+        shortCut: { keysOrCodes: "c", metaKey: true, shiftKey: true },
+      },
+      {
+        title: "Copy",
+        enabled: () => this.canCopy(),
+        callback: () => this.doCopy(),
+        shortCut: { keysOrCodes: "c", metaKey: true, shiftKey: false },
+      },
+      {
+        title: "Paste",
+        enabled: () => this.canPaste(),
+        callback: () => this.doPaste(),
+        shortCut: { keysOrCodes: "v", metaKey: true, shiftKey: false },
+      },
+      {
+        title: "Deep Paste",
+        enabled: () => this.canDeepPaste(),
+        callback: () => this.doDeepPaste(),
+        shortCut: { keysOrCodes: "v", metaKey: true, shiftKey: true },
+      },
+      {
+        title: "Delete",
+        enabled: () => this.canDelete(),
+        callback: () => this.doDelete(),
+        shortCut: { keysOrCodes: "Backspace", metaKey: false, shiftKey: false },
+      },
+    ];
+
+    for (const command of basicEditCommands) {
+      this.basicContextMenuItems.push(command);
+    }
+    this.basicContextMenuItems.push(MenuItemDivider);
+
     for (const selectNone of [false, true]) {
       this.basicContextMenuItems.push({
         title: selectNone ? "Select None" : "Select All",
@@ -737,6 +777,7 @@ export class EditorController {
     // `callback` is a callable that will be called with the event as its single
     // argument.
     //
+
     for (const keyOrCode of keysOrCodes) {
       const handlerDef = { ...modifiers, callback };
       if (!this.shortCutHandlers[keyOrCode]) {
@@ -797,6 +838,46 @@ export class EditorController {
     this.sourcesList.setSelectedItemIndex(
       await this.sceneController.getSelectedSource()
     );
+  }
+
+  canCut() {
+    return true;
+  }
+
+  canCopy() {
+    return true;
+  }
+
+  canPaste() {
+    return true;
+  }
+
+  canDeepPaste() {
+    return true;
+  }
+
+  canDelete() {
+    return true;
+  }
+
+  doCut() {
+    console.log("cut");
+  }
+
+  doCopy() {
+    console.log("copy");
+  }
+
+  doPaste() {
+    console.log("paste");
+  }
+
+  doDeepPaste() {
+    console.log("deep paste");
+  }
+
+  doDelete() {
+    console.log("delete");
   }
 
   canSelectAllNone(selectNone) {

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -708,7 +708,7 @@ export class EditorController {
         title: "Delete",
         enabled: () => this.canDelete(),
         callback: () => this.doDelete(),
-        shortCut: { keysOrCodes: "Backspace", metaKey: false, shiftKey: false },
+        shortCut: { keysOrCodes: ["Backspace"], metaKey: false, shiftKey: false },
       },
     ];
 

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -708,7 +708,11 @@ export class EditorController {
         title: "Delete",
         enabled: () => this.canDelete(),
         callback: () => this.doDelete(),
-        shortCut: { keysOrCodes: ["Backspace"], metaKey: false, shiftKey: false },
+        shortCut: {
+          keysOrCodes: ["Delete", "Backspace"],
+          metaKey: false,
+          shiftKey: false,
+        },
       },
     ];
 


### PR DESCRIPTION
Implements #276 
All the functions are mocked at the moment and might be consolidated but I have taken the same approach as for the Undo/Redo and Select All/None

<img width="400" alt="Screenshot 2023-02-16 at 15 04 50" src="https://user-images.githubusercontent.com/11830669/219372609-268aed26-4d43-4a10-bbbd-3009daf7c27c.png">
