### PR TITLE
Fix Safari ctrl+click context menu

### DIFF
--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -188,7 +188,6 @@ export class EditorController {
     this.canvasController.canvas.addEventListener("contextmenu", (event) =>
       this.contextMenuHandler(event)
     );
-
     window.addEventListener("click", (event) => this.dismissContextMenu(event));
     window.addEventListener("blur", (event) => this.dismissContextMenu(event));
 

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -188,6 +188,7 @@ export class EditorController {
     this.canvasController.canvas.addEventListener("contextmenu", (event) =>
       this.contextMenuHandler(event)
     );
+
     window.addEventListener("click", (event) => this.dismissContextMenu(event));
     window.addEventListener("blur", (event) => this.dismissContextMenu(event));
 
@@ -949,7 +950,7 @@ export class EditorController {
   }
 
   dismissContextMenu(event) {
-    if (!this.contextMenu) {
+    if (!this.contextMenu || event.ctrlKey) {
       return;
     }
     if (event) {
@@ -958,6 +959,7 @@ export class EditorController {
         return;
       }
     }
+
     this.contextMenu.dismiss();
     delete this.contextMenu;
   }

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -958,7 +958,6 @@ export class EditorController {
         return;
       }
     }
-
     this.contextMenu.dismiss();
     delete this.contextMenu;
   }


### PR DESCRIPTION
Fixes #287 