### PR TITLE
Refactor common editInstance + recordChanges combinations

### DIFF
--- a/src/fontra/views/editor/edit-tools-pointer.js
+++ b/src/fontra/views/editor/edit-tools-pointer.js
@@ -172,59 +172,53 @@ export class PointerTool extends BaseTool {
   }
 
   async handlePointsDoubleClick(pointIndices) {
-    await this.sceneController.editInstance((sendIncrementalChange, instance) => {
-      const changes = recordChanges(instance, (instance) => {
-        const path = instance.path;
-        for (const pointIndex of pointIndices) {
-          const pointType = path.pointTypes[pointIndex];
-          const [prevIndex, prevPoint, nextIndex, nextPoint] = neighborPoints(
-            path,
-            pointIndex
-          );
-          if (
-            (!prevPoint || !nextPoint || (!prevPoint.type && !nextPoint.type)) &&
-            pointType !== VarPackedPath.SMOOTH_FLAG
-          ) {
-            continue;
-          }
-          if (
-            pointType === VarPackedPath.ON_CURVE ||
-            pointType === VarPackedPath.SMOOTH_FLAG
-          ) {
-            const newPointType =
-              pointType === VarPackedPath.ON_CURVE
-                ? VarPackedPath.SMOOTH_FLAG
-                : VarPackedPath.ON_CURVE;
-            path.pointTypes[pointIndex] = newPointType;
-            if (newPointType === VarPackedPath.SMOOTH_FLAG) {
-              const anchorPoint = path.getPoint(pointIndex);
-              if (prevPoint?.type && nextPoint?.type) {
-                // Fix-up both incoming and outgoing handles
-                const [newPrevPoint, newNextPoint] = alignHandles(
-                  prevPoint,
-                  anchorPoint,
-                  nextPoint
-                );
-                path.setPointPosition(prevIndex, newPrevPoint.x, newPrevPoint.y);
-                path.setPointPosition(nextIndex, newNextPoint.x, newNextPoint.y);
-              } else if (prevPoint?.type) {
-                // Fix-up incoming handle
-                const newPrevPoint = alignHandle(nextPoint, anchorPoint, prevPoint);
-                path.setPointPosition(prevIndex, newPrevPoint.x, newPrevPoint.y);
-              } else if (nextPoint?.type) {
-                // Fix-up outgoing handle
-                const newNextPoint = alignHandle(prevPoint, anchorPoint, nextPoint);
-                path.setPointPosition(nextIndex, newNextPoint.x, newNextPoint.y);
-              }
+    await this.sceneController.editInstanceAndRecordChanges((instance) => {
+      const path = instance.path;
+      for (const pointIndex of pointIndices) {
+        const pointType = path.pointTypes[pointIndex];
+        const [prevIndex, prevPoint, nextIndex, nextPoint] = neighborPoints(
+          path,
+          pointIndex
+        );
+        if (
+          (!prevPoint || !nextPoint || (!prevPoint.type && !nextPoint.type)) &&
+          pointType !== VarPackedPath.SMOOTH_FLAG
+        ) {
+          continue;
+        }
+        if (
+          pointType === VarPackedPath.ON_CURVE ||
+          pointType === VarPackedPath.SMOOTH_FLAG
+        ) {
+          const newPointType =
+            pointType === VarPackedPath.ON_CURVE
+              ? VarPackedPath.SMOOTH_FLAG
+              : VarPackedPath.ON_CURVE;
+          path.pointTypes[pointIndex] = newPointType;
+          if (newPointType === VarPackedPath.SMOOTH_FLAG) {
+            const anchorPoint = path.getPoint(pointIndex);
+            if (prevPoint?.type && nextPoint?.type) {
+              // Fix-up both incoming and outgoing handles
+              const [newPrevPoint, newNextPoint] = alignHandles(
+                prevPoint,
+                anchorPoint,
+                nextPoint
+              );
+              path.setPointPosition(prevIndex, newPrevPoint.x, newPrevPoint.y);
+              path.setPointPosition(nextIndex, newNextPoint.x, newNextPoint.y);
+            } else if (prevPoint?.type) {
+              // Fix-up incoming handle
+              const newPrevPoint = alignHandle(nextPoint, anchorPoint, prevPoint);
+              path.setPointPosition(prevIndex, newPrevPoint.x, newPrevPoint.y);
+            } else if (nextPoint?.type) {
+              // Fix-up outgoing handle
+              const newNextPoint = alignHandle(prevPoint, anchorPoint, nextPoint);
+              path.setPointPosition(nextIndex, newNextPoint.x, newNextPoint.y);
             }
           }
         }
-      });
-      return {
-        changes: changes,
-        undoLabel: "toggle smooth",
-        broadcast: true,
-      };
+      }
+      return "Toggle Smooth";
     });
   }
 

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -862,19 +862,15 @@ export class EditorController {
       return;
     }
     let copyResult;
-    await this.sceneController.editInstance((sendIncrementalChange, instance) => {
-      const changes = recordChanges(instance, (instance) => {
-        copyResult = this._prepareCopyOrCut(instance, true);
-      });
+    await this.sceneController.editInstanceAndRecordChanges((instance) => {
+      copyResult = this._prepareCopyOrCut(instance, true);
       this.sceneController.selection = new Set();
-      return {
-        changes: changes,
-        undoLabel: "Cut Selection",
-        broadcast: true,
-      };
+      return "Cut Selection";
     });
-    const { instance, path } = copyResult;
-    await this._writeInstanceToClipboard(instance, path);
+    if (copyResult) {
+      const { instance, path } = copyResult;
+      await this._writeInstanceToClipboard(instance, path);
+    }
   }
 
   canCopy() {

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -979,7 +979,7 @@ export class EditorController {
     if (!pastedGlyph) {
       return;
     }
-    await this.sceneController.editInstance((sendIncrementalChange, instance) => {
+    await this.sceneController.editInstanceAndRecordChanges((instance) => {
       const selection = new Set();
       for (const pointIndex of range(
         instance.path.numPoints,
@@ -993,20 +993,14 @@ export class EditorController {
       )) {
         selection.add(`component/${componentIndex}`);
       }
-      const changes = recordChanges(instance, (instance) => {
-        instance.path.appendPath(pastedGlyph.path);
-        instance.components.splice(
-          instance.components.length,
-          0,
-          ...pastedGlyph.components
-        );
-      });
+      instance.path.appendPath(pastedGlyph.path);
+      instance.components.splice(
+        instance.components.length,
+        0,
+        ...pastedGlyph.components
+      );
       this.sceneController.selection = selection;
-      return {
-        changes: changes,
-        undoLabel: "Paste",
-        broadcast: true,
-      };
+      return "Paste";
     });
   }
 

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -1020,30 +1020,24 @@ export class EditorController {
   }
 
   async doDelete() {
-    await this.sceneController.editInstance((sendIncrementalChange, instance) => {
+    await this.sceneController.editInstanceAndRecordChanges((instance) => {
       const { point: pointSelection, component: componentSelection } = parseSelection(
         this.sceneController.selection
       );
 
-      const changes = recordChanges(instance, (instance) => {
-        const path = instance.path;
+      const path = instance.path;
 
-        if (pointSelection) {
-          deleteSelectedPoints(path, pointSelection);
-        }
+      if (pointSelection) {
+        deleteSelectedPoints(path, pointSelection);
+      }
 
-        if (componentSelection) {
-          for (const componentIndex of reversed(componentSelection)) {
-            instance.components.splice(componentIndex, 1);
-          }
+      if (componentSelection) {
+        for (const componentIndex of reversed(componentSelection)) {
+          instance.components.splice(componentIndex, 1);
         }
-      });
+      }
       this.sceneController.selection = new Set();
-      return {
-        changes: changes,
-        undoLabel: "Delete Selection",
-        broadcast: true,
-      };
+      return "Delete Selection";
     });
   }
 

--- a/src/fontra/views/editor/scene-controller.js
+++ b/src/fontra/views/editor/scene-controller.js
@@ -580,18 +580,12 @@ export class SceneController {
   }
 
   async breakContour() {
-    await this.editInstance(async (sendIncrementalChange, instance) => {
+    await this.editInstanceAndRecordChanges((instance) => {
       let numSplits;
       const { point: pointIndices } = parseSelection(this.selection);
-      const changes = recordChanges(instance, (instance) => {
-        numSplits = splitPathAtPointIndices(instance.path, pointIndices);
-      });
+      numSplits = splitPathAtPointIndices(instance.path, pointIndices);
       this.selection = new Set();
-      return {
-        changes: changes,
-        undoLabel: "Break Contour" + (numSplits > 1 ? "s" : ""),
-        broadcast: true,
-      };
+      return "Break Contour" + (numSplits > 1 ? "s" : "");
     });
   }
 


### PR DESCRIPTION
Adding `sceneController.editInstanceAndRecordChanges()`, which combines `editInstance` and `recordChanges`, allowing to simplify several cases where the two are used in direct combination.