### PR TITLE
Put GLIF data on plain text clipboard

### DIFF
--- a/src/fontra/backends/designspace.py
+++ b/src/fontra/backends/designspace.py
@@ -13,7 +13,7 @@ from fontTools.designspaceLib import DesignSpaceDocument
 from fontTools.misc.transform import Transform
 from fontTools.pens.recordingPen import RecordingPointPen
 from fontTools.ufoLib import UFOReader
-from fontTools.ufoLib.glifLib import GlyphSet
+from fontTools.ufoLib.glifLib import GlyphSet, writeGlyphToString
 
 from ..core.changes import applyChange
 from ..core.classes import (
@@ -555,3 +555,10 @@ def cleanupWatchFilesChanges(changes):
 def tuplifyLocation(loc):
     # TODO: find good place to share this (duplicated from opentype.py)
     return tuple(sorted(loc.items()))
+
+
+def serializeStaticGlyphAsGLIF(glyphName, staticGlyph, unicodes):
+    layerGlyph, drawPointsFunc = buildUFOLayerGlyph(
+        glyphSet={}, glyphName=glyphName, staticGlyph=staticGlyph, unicodes=unicodes
+    )
+    return writeGlyphToString(glyphName, layerGlyph, drawPointsFunc)

--- a/src/fontra/backends/designspace.py
+++ b/src/fontra/backends/designspace.py
@@ -13,7 +13,7 @@ from fontTools.designspaceLib import DesignSpaceDocument
 from fontTools.misc.transform import Transform
 from fontTools.pens.recordingPen import RecordingPointPen
 from fontTools.ufoLib import UFOReader
-from fontTools.ufoLib.glifLib import GlyphSet, writeGlyphToString
+from fontTools.ufoLib.glifLib import GlyphSet
 
 from ..core.changes import applyChange
 from ..core.classes import (
@@ -555,10 +555,3 @@ def cleanupWatchFilesChanges(changes):
 def tuplifyLocation(loc):
     # TODO: find good place to share this (duplicated from opentype.py)
     return tuple(sorted(loc.items()))
-
-
-def serializeStaticGlyphAsGLIF(glyphName, staticGlyph, unicodes):
-    layerGlyph, drawPointsFunc = buildUFOLayerGlyph(
-        glyphSet={}, glyphName=glyphName, staticGlyph=staticGlyph, unicodes=unicodes
-    )
-    return writeGlyphToString(glyphName, layerGlyph, drawPointsFunc)

--- a/src/fontra/client/core/font-controller.js
+++ b/src/fontra/client/core/font-controller.js
@@ -96,6 +96,15 @@ export class FontController {
     return result ? StaticGlyph.fromObject(result) : undefined;
   }
 
+  async serializeStaticGlyphAsGLIF(glyphName, staticGlyph) {
+    const result = await this.font.serializeStaticGlyphAsGLIF(
+      glyphName,
+      staticGlyph,
+      this.glyphMap[glyphName] || []
+    );
+    return result;
+  }
+
   hasGlyph(glyphName) {
     return glyphName in this.glyphMap;
   }

--- a/src/fontra/core/clipboard.py
+++ b/src/fontra/core/clipboard.py
@@ -3,9 +3,9 @@ from fontTools.pens.pointPen import GuessSmoothPointPen, SegmentToPointPen
 from fontTools.pens.recordingPen import RecordingPen
 from fontTools.pens.transformPen import TransformPointPen
 from fontTools.svgLib import SVGPath
-from fontTools.ufoLib.glifLib import readGlyphFromString
+from fontTools.ufoLib.glifLib import readGlyphFromString, writeGlyphToString
 
-from ..backends.designspace import UFOGlyph
+from ..backends.designspace import UFOGlyph, buildUFOLayerGlyph
 from .classes import StaticGlyph
 from .packedpath import PackedPathPointPen
 
@@ -47,3 +47,10 @@ def parseGLIF(data):
     return StaticGlyph(
         path=pen.getPath(), components=pen.components, xAdvance=ufoGlyph.width
     )
+
+
+def serializeStaticGlyphAsGLIF(glyphName, staticGlyph, unicodes):
+    layerGlyph, drawPointsFunc = buildUFOLayerGlyph(
+        glyphSet={}, glyphName=glyphName, staticGlyph=staticGlyph, unicodes=unicodes
+    )
+    return writeGlyphToString(glyphName, layerGlyph, drawPointsFunc)

--- a/src/fontra/core/fonthandler.py
+++ b/src/fontra/core/fonthandler.py
@@ -8,6 +8,7 @@ from copy import deepcopy
 from dataclasses import dataclass
 from typing import Any
 
+from ..backends.designspace import serializeStaticGlyphAsGLIF
 from .changes import (
     applyChange,
     collectChangePaths,
@@ -18,7 +19,7 @@ from .changes import (
     patternIntersect,
     patternUnion,
 )
-from .classes import Font
+from .classes import Font, StaticGlyph, from_dict
 from .clipboard import parseClipboard
 from .glyphnames import getSuggestedGlyphName, getUnicodeFromGlyphName
 from .lrucache import LRUCache
@@ -453,6 +454,13 @@ class FontHandler:
     @remoteMethod
     async def parseClipboard(self, data, *, connection):
         return parseClipboard(data)
+
+    @remoteMethod
+    async def serializeStaticGlyphAsGLIF(
+        self, glyphName, staticGlyph, unicodes, *, connection
+    ):
+        staticGlyph = from_dict(StaticGlyph, staticGlyph)
+        return serializeStaticGlyphAsGLIF(glyphName, staticGlyph, unicodes)
 
 
 def _iterAllComponentNames(glyph):

--- a/src/fontra/core/fonthandler.py
+++ b/src/fontra/core/fonthandler.py
@@ -8,7 +8,6 @@ from copy import deepcopy
 from dataclasses import dataclass
 from typing import Any
 
-from ..backends.designspace import serializeStaticGlyphAsGLIF
 from .changes import (
     applyChange,
     collectChangePaths,
@@ -20,7 +19,7 @@ from .changes import (
     patternUnion,
 )
 from .classes import Font, StaticGlyph, from_dict
-from .clipboard import parseClipboard
+from .clipboard import parseClipboard, serializeStaticGlyphAsGLIF
 from .glyphnames import getSuggestedGlyphName, getUnicodeFromGlyphName
 from .lrucache import LRUCache
 

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -894,10 +894,17 @@ export class EditorController {
     if (!bounds) {
       return;
     }
+    const preferGLIF = true; // TODO should be user preference
     const svgString = pathToSVG(path, bounds);
+    const glyphName = this.sceneController.getSelectedGlyphName();
+    const unicodes = this.fontController.glyphMap[glyphName] || [];
+    const glifString = await this.fontController.serializeStaticGlyphAsGLIF(
+      glyphName,
+      instance
+    );
 
     const clipboardObject = {
-      "text/plain": svgString,
+      "text/plain": preferGLIF ? glifString : svgString,
       "text/html": svgString,
       "web image/svg+xml": svgString,
       "web fontra/static-glyph": JSON.stringify(instance),

--- a/test-py/test_clipboard.py
+++ b/test-py/test_clipboard.py
@@ -1,7 +1,7 @@
 import pytest
 
 from fontra.core.classes import StaticGlyph
-from fontra.core.clipboard import parseClipboard
+from fontra.core.clipboard import parseClipboard, serializeStaticGlyphAsGLIF
 from fontra.core.packedpath import ContourInfo, PackedPath
 
 
@@ -60,6 +60,46 @@ from fontra.core.packedpath import ContourInfo, PackedPath
 )
 def test_parseClipboard(inputData, expectedResult):
     result = parseClipboard(inputData)
+    if result is not None:
+        result = result
+    assert expectedResult == result
+
+
+@pytest.mark.parametrize(
+    "glyphName, glyph, unicodes, expectedResult",
+    [
+        (
+            "period",
+            StaticGlyph(
+                path=PackedPath(
+                    coordinates=[60, 0, 110, 0, 110, 120, 60, 120],
+                    pointTypes=[0, 0, 0, 0],
+                    contourInfo=[ContourInfo(endPoint=3, isClosed=True)],
+                ),
+                components=[],
+                xAdvance=170,
+                yAdvance=None,
+                verticalOrigin=None,
+            ),
+            [0x002E],
+            "<?xml version='1.0' encoding='UTF-8'?>\n"
+            '<glyph name="period" format="2">\n'
+            '  <advance width="170"/>\n'
+            '  <unicode hex="002E"/>\n'
+            "  <outline>\n"
+            "    <contour>\n"
+            '      <point x="60" y="0" type="line"/>\n'
+            '      <point x="110" y="0" type="line"/>\n'
+            '      <point x="110" y="120" type="line"/>\n'
+            '      <point x="60" y="120" type="line"/>\n'
+            "    </contour>\n"
+            "  </outline>\n"
+            "</glyph>\n",
+        ),
+    ],
+)
+def test_serializeStaticGlyphAsGLIF(glyphName, glyph, unicodes, expectedResult):
+    result = serializeStaticGlyphAsGLIF(glyphName, glyph, unicodes)
     if result is not None:
         result = result
     assert expectedResult == result


### PR DESCRIPTION
This fixes #313.

- For now: put GLIF data on clipboard unconditionally, instead of SVG
- For now: do this via the server, as reimplementing in JS is more work
- Future: give the user an option between SVG, GLIF and JSON

~Perhaps needs a test case.~