### PR TITLE
Implement paste from SVG and GLIF data

### DIFF
--- a/src/fontra/client/core/change-recorder.js
+++ b/src/fontra/client/core/change-recorder.js
@@ -73,6 +73,7 @@ function getVarPackedPathProxyMethods(subject, changes) {
 
 export const proxyMethodsMap = {
   Array: getArrayProxyMethods,
+  VarArray: getArrayProxyMethods,
   VarPackedPath: getVarPackedPathProxyMethods, // Poss. need to change the key to VarPackedPath.name when minifying
 };
 

--- a/src/fontra/client/core/font-controller.js
+++ b/src/fontra/client/core/font-controller.js
@@ -91,6 +91,11 @@ export class FontController {
     return await this.font.getUnicodeFromGlyphName(glyphName);
   }
 
+  async parseClipboard(data) {
+    const result = await this.font.parseClipboard(data);
+    return result ? StaticGlyph.fromObject(result) : undefined;
+  }
+
   hasGlyph(glyphName) {
     return glyphName in this.glyphMap;
   }

--- a/src/fontra/client/core/utils.js
+++ b/src/fontra/client/core/utils.js
@@ -234,3 +234,24 @@ export async function writeToClipboard(clipboardObject) {
 
   navigator.clipboard.write([new ClipboardItem(clipboardItemObject)]);
 }
+
+export async function readClipboardTypes() {
+  const clipboardContents = await navigator.clipboard.read();
+  const clipboardTypes = [];
+  for (const item of clipboardContents) {
+    clipboardTypes.push(...item.types);
+  }
+  return clipboardTypes;
+}
+
+export async function readClipboard() {
+  const clipboardObject = {};
+  const clipboardContents = await navigator.clipboard.read();
+  for (const item of clipboardContents) {
+    for (const type of item.types) {
+      const blob = await item.getType(type);
+      clipboardObject[type] = await blob.text();
+    }
+  }
+  return clipboardObject;
+}

--- a/src/fontra/client/core/var-path.js
+++ b/src/fontra/client/core/var-path.js
@@ -209,10 +209,19 @@ export class VarPackedPath {
   }
 
   appendPath(path) {
-    const numContours = path.contourInfo.length;
-    for (let i = 0; i < numContours; i++) {
-      this.appendContour(path.getContour(i));
-    }
+    this.coordinates.push(...path.coordinates);
+    this.pointTypes.push(...path.pointTypes);
+    const endPointOffset = this.contourInfo.length
+      ? this.contourInfo.at(-1).endPoint + 1
+      : 0;
+    this.contourInfo.push(
+      ...path.contourInfo.map((contour) => {
+        return {
+          endPoint: contour.endPoint + endPointOffset,
+          isClosed: contour.isClosed,
+        };
+      })
+    );
   }
 
   getPoint(pointIndex) {

--- a/src/fontra/client/core/var-path.js
+++ b/src/fontra/client/core/var-path.js
@@ -209,19 +209,10 @@ export class VarPackedPath {
   }
 
   appendPath(path) {
-    this.coordinates.push(...path.coordinates);
-    this.pointTypes.push(...path.pointTypes);
-    const endPointOffset = this.contourInfo.length
-      ? this.contourInfo.at(-1).endPoint + 1
-      : 0;
-    this.contourInfo.push(
-      ...path.contourInfo.map((contour) => {
-        return {
-          endPoint: contour.endPoint + endPointOffset,
-          isClosed: contour.isClosed,
-        };
-      })
-    );
+    const numContours = path.contourInfo.length;
+    for (let i = 0; i < numContours; i++) {
+      this.appendContour(path.getContour(i));
+    }
   }
 
   getPoint(pointIndex) {

--- a/src/fontra/core/clipboard.py
+++ b/src/fontra/core/clipboard.py
@@ -21,6 +21,7 @@ def parseClipboard(data):
 
 
 def parseSVG(data):
+    data = data.encode("utf-8")
     svgPath = SVGPath.fromstring(data)
     pen = PackedPathPointPen()
     svgPath.draw(SegmentToPointPen(GuessSmoothPointPen(pen)))

--- a/src/fontra/core/clipboard.py
+++ b/src/fontra/core/clipboard.py
@@ -1,9 +1,7 @@
 from fontTools.pens.boundsPen import ControlBoundsPen
-from fontTools.pens.pointPen import (
-    GuessSmoothPointPen,
-    PointToSegmentPen,
-    SegmentToPointPen,
-)
+from fontTools.pens.pointPen import GuessSmoothPointPen, SegmentToPointPen
+from fontTools.pens.recordingPen import RecordingPen
+from fontTools.pens.transformPen import TransformPointPen
 from fontTools.svgLib import SVGPath
 from fontTools.ufoLib.glifLib import readGlyphFromString
 
@@ -22,13 +20,18 @@ def parseClipboard(data):
 
 def parseSVG(data):
     data = data.encode("utf-8")
-    svgPath = SVGPath.fromstring(data)
-    pen = PackedPathPointPen()
-    svgPath.draw(SegmentToPointPen(GuessSmoothPointPen(pen)))
-    path = pen.getPath()
+    svgPath = SVGPath.fromstring(data, transform=(1, 0, 0, -1, 0, 0))
+    recPen = RecordingPen()
+    svgPath.draw(recPen)
     boundsPen = ControlBoundsPen(None)
-    path.drawPoints(PointToSegmentPen(boundsPen))
-    return StaticGlyph(path=path, xAdvance=boundsPen.bounds[2])
+    recPen.replay(boundsPen)
+    xMin, yMin, xMax, yMax = boundsPen.bounds
+
+    pen = PackedPathPointPen()
+    tPen = TransformPointPen(pen, (1, 0, 0, 1, 0, -yMin))
+    recPen.replay(SegmentToPointPen(GuessSmoothPointPen(tPen)))
+
+    return StaticGlyph(path=pen.getPath(), xAdvance=xMax)
 
 
 def parseGLIF(data):

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -876,7 +876,6 @@ export class EditorController {
     };
 
     writeToClipboard(clipboardObject);
-    console.log("Glyph copied!");
   }
 
   canPaste() {

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -31,6 +31,7 @@ import {
   scheduleCalls,
   themeSwitchFromLocalStorage,
   throttleCalls,
+  range,
   readClipboard,
   readClipboardTypes,
   reversed,
@@ -890,12 +891,30 @@ export class EditorController {
       return;
     }
     await this.sceneController.editInstance((sendIncrementalChange, instance) => {
+      const selection = new Set();
+      for (const pointIndex of range(
+        instance.path.numPoints,
+        instance.path.numPoints + pastedGlyph.path.numPoints
+      )) {
+        selection.add(`point/${pointIndex}`);
+      }
+      for (const componentIndex of range(
+        instance.components.length,
+        instance.components.length + pastedGlyph.components.length
+      )) {
+        selection.add(`component/${componentIndex}`);
+      }
       const changes = recordChanges(instance, (instance) => {
         instance.path.appendPath(pastedGlyph.path);
+        instance.components.splice(
+          instance.components.length,
+          0,
+          ...pastedGlyph.components
+        );
       });
       return {
         changes: changes,
-        selection: new Set(),
+        selection: selection,
         undoLabel: "Paste",
         broadcast: true,
       };

--- a/src/fontra/views/editor/scene-draw-funcs.js
+++ b/src/fontra/views/editor/scene-draw-funcs.js
@@ -405,6 +405,9 @@ export const drawComponentSelectionLayer = requireEditingGlyph(
     const selectedComponentLineWidth = drawingParameters.selectedComponentLineWidth;
 
     for (const componentIndex of combinedComponentIndices || []) {
+      if (componentIndex >= glyph.components.length) {
+        continue;
+      }
       const drawSelectionFill =
         isHoverSelected || componentIndex !== hoveredComponentIndex;
       const componentPath = glyph.components[componentIndex].path2d;

--- a/test-py/test_clipboard.py
+++ b/test-py/test_clipboard.py
@@ -17,7 +17,7 @@ from fontra.core.packedpath import ContourInfo, PackedPath
             "</svg>",
             StaticGlyph(
                 path=PackedPath(
-                    coordinates=[60.0, 120.0, 110.0, 120.0, 110.0, 0.0, 60.0, 0.0],
+                    coordinates=[60.0, 0.0, 110.0, 0.0, 110.0, 120.0, 60.0, 120.0],
                     pointTypes=[0, 0, 0, 0],
                     contourInfo=[ContourInfo(endPoint=3, isClosed=True)],
                 ),


### PR DESCRIPTION
This implements paste from SVG and GLIF data. Part of #75 and #260.

To do:
- [x] Fix pasted SVG transformation (it's currently upside down)