### PR TITLE
Copy paste custom data in Safari and Firefox

### DIFF
--- a/src/fontra/client/core/utils.js
+++ b/src/fontra/client/core/utils.js
@@ -235,16 +235,12 @@ export async function writeToClipboard(clipboardObject) {
   try {
     await navigator.clipboard.write([new ClipboardItem(clipboardItemObject)]);
   } catch {
-    // Write at least the plain/text MIME type to the clipboard
-    if (clipboardObject["text/plain"])
-      try {
-        await navigator.clipboard.writeText(clipboardObject["text/plain"]);
-      } catch {
-        // TODO: Safari complains that this needs to be handled. It's probably right.
-      }
-
     // Write to LocalStorage for internal Fontra use
     writeToLocalStorage(clipboardObject);
+
+    // Write at least the plain/text MIME type to the clipboard
+    if (clipboardObject["text/plain"])
+      await navigator.clipboard.writeText(clipboardObject["text/plain"]);
   }
 }
 

--- a/src/fontra/client/core/utils.js
+++ b/src/fontra/client/core/utils.js
@@ -237,9 +237,13 @@ export async function writeToClipboard(clipboardObject) {
   } catch {
     // Write at least the plain/text MIME type to the clipboard
     if (clipboardObject["text/plain"])
-      navigator.clipboard.writeText(clipboardObject["text/plain"]);
+      try {
+        await navigator.clipboard.writeText(clipboardObject["text/plain"]);
+      } catch {
+        // TODO: Safari complains that this needs to be handled. It's probably right.
+      }
 
-    // If custom web MIME type is unsupported, write to LocalStorage for internal Fontra use
+    // Write to LocalStorage for internal Fontra use
     writeToLocalStorage(clipboardObject);
   }
 }
@@ -273,6 +277,7 @@ function writeToLocalStorage(clipboardObject) {
 
   for (const [clipboardName, clipboardType] of Object.entries(allowedTypes)) {
     const clipboardItem = clipboardObject[clipboardType];
+
     localStorage.setItem(clipboardName, clipboardItem);
   }
 }

--- a/src/fontra/client/core/utils.js
+++ b/src/fontra/client/core/utils.js
@@ -1,5 +1,3 @@
-import { deepCompare } from "./var-model.js";
-
 export function objectsEqual(obj1, obj2) {
   // Shallow object compare. Arguments may be null or undefined
   if (!obj1 || !obj2) {
@@ -281,20 +279,4 @@ function writeToLocalStorage(clipboardObject) {
 
     localStorage.setItem(clipboardName, clipboardItem);
   }
-}
-
-export function deepCompareGlyphPaths(glyphA, glyphB) {
-  if (typeof glyphA !== typeof glyphB && typeof glyphA === "object") {
-    throw new TypeError(
-      `can't compare entities of types: ${typeof glyphA} and ${typeof glyphB}`
-    );
-  }
-
-  const coordinatesCompare = deepCompare(
-    glyphA.path.coordinates,
-    glyphB.path.coordinates
-  );
-  const pointTypesCompare = deepCompare(glyphA.path.pointTypes, glyphB.path.pointTypes);
-
-  return coordinatesCompare === 0 && pointTypesCompare === 0;
 }

--- a/src/fontra/client/core/utils.js
+++ b/src/fontra/client/core/utils.js
@@ -232,7 +232,9 @@ export async function writeToClipboard(clipboardObject) {
     });
   }
 
-  navigator.clipboard.write([new ClipboardItem(clipboardItemObject)]);
+  navigator.clipboard.write([new ClipboardItem(clipboardItemObject)]).catch((error) => {
+    writeTextToClipboard(clipboardObject);
+  });
 }
 
 export async function readClipboardTypes() {
@@ -254,4 +256,9 @@ export async function readFromClipboard(type) {
     }
   }
   return undefined;
+}
+
+function writeTextToClipboard(clipboardObject) {
+  if (clipboardObject["text/plain"])
+    navigator.clipboard.writeText(clipboardObject["text/plain"]);
 }

--- a/src/fontra/client/core/utils.js
+++ b/src/fontra/client/core/utils.js
@@ -244,7 +244,7 @@ export async function readClipboardTypes() {
   return clipboardTypes;
 }
 
-export async function readClipboard(type) {
+export async function readFromClipboard(type) {
   const clipboardObject = {};
   const clipboardContents = await navigator.clipboard.read();
   for (const item of clipboardContents) {

--- a/src/fontra/client/core/utils.js
+++ b/src/fontra/client/core/utils.js
@@ -1,3 +1,5 @@
+import { deepCompare } from "./var-model.js";
+
 export function objectsEqual(obj1, obj2) {
   // Shallow object compare. Arguments may be null or undefined
   if (!obj1 || !obj2) {
@@ -258,7 +260,6 @@ export async function readClipboardTypes() {
 }
 
 export async function readFromClipboard(type) {
-  const clipboardObject = {};
   const clipboardContents = await navigator.clipboard.read();
   for (const item of clipboardContents) {
     if (item.types.includes(type)) {
@@ -280,4 +281,20 @@ function writeToLocalStorage(clipboardObject) {
 
     localStorage.setItem(clipboardName, clipboardItem);
   }
+}
+
+export function deepCompareGlyphPaths(glyphA, glyphB) {
+  if (typeof glyphA !== typeof glyphB && typeof glyphA === "object") {
+    throw new TypeError(
+      `can't compare entities of types: ${typeof glyphA} and ${typeof glyphB}`
+    );
+  }
+
+  const coordinatesCompare = deepCompare(
+    glyphA.path.coordinates,
+    glyphB.path.coordinates
+  );
+  const pointTypesCompare = deepCompare(glyphA.path.pointTypes, glyphB.path.pointTypes);
+
+  return coordinatesCompare === 0 && pointTypesCompare === 0;
 }

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -34,8 +34,7 @@ import {
   themeSwitchFromLocalStorage,
   throttleCalls,
   range,
-  readClipboard,
-  readClipboardTypes,
+  readFromClipboard,
   reversed,
   writeToClipboard,
 } from "../core/utils.js";
@@ -971,11 +970,11 @@ export class EditorController {
 
   async doPaste() {
     let pastedGlyph;
-    const customJSON = await readClipboard("web fontra/static-glyph");
+    const customJSON = await readFromClipboard("web fontra/static-glyph");
     if (customJSON) {
       pastedGlyph = StaticGlyph.fromObject(JSON.parse(customJSON));
     } else {
-      const plainText = await readClipboard("text/plain");
+      const plainText = await readFromClipboard("text/plain");
       if (plainText) {
         pastedGlyph = await this.fontController.parseClipboard(plainText);
       }

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -37,6 +37,7 @@ import {
   readFromClipboard,
   reversed,
   writeToClipboard,
+  deepCompareGlyphPaths,
 } from "../core/utils.js";
 import { SceneController } from "./scene-controller.js";
 import * as sceneDraw from "./scene-draw-funcs.js";
@@ -974,20 +975,29 @@ export class EditorController {
 
   async doPaste() {
     let pastedGlyph;
-    const customJSON =
-      (await readFromClipboard("web fontra/static-glyph")) ||
-      localStorage.getItem("clipboardSelection.glyph");
-    if (customJSON) {
-      pastedGlyph = StaticGlyph.fromObject(JSON.parse(customJSON));
-    } else {
-      const plainText = await readFromClipboard("text/plain");
-      if (plainText) {
-        pastedGlyph = await this.fontController.parseClipboard(plainText);
-      }
+
+    const plainText = await readFromClipboard("text/plain");
+    if (plainText) {
+      pastedGlyph = await this.fontController.parseClipboard(plainText);
     }
+
+    const isTheSameGlyphPath = deepCompareGlyphPaths(
+      pastedGlyph,
+      JSON.parse(localStorage.getItem("clipboardSelection.glyph"))
+    );
+
+    if (isTheSameGlyphPath) {
+      const customJSON =
+        (await readFromClipboard("web fontra/static-glyph")) ||
+        localStorage.getItem("clipboardSelection.glyph");
+
+      pastedGlyph = StaticGlyph.fromObject(JSON.parse(customJSON));
+    }
+
     if (!pastedGlyph) {
       return;
     }
+
     await this.sceneController.editInstance((sendIncrementalChange, instance) => {
       const selection = new Set();
       for (const pointIndex of range(

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -970,7 +970,9 @@ export class EditorController {
 
   async doPaste() {
     let pastedGlyph;
-    const customJSON = await readFromClipboard("web fontra/static-glyph");
+    const customJSON =
+      (await readFromClipboard("web fontra/static-glyph")) ||
+      localStorage.getItem("clipboardSelection.glyph");
     if (customJSON) {
       pastedGlyph = StaticGlyph.fromObject(JSON.parse(customJSON));
     } else {

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -804,7 +804,11 @@ export class EditorController {
     if (callback !== undefined) {
       event.preventDefault();
       event.stopImmediatePropagation();
-      await callback(event);
+      try {
+        await callback(event);
+      } catch {
+        // TODO: Safari complains that this needs to be handled. It's probably right.
+      }
     }
   }
 

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -37,7 +37,6 @@ import {
   readFromClipboard,
   reversed,
   writeToClipboard,
-  deepCompareGlyphPaths,
 } from "../core/utils.js";
 import { SceneController } from "./scene-controller.js";
 import * as sceneDraw from "./scene-draw-funcs.js";
@@ -981,10 +980,8 @@ export class EditorController {
       pastedGlyph = await this.fontController.parseClipboard(plainText);
     }
 
-    const isTheSameGlyphPath = deepCompareGlyphPaths(
-      pastedGlyph,
-      JSON.parse(localStorage.getItem("clipboardSelection.glyph"))
-    );
+    const isTheSameGlyphPath =
+      JSON.stringify(pastedGlyph) === localStorage.getItem("clipboardSelection.glyph");
 
     if (isTheSameGlyphPath) {
       const customJSON =


### PR DESCRIPTION
Fixes #312 
This manages to:
– copy/paste within Fontra in any browser
– copy/paste between Fontra and RF in any browser
