### PR TITLE
Server-side clipboard support code: parse SVG + GLIF

### DIFF
--- a/src/fontra/core/clipboard.py
+++ b/src/fontra/core/clipboard.py
@@ -4,8 +4,8 @@ from fontTools.pens.pointPen import (
     PointToSegmentPen,
     SegmentToPointPen,
 )
-from fontTools.ufoLib.glifLib import readGlyphFromString
 from fontTools.svgLib import SVGPath
+from fontTools.ufoLib.glifLib import readGlyphFromString
 
 from .classes import StaticGlyph
 from .packedpath import PackedPathPointPen

--- a/src/fontra/core/clipboard.py
+++ b/src/fontra/core/clipboard.py
@@ -7,6 +7,7 @@ from fontTools.pens.pointPen import (
 from fontTools.svgLib import SVGPath
 from fontTools.ufoLib.glifLib import readGlyphFromString
 
+from ..backends.designspace import UFOGlyph
 from .classes import StaticGlyph
 from .packedpath import PackedPathPointPen
 
@@ -27,10 +28,6 @@ def parseSVG(data):
     boundsPen = ControlBoundsPen(None)
     path.drawPoints(PointToSegmentPen(boundsPen))
     return StaticGlyph(path=path, xAdvance=boundsPen.bounds[2])
-
-
-class UFOGlyph:
-    width = 500
 
 
 def parseGLIF(data):

--- a/src/fontra/core/clipboard.py
+++ b/src/fontra/core/clipboard.py
@@ -1,0 +1,46 @@
+from fontTools.pens.boundsPen import ControlBoundsPen
+from fontTools.pens.pointPen import (
+    GuessSmoothPointPen,
+    PointToSegmentPen,
+    SegmentToPointPen,
+)
+from fontTools.ufoLib.glifLib import readGlyphFromString
+from fontTools.svgLib import SVGPath
+
+from .classes import StaticGlyph
+from .packedpath import PackedPathPointPen
+
+
+def parseClipboard(data):
+    if "<svg " in data:
+        return parseSVG(data)
+    if "<?xml" in data and "<glyph " in data:
+        return parseGLIF(data)
+    return None
+
+
+def parseSVG(data):
+    svgPath = SVGPath.fromstring(data)
+    pen = PackedPathPointPen()
+    svgPath.draw(SegmentToPointPen(GuessSmoothPointPen(pen)))
+    path = pen.getPath()
+    boundsPen = ControlBoundsPen(None)
+    path.drawPoints(PointToSegmentPen(boundsPen))
+    return StaticGlyph(path=path, xAdvance=boundsPen.bounds[2])
+
+
+class UFOGlyph:
+    width = 500
+
+
+def parseGLIF(data):
+    pen = PackedPathPointPen()
+    ufoGlyph = UFOGlyph()
+    readGlyphFromString(
+        data,
+        glyphObject=ufoGlyph,
+        pointPen=pen,
+    )
+    return StaticGlyph(
+        path=pen.getPath(), components=pen.components, xAdvance=ufoGlyph.width
+    )

--- a/src/fontra/core/fonthandler.py
+++ b/src/fontra/core/fonthandler.py
@@ -19,6 +19,7 @@ from .changes import (
     patternUnion,
 )
 from .classes import Font
+from .clipboard import parseClipboard
 from .glyphnames import getSuggestedGlyphName, getUnicodeFromGlyphName
 from .lrucache import LRUCache
 
@@ -448,6 +449,10 @@ class FontHandler:
     @remoteMethod
     async def getUnicodeFromGlyphName(self, glyphName, *, connection):
         return getUnicodeFromGlyphName(glyphName)
+
+    @remoteMethod
+    async def parseClipboard(self, data, *, connection):
+        return parseClipboard(data)
 
 
 def _iterAllComponentNames(glyph):

--- a/test-py/test_clipboard.py
+++ b/test-py/test_clipboard.py
@@ -1,0 +1,58 @@
+from fontra.core.classes import StaticGlyph
+from fontra.core.clipboard import parseClipboard
+from fontra.core.packedpath import ContourInfo, PackedPath, PointType
+import pytest
+
+
+@pytest.mark.parametrize(
+    "inputData, expectedResult",
+    [
+        ("dasasdad", None),
+        (
+            '<svg xmlns="http://www.w3.org/2000/svg" width="50" '
+            'height="120" viewBox="60 0 50 120">'
+            '<path transform="matrix(1 0 0 -1 0 120)" '
+            'd="M60,0L110,0L110,120L60,120L60,0Z"/>'
+            "</svg>",
+            StaticGlyph(
+                path=PackedPath(
+                    coordinates=[60.0, 120.0, 110.0, 120.0, 110.0, 0.0, 60.0, 0.0],
+                    pointTypes=[0, 0, 0, 0],
+                    contourInfo=[ContourInfo(endPoint=3, isClosed=True)],
+                ),
+                xAdvance=110.0,
+            ),
+        ),
+        (
+            "<?xml version='1.0' encoding='UTF-8'?>"
+            '<glyph name="period" format="2">'
+            '  <advance width="170"/>'
+            '  <unicode hex="002E"/>'
+            "  <outline>"
+            "    <contour>"
+            '      <point x="60" y="0" type="line"/>'
+            '      <point x="110" y="0" type="line"/>'
+            '      <point x="110" y="120" type="line"/>'
+            '      <point x="60" y="120" type="line"/>'
+            "    </contour>"
+            "  </outline>"
+            "</glyph>",
+            StaticGlyph(
+                path=PackedPath(
+                    coordinates=[60, 0, 110, 0, 110, 120, 60, 120],
+                    pointTypes=[0, 0, 0, 0],
+                    contourInfo=[ContourInfo(endPoint=3, isClosed=True)],
+                ),
+                components=[],
+                xAdvance=170,
+                yAdvance=None,
+                verticalOrigin=None,
+            ),
+        ),
+    ],
+)
+def test_parseClipboard(inputData, expectedResult):
+    result = parseClipboard(inputData)
+    if result is not None:
+        result = result
+    assert expectedResult == result

--- a/test-py/test_clipboard.py
+++ b/test-py/test_clipboard.py
@@ -1,7 +1,8 @@
+import pytest
+
 from fontra.core.classes import StaticGlyph
 from fontra.core.clipboard import parseClipboard
 from fontra.core.packedpath import ContourInfo, PackedPath, PointType
-import pytest
 
 
 @pytest.mark.parametrize(

--- a/test-py/test_clipboard.py
+++ b/test-py/test_clipboard.py
@@ -8,7 +8,7 @@ from fontra.core.packedpath import ContourInfo, PackedPath
 @pytest.mark.parametrize(
     "inputData, expectedResult",
     [
-        ("dasasdad", None),
+        ("dasasdad", None),  # unparsable
         (
             '<svg xmlns="http://www.w3.org/2000/svg" width="50" '
             'height="120" viewBox="60 0 50 120">'

--- a/test-py/test_clipboard.py
+++ b/test-py/test_clipboard.py
@@ -2,7 +2,7 @@ import pytest
 
 from fontra.core.classes import StaticGlyph
 from fontra.core.clipboard import parseClipboard
-from fontra.core.packedpath import ContourInfo, PackedPath, PointType
+from fontra.core.packedpath import ContourInfo, PackedPath
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Add support code to parse SVG and GLIF data. Part of #260.