### PR TITLE
[clipboard] Always write clipboard to localStorage

### DIFF
--- a/src/fontra/client/core/utils.js
+++ b/src/fontra/client/core/utils.js
@@ -236,10 +236,7 @@ export async function writeToClipboard(clipboardObject) {
 
   try {
     await navigator.clipboard.write([new ClipboardItem(clipboardItemObject)]);
-  } catch {
-    // Write to LocalStorage for internal Fontra use
-    writeClipboardToLocalStorage(clipboardObject);
-
+  } catch (error) {
     // Write at least the plain/text MIME type to the clipboard
     if (clipboardObject["text/plain"]) {
       await navigator.clipboard.writeText(clipboardObject["text/plain"]);
@@ -265,22 +262,6 @@ export async function readFromClipboard(type) {
     }
   }
   return undefined;
-}
-
-export function writeClipboardToLocalStorage(clipboardObject) {
-  const localStorageTypeMapping = [
-    ["text/plain", "clipboardSelection.text-plain"],
-    ["web fontra/static-glyph", "clipboardSelection.glyph"],
-  ];
-
-  for (const [clipboardType, clipboardItemKey] of localStorageTypeMapping) {
-    const clipboardItem = clipboardObject[clipboardType];
-    if (clipboardItem) {
-      localStorage.setItem(clipboardItemKey, clipboardItem);
-    } else {
-      localStorage.removeItem(clipboardItemKey);
-    }
-  }
 }
 
 export function makeAffineTransform(transformation) {

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -37,7 +37,6 @@ import {
   readFromClipboard,
   reversed,
   writeToClipboard,
-  writeClipboardToLocalStorage,
 } from "../core/utils.js";
 import { SceneController } from "./scene-controller.js";
 import * as sceneDraw from "./scene-draw-funcs.js";
@@ -935,11 +934,18 @@ export class EditorController {
     const { glifString, svgString } = this._getGLIFandSVGStrings(instance, path);
 
     const preferGLIF = true; // TODO should be user preference
+
+    const plainText = preferGLIF ? glifString : svgString;
+    const customJSON = JSON.stringify(instance);
+
+    localStorage.setItem("clipboardSelection.text-plain", plainText);
+    localStorage.setItem("clipboardSelection.glyph", customJSON);
+
     const clipboardObject = {
-      "text/plain": preferGLIF ? glifString : svgString,
+      "text/plain": plainText,
       "text/html": svgString,
       "web image/svg+xml": svgString,
-      "web fontra/static-glyph": JSON.stringify(instance),
+      "web fontra/static-glyph": customJSON,
     };
 
     await writeToClipboard(clipboardObject);
@@ -951,11 +957,12 @@ export class EditorController {
     const preferGLIF = true; // TODO should be user preference
 
     const plainText = preferGLIF ? glifString : svgString;
+    const customJSON = JSON.stringify(instance);
+
+    localStorage.setItem("clipboardSelection.text-plain", plainText);
+    localStorage.setItem("clipboardSelection.glyph", customJSON);
+
     event.clipboardData.setData("text/plain", plainText);
-    writeClipboardToLocalStorage({
-      "text/plain": plainText,
-      "web fontra/static-glyph": JSON.stringify(instance),
-    });
   }
 
   _prepareCopyOrCut(editInstance, doCut = false) {


### PR DESCRIPTION
While this is redundant on Chrome, it simplifies the code, and makes the localSorage clipboard code behave consistently between Firefox and Safari.
 
Fixes #331