### PR TITLE
Rework undo selection protocol to not have two ways to do the same thing

### DIFF
--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -998,9 +998,9 @@ export class EditorController {
           ...pastedGlyph.components
         );
       });
+      this.sceneController.selection = selection;
       return {
         changes: changes,
-        selection: selection,
         undoLabel: "Paste",
         broadcast: true,
       };
@@ -1041,9 +1041,9 @@ export class EditorController {
           }
         }
       });
+      this.sceneController.selection = new Set();
       return {
         changes: changes,
-        selection: new Set(),
         undoLabel: "Delete Selection",
         broadcast: true,
       };

--- a/src/fontra/views/editor/scene-controller.js
+++ b/src/fontra/views/editor/scene-controller.js
@@ -438,15 +438,11 @@ export class SceneController {
 
     const {
       changes: changes,
-      selection: newSelection, // Optional
       undoLabel: undoLabel,
       broadcast: broadcast,
     } = result || {};
 
     if (changes && changes.hasChange) {
-      if (newSelection) {
-        this.selection = newSelection;
-      }
       const undoInfo = {
         label: undoLabel,
         undoSelection: initialSelection,
@@ -528,9 +524,9 @@ export class SceneController {
           instance.path.insertContour(contourIndex, packedContour);
         }
       });
+      this.selection = newSelection;
       return {
         changes: changes,
-        selection: newSelection,
         undoLabel: "Reverse Contour Direction",
         broadcast: true,
       };
@@ -572,9 +568,9 @@ export class SceneController {
         });
       });
 
+      this.selection = newSelection;
       return {
         changes: changes,
-        selection: newSelection,
         undoLabel: "Set Start Point",
         broadcast: true,
       };
@@ -588,9 +584,9 @@ export class SceneController {
       const changes = recordChanges(instance, (instance) => {
         numSplits = splitPathAtPointIndices(instance.path, pointIndices);
       });
+      this.selection = new Set();
       return {
         changes: changes,
-        selection: new Set(),
         undoLabel: "Break Contour" + (numSplits > 1 ? "s" : ""),
         broadcast: true,
       };
@@ -626,9 +622,9 @@ export class SceneController {
         }
       });
 
+      this.selection = new Set();
       return {
         changes: changes,
-        selection: new Set(),
         undoLabel:
           "Decompose Component" + (componentSelection?.length === 1 ? "" : "s"),
         broadcast: true,


### PR DESCRIPTION
Setting the selection on the sceneController had the same effect as passing it as part of the undo info block. Since the former is more flexible, I removed the latter route.