### PR TITLE
Rework event clipboard

### DIFF
--- a/src/fontra/client/core/font-controller.js
+++ b/src/fontra/client/core/font-controller.js
@@ -96,15 +96,6 @@ export class FontController {
     return result ? StaticGlyph.fromObject(result) : undefined;
   }
 
-  async serializeStaticGlyphAsGLIF(glyphName, staticGlyph) {
-    const result = await this.font.serializeStaticGlyphAsGLIF(
-      glyphName,
-      staticGlyph,
-      this.glyphMap[glyphName] || []
-    );
-    return result;
-  }
-
   hasGlyph(glyphName) {
     return glyphName in this.glyphMap;
   }

--- a/src/fontra/client/core/glyph-controller.js
+++ b/src/fontra/client/core/glyph-controller.js
@@ -4,7 +4,7 @@ import {
   registerRepresentationFactory,
 } from "./representation-cache.js";
 import { Transform } from "./transform.js";
-import { enumerate } from "./utils.js";
+import { enumerate, makeAffineTransform } from "./utils.js";
 import { StaticGlyph } from "./var-glyph.js";
 import {
   VariationModel,
@@ -562,22 +562,6 @@ function mergeLocations(loc1, loc2) {
     return loc2;
   }
   return { ...loc1, ...loc2 };
-}
-
-function makeAffineTransform(transformation) {
-  let t = new Transform();
-  t = t.translate(
-    transformation.translateX + transformation.tCenterX,
-    transformation.translateY + transformation.tCenterY
-  );
-  t = t.rotate(transformation.rotation * (Math.PI / 180));
-  t = t.scale(transformation.scaleX, transformation.scaleY);
-  t = t.skew(
-    -transformation.skewX * (Math.PI / 180),
-    transformation.skewY * (Math.PI / 180)
-  );
-  t = t.translate(-transformation.tCenterX, -transformation.tCenterY);
-  return t;
 }
 
 function decomposeAffineTransform(affine) {

--- a/src/fontra/client/core/glyph-glif.js
+++ b/src/fontra/client/core/glyph-glif.js
@@ -5,12 +5,16 @@ export function staticGlyphToGLIF(glyphName, glyph, unicodes) {
     "<?xml version='1.0' encoding='UTF-8'?>",
     `<glyph name="${glyphName}" format="2">`,
   ];
+
   for (const codePoint of unicodes || []) {
     const unicode_hex = codePoint.toString(16).toUpperCase().padStart(4, "0");
     lines.push(`  <unicode hex="${unicode_hex}"/>`);
   }
-  lines.push("  <outline>");
+
   const typeMap = { cubic: "curve", quad: "qcurve" };
+
+  lines.push("  <outline>");
+
   for (const contour of glyph.path.iterUnpackedContours()) {
     const points = contour.points;
     lines.push("    <contour>");

--- a/src/fontra/client/core/glyph-glif.js
+++ b/src/fontra/client/core/glyph-glif.js
@@ -1,0 +1,83 @@
+import { makeAffineTransform } from "./utils.js";
+
+export function staticGlyphToGLIF(glyphName, glyph, unicodes) {
+  const lines = [
+    "<?xml version='1.0' encoding='UTF-8'?>",
+    `<glyph name="${glyphName}" format="2">`,
+  ];
+  for (const codePoint of unicodes || []) {
+    const unicode_hex = codePoint.toString(16).toUpperCase().padStart(4, "0");
+    lines.push(`  <unicode hex="${unicode_hex}"/>`);
+  }
+  lines.push("  <outline>");
+  const typeMap = { cubic: "curve", quad: "qcurve" };
+  for (const contour of glyph.path.iterUnpackedContours()) {
+    const points = contour.points;
+    lines.push("    <contour>");
+
+    let curveType;
+    if (contour.isClosed) {
+      curveType = typeMap[points.at(-1).type] || "line";
+    } else {
+      // strip leading and trailing off-curve points
+      while (points.length && points[0].type) {
+        points.shift();
+      }
+      while (points.length && points.at(-1).type) {
+        points.pop();
+      }
+      curveType = "move";
+    }
+    const numPoints = points.length;
+
+    for (const point of points) {
+      const attrs = { x: point.x, y: point.y };
+      if (point.type) {
+        curveType = typeMap[point.type] || "line";
+      } else {
+        attrs["type"] = curveType;
+        curveType = "line";
+      }
+      if (point.smooth) {
+        attrs["smooth"] = "yes";
+      }
+      lines.push(`      <point ${formatAttributes(attrs)}/>`);
+    }
+    lines.push("    </contour>");
+  }
+
+  for (const component of glyph.components) {
+    if (Object.keys(component.location).length) {
+      // Skip variable components for now
+      // TODO: implement variable-components-in-ufo
+      continue;
+    }
+    const t = makeAffineTransform(component.transformation);
+    const attrs = { base: component.name };
+    for (const [fontraField, ufoField, defaultValue] of transformFieldsMap) {
+      if (t[fontraField] != defaultValue) {
+        attrs[ufoField] = t[fontraField];
+      }
+    }
+    lines.push(`    <component ${formatAttributes(attrs)}/>`);
+  }
+
+  lines.push("  </outline>");
+  lines.push("</glyph>");
+  return lines.join("\n") + "\n";
+}
+
+function formatAttributes(attrs) {
+  return Object.entries(attrs)
+    .map((item) => `${item[0]}="${item[1]}"`)
+    .join(" ");
+}
+
+const transformFieldsMap = [
+  ["xx", "xScale", 1],
+  ["xy", "xyScale", 0],
+  ["yx", "yxScale", 0],
+  ["yy", "yScale", 1],
+  ["dx", "xOffset", 0],
+  ["dy", "yOffset", 0],
+];

--- a/src/fontra/client/core/utils.js
+++ b/src/fontra/client/core/utils.js
@@ -1,3 +1,5 @@
+import { Transform } from "./transform.js";
+
 export function objectsEqual(obj1, obj2) {
   // Shallow object compare. Arguments may be null or undefined
   if (!obj1 || !obj2) {
@@ -279,4 +281,20 @@ export function writeClipboardToLocalStorage(clipboardObject) {
       localStorage.removeItem(clipboardItemKey);
     }
   }
+}
+
+export function makeAffineTransform(transformation) {
+  let t = new Transform();
+  t = t.translate(
+    transformation.translateX + transformation.tCenterX,
+    transformation.translateY + transformation.tCenterY
+  );
+  t = t.rotate(transformation.rotation * (Math.PI / 180));
+  t = t.scale(transformation.scaleX, transformation.scaleY);
+  t = t.skew(
+    -transformation.skewX * (Math.PI / 180),
+    transformation.skewY * (Math.PI / 180)
+  );
+  t = t.translate(-transformation.tCenterX, -transformation.tCenterY);
+  return t;
 }

--- a/src/fontra/core/fonthandler.py
+++ b/src/fontra/core/fonthandler.py
@@ -18,8 +18,8 @@ from .changes import (
     patternIntersect,
     patternUnion,
 )
-from .classes import Font, StaticGlyph, from_dict
-from .clipboard import parseClipboard, serializeStaticGlyphAsGLIF
+from .classes import Font
+from .clipboard import parseClipboard
 from .glyphnames import getSuggestedGlyphName, getUnicodeFromGlyphName
 from .lrucache import LRUCache
 
@@ -453,13 +453,6 @@ class FontHandler:
     @remoteMethod
     async def parseClipboard(self, data, *, connection):
         return parseClipboard(data)
-
-    @remoteMethod
-    async def serializeStaticGlyphAsGLIF(
-        self, glyphName, staticGlyph, unicodes, *, connection
-    ):
-        staticGlyph = from_dict(StaticGlyph, staticGlyph)
-        return serializeStaticGlyphAsGLIF(glyphName, staticGlyph, unicodes)
 
 
 def _iterAllComponentNames(glyph):


### PR DESCRIPTION
Fixes #328.

- This adds a JS implementation to write GLIF data
- Removes the "pre-copy" logic on selection change
- Refactors a bit to mostly reuse the regular doCut and doCopy code