### PR TITLE
Add Settings panel to the sidebar

### DIFF
--- a/src/fontra/client/core/utils.js
+++ b/src/fontra/client/core/utils.js
@@ -96,7 +96,6 @@ export function hyphenatedToCamelCase(s) {
 }
 
 export const THEME_KEY = "fontra-theme";
-export const CLIPBOARD_FORMAT_KEY = "fontra-clipboard-format";
 
 export function themeSwitch(value) {
   const rootElement = document.querySelector("html");
@@ -122,10 +121,6 @@ function _themeSwitchFromLocalStorage() {
   if (themeValue) {
     themeSwitch(themeValue);
   }
-}
-
-export function clipboardFormatSwitch(value) {
-  localStorage.setItem(CLIPBOARD_FORMAT_KEY, value);
 }
 
 export function hasShortcutModifierKey(event) {

--- a/src/fontra/client/core/utils.js
+++ b/src/fontra/client/core/utils.js
@@ -109,9 +109,13 @@ export function themeSwitch(value) {
 export function themeSwitchFromLocalStorage() {
   _themeSwitchFromLocalStorage();
 
-  addEventListener("storage", (event) => {
+  window.addEventListener("storage", (event) => {
     if (event.key === THEME_KEY) {
       _themeSwitchFromLocalStorage();
+      const event = new CustomEvent("fontra-theme-switch", {
+        bubbles: false,
+      });
+      window.dispatchEvent(event);
     }
   });
 }

--- a/src/fontra/client/core/utils.js
+++ b/src/fontra/client/core/utils.js
@@ -96,6 +96,7 @@ export function hyphenatedToCamelCase(s) {
 }
 
 export const THEME_KEY = "fontra-theme";
+export const CLIPBOARD_FORMAT_KEY = "fontra-clipboard-format";
 
 export function themeSwitch(value) {
   const rootElement = document.querySelector("html");
@@ -121,6 +122,10 @@ function _themeSwitchFromLocalStorage() {
   if (themeValue) {
     themeSwitch(themeValue);
   }
+}
+
+export function clipboardFormatSwitch(value) {
+  localStorage.setItem(CLIPBOARD_FORMAT_KEY, value);
 }
 
 export function hasShortcutModifierKey(event) {

--- a/src/fontra/client/settings.html
+++ b/src/fontra/client/settings.html
@@ -21,68 +21,15 @@
       h2 {
         font-size: 1em;
       }
-
-      #settings-theme {
-        display: grid;
-        grid-template-columns: min-content min-content;
-      }
     </style>
+        <script type="module" src="/web-components/general-settings.js"></script>
   </head>
   <body>
     <a href="/"><img src="/images/fontra-icon.svg" width="100" height="100" /></a>
     <div>
       <h1>Fontra Settings</h1>
       <h2>Theme</h2>
-      <div id="settings-theme">
-        <input
-          id="theme-automatic"
-          value="automatic"
-          onclick="themeSwitchCallback()"
-          name="theme-settings"
-          type="radio"
-          checked
-        />
-        <label for="theme-automatic">Automatic (use OS setting)</label>
-
-        <input
-          id="theme-light"
-          value="light"
-          onclick="themeSwitchCallback()"
-          name="theme-settings"
-          type="radio"
-        />
-        <label for="theme-light">Light theme</label>
-
-        <input
-          id="theme-dark"
-          value="dark"
-          onclick="themeSwitchCallback()"
-          name="theme-settings"
-          type="radio"
-        />
-        <label for="theme-dark">Dark theme</label>
-      </div>
-    </div>
+      <general-settings/>
+      
   </body>
-  <script type="module">
-    import { THEME_KEY, themeSwitch } from "./core/utils.js";
-
-    function themeSwitchCallback() {
-      const themeValue = document.querySelector(
-        'input[name="theme-settings"]:checked'
-      ).value;
-      themeSwitch(themeValue);
-      localStorage.setItem(THEME_KEY, themeValue);
-    }
-
-    window.themeSwitchCallback = themeSwitchCallback;
-
-    const themeValue = localStorage.getItem("fontra-theme");
-    if (themeValue) {
-      for (const element of document.querySelectorAll('input[name="theme-settings"]')) {
-        element.checked = themeValue === element.value;
-      }
-      themeSwitch(themeValue);
-    }
-  </script>
 </html>

--- a/src/fontra/client/settings.html
+++ b/src/fontra/client/settings.html
@@ -17,15 +17,13 @@
       h1 {
         font-size: 1.5em;
       }
-
-
     </style>
         <script type="module" src="/web-components/general-settings.js"></script>
   </head>
   <body>
     <a href="/"><img src="/images/fontra-icon.svg" width="100" height="100" /></a>
     <div>
+      <h1>Fontra Settings</h1>
       <general-settings/>
-      
   </body>
 </html>

--- a/src/fontra/client/settings.html
+++ b/src/fontra/client/settings.html
@@ -18,17 +18,13 @@
         font-size: 1.5em;
       }
 
-      h2 {
-        font-size: 1em;
-      }
+
     </style>
         <script type="module" src="/web-components/general-settings.js"></script>
   </head>
   <body>
     <a href="/"><img src="/images/fontra-icon.svg" width="100" height="100" /></a>
     <div>
-      <h1>Fontra Settings</h1>
-      <h2>Theme</h2>
       <general-settings/>
       
   </body>

--- a/src/fontra/client/settings.html
+++ b/src/fontra/client/settings.html
@@ -18,12 +18,17 @@
         font-size: 1.5em;
       }
     </style>
-        <script type="module" src="/web-components/general-settings.js"></script>
+    <script type="module" src="/web-components/general-settings.js"></script>
   </head>
   <body>
     <a href="/"><img src="/images/fontra-icon.svg" width="100" height="100" /></a>
     <div>
       <h1>Fontra Settings</h1>
-      <general-settings/>
+      <general-settings />
+    </div>
   </body>
+  <script type="module">
+    import { themeSwitchFromLocalStorage } from "./core/utils.js";
+    themeSwitchFromLocalStorage();
+  </script>
 </html>

--- a/src/fontra/client/web-components/general-settings.js
+++ b/src/fontra/client/web-components/general-settings.js
@@ -1,5 +1,10 @@
 import { html, css, LitElement } from "https://cdn.jsdelivr.net/npm/lit@2.6.1/+esm";
-import { THEME_KEY, themeSwitch } from "../core/utils.js";
+import {
+  THEME_KEY,
+  themeSwitch,
+  CLIPBOARD_FORMAT_KEY,
+  clipboardFormatSwitch,
+} from "../core/utils.js";
 export class GeneralSettings extends LitElement {
   static styles = css`
     h2 {
@@ -14,19 +19,31 @@ export class GeneralSettings extends LitElement {
 
   constructor() {
     super();
-    this.settingOptions = [
-      ["theme-automatic", "automatic", "Automatic (use OS setting)"],
-      ["theme-light", "light", "Light theme"],
-      ["theme-dark", "dark", "Dark theme"],
-    ];
-    this.checked = "automatic"; // checked by default
+    this.themeOptions = {
+      options: [
+        ["theme-automatic", "automatic", "Automatic (use OS setting)"],
+        ["theme-light", "light", "Light theme"],
+        ["theme-dark", "dark", "Dark theme"],
+      ],
+      checked: "automatic", // checked by default
+    };
+
+    this.clipboardFormatOptions = {
+      options: [
+        ["clipboard-format-svg", "svg", "SVG"],
+        ["clipboard-format-glif", "glif", "GLIF (RoboFont)"],
+        ["clipboard-format-json", "json", "JSON (Fontra)"],
+      ],
+      checked: "glif", // checked by default
+    };
+
     this.setupSettings();
   }
 
   themeSettings() {
     return html`
       <h2>Theme</h2>
-      ${this.settingOptions.map((option) => {
+      ${this.themeOptions.options.map((option) => {
         const [optionId, optionValue, optionLabel] = option;
         return html`
           <div id="settings-theme">
@@ -36,7 +53,7 @@ export class GeneralSettings extends LitElement {
               @click=${(option) => this.themeSwitchCallback(option)}
               name="theme-settings"
               type="radio"
-              .checked=${this.checked === optionValue}
+              .checked=${this.themeOptions.checked === optionValue}
             />
             <label for="${optionId}">${optionLabel}</label>
           </div>
@@ -45,17 +62,41 @@ export class GeneralSettings extends LitElement {
     `;
   }
 
+  clipboardFormatSettings() {
+    return html` <h2>Clipboard Export Format</h2>
+      ${this.clipboardFormatOptions.options.map((option) => {
+        const [optionId, optionValue, optionLabel] = option;
+        return html`
+          <div id="settings-clipboard-format">
+            <input
+              id="${optionId}"
+              value="${optionValue}"
+              @click=${(option) => this.clipboardFormatSwitchCallback(option)}
+              name="clipboard-format-settings"
+              type="radio"
+              .checked=${this.clipboardFormatOptions.checked === optionValue}
+            />
+            <label for="${optionId}">${optionLabel}</label>
+          </div>
+        `;
+      })}`;
+  }
+
   render() {
-    return this.themeSettings();
+    return html` ${this.themeSettings()} ${this.clipboardFormatSettings()} `;
   }
 
   setupSettings() {
-    window.themeSwitchCallback = this.themeSwitchCallback;
-
-    const themeValue = localStorage.getItem("fontra-theme");
+    const themeValue = localStorage.getItem(THEME_KEY);
     if (themeValue) {
-      this.checked = themeValue;
+      this.themeOptions.checked = themeValue;
       themeSwitch(themeValue);
+    }
+
+    const clipboardFormatValue = localStorage.getItem(CLIPBOARD_FORMAT_KEY);
+    if (clipboardFormatValue) {
+      this.clipboardFormatOptions.checked = clipboardFormatValue;
+      clipboardFormatSwitch(clipboardFormatValue);
     }
   }
 
@@ -63,6 +104,12 @@ export class GeneralSettings extends LitElement {
     const themeValue = option.target.value;
     themeSwitch(themeValue);
     localStorage.setItem(THEME_KEY, themeValue);
+  }
+
+  clipboardFormatSwitchCallback(option) {
+    const clipboardFormatValue = option.target.value;
+    clipboardFormatSwitch(clipboardFormatValue);
+    localStorage.setItem(CLIPBOARD_FORMAT_KEY, clipboardFormatValue);
   }
 }
 

--- a/src/fontra/client/web-components/general-settings.js
+++ b/src/fontra/client/web-components/general-settings.js
@@ -2,6 +2,10 @@ import { html, css, LitElement } from "https://cdn.jsdelivr.net/npm/lit@2.6.1/+e
 import { THEME_KEY, themeSwitch } from "../core/utils.js";
 export class GeneralSettings extends LitElement {
   static styles = css`
+    h2 {
+      font-size: 1em;
+    }
+
     #settings-theme {
       display: grid;
       grid-template-columns: min-content min-content;
@@ -19,23 +23,30 @@ export class GeneralSettings extends LitElement {
     this.setupSettings();
   }
 
+  themeSettings() {
+    return html`
+      <h2>Theme</h2>
+      ${this.settingOptions.map((option) => {
+        const [optionId, optionValue, optionLabel] = option;
+        return html`
+          <div id="settings-theme">
+            <input
+              id="${optionId}"
+              value="${optionValue}"
+              @click=${(option) => this.themeSwitchCallback(option)}
+              name="theme-settings"
+              type="radio"
+              .checked=${this.checked === optionValue}
+            />
+            <label for="${optionId}">${optionLabel}</label>
+          </div>
+        `;
+      })}
+    `;
+  }
+
   render() {
-    return this.settingOptions.map((option) => {
-      const [optionId, optionValue, optionLabel] = option;
-      return html`
-        <div id="settings-theme">
-          <input
-            id="${optionId}"
-            value="${optionValue}"
-            @click=${(option) => this.themeSwitchCallback(option)}
-            name="theme-settings"
-            type="radio"
-            .checked=${this.checked === optionValue}
-          />
-          <label for="${optionId}">${optionLabel}</label>
-        </div>
-      `;
-    });
+    return this.themeSettings();
   }
 
   setupSettings() {

--- a/src/fontra/client/web-components/general-settings.js
+++ b/src/fontra/client/web-components/general-settings.js
@@ -100,6 +100,10 @@ export class GeneralSettings extends LitElement {
     const themeValue = option.target.value;
     themeSwitch(themeValue);
     localStorage.setItem(THEME_KEY, themeValue);
+    const event = new CustomEvent("fontra-theme-switch", {
+      bubbles: false,
+    });
+    window.dispatchEvent(event);
   }
 
   clipboardFormatSwitchCallback(option) {

--- a/src/fontra/client/web-components/general-settings.js
+++ b/src/fontra/client/web-components/general-settings.js
@@ -39,6 +39,12 @@ export class GeneralSettings extends LitElement {
       this.setupSettings();
       this.requestUpdate();
     });
+    window.addEventListener("storage", (event) => {
+      if (event.key === "fontra-clipboard-format") {
+        this.setupSettings();
+        this.requestUpdate();
+      }
+    });
   }
 
   themeSettings() {

--- a/src/fontra/client/web-components/general-settings.js
+++ b/src/fontra/client/web-components/general-settings.js
@@ -34,6 +34,11 @@ export class GeneralSettings extends LitElement {
     };
 
     this.setupSettings();
+
+    window.addEventListener("fontra-theme-switch", (event) => {
+      this.setupSettings();
+      this.requestUpdate();
+    });
   }
 
   themeSettings() {

--- a/src/fontra/client/web-components/general-settings.js
+++ b/src/fontra/client/web-components/general-settings.js
@@ -1,5 +1,6 @@
 import { html, css, LitElement } from "https://cdn.jsdelivr.net/npm/lit@2.6.1/+esm";
 import { THEME_KEY, themeSwitch } from "../core/utils.js";
+
 export class GeneralSettings extends LitElement {
   static styles = css`
     h2 {

--- a/src/fontra/client/web-components/general-settings.js
+++ b/src/fontra/client/web-components/general-settings.js
@@ -1,10 +1,5 @@
 import { html, css, LitElement } from "https://cdn.jsdelivr.net/npm/lit@2.6.1/+esm";
-import {
-  THEME_KEY,
-  themeSwitch,
-  CLIPBOARD_FORMAT_KEY,
-  clipboardFormatSwitch,
-} from "../core/utils.js";
+import { THEME_KEY, themeSwitch } from "../core/utils.js";
 export class GeneralSettings extends LitElement {
   static styles = css`
     h2 {
@@ -93,10 +88,10 @@ export class GeneralSettings extends LitElement {
       themeSwitch(themeValue);
     }
 
-    const clipboardFormatValue = localStorage.getItem(CLIPBOARD_FORMAT_KEY);
+    const clipboardFormatValue = localStorage.getItem("fontra-clipboard-format");
     if (clipboardFormatValue) {
       this.clipboardFormatOptions.checked = clipboardFormatValue;
-      clipboardFormatSwitch(clipboardFormatValue);
+      localStorage.setItem("fontra-clipboard-format", clipboardFormatValue);
     }
   }
 
@@ -107,9 +102,7 @@ export class GeneralSettings extends LitElement {
   }
 
   clipboardFormatSwitchCallback(option) {
-    const clipboardFormatValue = option.target.value;
-    clipboardFormatSwitch(clipboardFormatValue);
-    localStorage.setItem(CLIPBOARD_FORMAT_KEY, clipboardFormatValue);
+    localStorage.setItem("fontra-clipboard-format", option.target.value);
   }
 }
 

--- a/src/fontra/client/web-components/general-settings.js
+++ b/src/fontra/client/web-components/general-settings.js
@@ -97,13 +97,11 @@ export class GeneralSettings extends LitElement {
     const themeValue = localStorage.getItem(THEME_KEY);
     if (themeValue) {
       this.themeOptions.checked = themeValue;
-      themeSwitch(themeValue);
     }
 
     const clipboardFormatValue = localStorage.getItem("fontra-clipboard-format");
     if (clipboardFormatValue) {
       this.clipboardFormatOptions.checked = clipboardFormatValue;
-      localStorage.setItem("fontra-clipboard-format", clipboardFormatValue);
     }
   }
 

--- a/src/fontra/client/web-components/general-settings.js
+++ b/src/fontra/client/web-components/general-settings.js
@@ -27,7 +27,7 @@ export class GeneralSettings extends LitElement {
       options: [
         ["clipboard-format-svg", "svg", "SVG"],
         ["clipboard-format-glif", "glif", "GLIF (RoboFont)"],
-        ["clipboard-format-json", "json", "JSON (Fontra)"],
+        ["clipboard-format-json", "fontra-json", "JSON (Fontra)"],
       ],
       checked: "glif", // checked by default
     };

--- a/src/fontra/client/web-components/general-settings.js
+++ b/src/fontra/client/web-components/general-settings.js
@@ -1,0 +1,58 @@
+import { html, css, LitElement } from "https://cdn.jsdelivr.net/npm/lit@2.6.1/+esm";
+import { THEME_KEY, themeSwitch } from "../core/utils.js";
+export class GeneralSettings extends LitElement {
+  static styles = css`
+    #settings-theme {
+      display: grid;
+      grid-template-columns: min-content min-content;
+    }
+  `;
+
+  constructor() {
+    super();
+    this.settingOptions = [
+      ["theme-automatic", "automatic", "Automatic (use OS setting)"],
+      ["theme-light", "light", "Light theme"],
+      ["theme-dark", "dark", "Dark theme"],
+    ];
+    this.checked = "automatic"; // checked by default
+    this.setupSettings();
+  }
+
+  render() {
+    return this.settingOptions.map((option) => {
+      const [optionId, optionValue, optionLabel] = option;
+      return html`
+        <div id="settings-theme">
+          <input
+            id="${optionId}"
+            value="${optionValue}"
+            @click=${(option) => this.themeSwitchCallback(option)}
+            name="theme-settings"
+            type="radio"
+            .checked=${this.checked === optionValue}
+          />
+          <label for="${optionId}">${optionLabel}</label>
+        </div>
+      `;
+    });
+  }
+
+  setupSettings() {
+    window.themeSwitchCallback = this.themeSwitchCallback;
+
+    const themeValue = localStorage.getItem("fontra-theme");
+    if (themeValue) {
+      this.checked = themeValue;
+      themeSwitch(themeValue);
+    }
+  }
+
+  themeSwitchCallback(option) {
+    const themeValue = option.target.value;
+    themeSwitch(themeValue);
+    localStorage.setItem(THEME_KEY, themeValue);
+  }
+}
+
+customElements.define("general-settings", GeneralSettings);

--- a/src/fontra/views/editor/editor.html
+++ b/src/fontra/views/editor/editor.html
@@ -335,6 +335,14 @@
             </div>
           </div>
         </div>
+
+        <div class="sidebar-content" data-sidebar-name="settings">
+          <div class="sidebar-settings">
+            <div class="settings" id="settings">
+              <!-- contents will be filled dynamically -->
+            </div>
+          </div>
+        </div>
       </div>
 
       <div class="main-container">
@@ -354,7 +362,8 @@
               sliders
             </div>
             <!-- <div class="sidebar-tab" data-sidebar-name="layers">layers</div> -->
-            <!-- <div class="sidebar-tab" data-sidebar-name="settings">gear</div> -->
+            <div class="sidebar-tab" data-sidebar-name="settings">gear</div>
+            </div>
           </div>
 
           <div class="tool-overlay-container">

--- a/src/fontra/views/editor/editor.html
+++ b/src/fontra/views/editor/editor.html
@@ -278,6 +278,15 @@
       grid-template-rows: auto 1fr;
     }
 
+    .sidebar-settings {
+      box-sizing: border-box;
+      height: 100%;
+      display: grid;
+      gap: 1em;
+      padding: 1em;
+      grid-template-rows: auto 1fr;
+    }
+
     .sidebar-selection-info {
       box-sizing: border-box;
       height: 100%;

--- a/src/fontra/views/editor/editor.html
+++ b/src/fontra/views/editor/editor.html
@@ -8,6 +8,7 @@
     <link href="/css/context-menu.css" rel="stylesheet" />
     <link href="/css/core.css" rel="stylesheet" />
     <link href="/editor/editor.css" rel="stylesheet" />
+    <script type="module" src="/web-components/general-settings.js"></script>
   </head>
 
   <style type="text/css">
@@ -340,6 +341,7 @@
           <div class="sidebar-settings">
             <div class="settings" id="settings">
               <!-- contents will be filled dynamically -->
+              <general-settings />
             </div>
           </div>
         </div>

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -273,6 +273,7 @@ export class EditorController {
     await this.fontController.subscribeChanges(rootSubscriptionPattern, false);
     await this.initGlyphNames();
     await this.initSliders();
+    this.initSettings();
     this.initTools();
     this.initSourcesList();
     await this.setupFromWindowLocation();
@@ -342,6 +343,11 @@ export class EditorController {
         this.autoViewBox = false;
       })
     );
+  }
+
+  initSettings() {
+    const settingsTab = document.querySelector("#settings");
+    settingsTab.innerText = "Hello from editor.js";
   }
 
   initTools() {

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -26,6 +26,7 @@ import { addItemwise, subItemwise, mulScalar } from "../core/var-funcs.js";
 import { joinPaths } from "../core/var-path.js";
 import {
   THEME_KEY,
+  CLIPBOARD_FORMAT_KEY,
   makeUPlusStringFromCodePoint,
   hasShortcutModifierKey,
   hyphenatedToCamelCase,
@@ -940,8 +941,9 @@ export class EditorController {
       return;
     }
 
-    const preferGLIF = true; // TODO should be user preference
-
+    const preferGLIF =
+      !localStorage.getItem(CLIPBOARD_FORMAT_KEY) ||
+      localStorage.getItem(CLIPBOARD_FORMAT_KEY) === "glif";
     const svgString = pathToSVG(path, bounds);
 
     const glyphName = this.sceneController.getSelectedGlyphName();

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -347,7 +347,8 @@ export class EditorController {
 
   initSettings() {
     const settingsTab = document.querySelector("#settings");
-    settingsTab.innerText = "Hello from editor.js";
+    // console.log(GeneralSettings);
+    // settingsTab.innerText = "Hello from editor.js";
   }
 
   initTools() {

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -192,10 +192,8 @@ export class EditorController {
     window
       .matchMedia("(prefers-color-scheme: dark)")
       .addListener((event) => this.themeChanged(event));
-    window.addEventListener("storage", (event) => {
-      if (event.key === THEME_KEY) {
-        this.themeChanged(event);
-      }
+    window.addEventListener("fontra-theme-switch", (event) => {
+      this.themeChanged(event);
     });
 
     this.canvasController.canvas.addEventListener("contextmenu", (event) =>

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -942,18 +942,10 @@ export class EditorController {
     const clipboardExportFormat =
       localStorage.getItem("fontra-clipboard-format") || "glif";
 
-    const plainTextString = () => {
-      switch (clipboardExportFormat) {
-        case "svg":
-          return svgString;
-        case "glif":
-          return glifString;
-        case "fontra-json":
-          return jsonString;
-      }
-    };
+    const mapping = { "svg": svgString, "glif": glifString, "fontra-json": jsonString };
+    const plainTextString = mapping[clipboardExportFormat] || glifString;
 
-    localStorage.setItem("clipboardSelection.text-plain", plainTextString());
+    localStorage.setItem("clipboardSelection.text-plain", plainTextString);
     localStorage.setItem("clipboardSelection.glyph", jsonString);
 
     if (event) {

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -26,7 +26,6 @@ import { addItemwise, subItemwise, mulScalar } from "../core/var-funcs.js";
 import { joinPaths } from "../core/var-path.js";
 import {
   THEME_KEY,
-  CLIPBOARD_FORMAT_KEY,
   makeUPlusStringFromCodePoint,
   hasShortcutModifierKey,
   hyphenatedToCamelCase,
@@ -274,7 +273,6 @@ export class EditorController {
     await this.fontController.subscribeChanges(rootSubscriptionPattern, false);
     await this.initGlyphNames();
     await this.initSliders();
-    this.initSettings();
     this.initTools();
     this.initSourcesList();
     await this.setupFromWindowLocation();
@@ -344,12 +342,6 @@ export class EditorController {
         this.autoViewBox = false;
       })
     );
-  }
-
-  initSettings() {
-    const settingsTab = document.querySelector("#settings");
-    // console.log(GeneralSettings);
-    // settingsTab.innerText = "Hello from editor.js";
   }
 
   initTools() {
@@ -941,20 +933,27 @@ export class EditorController {
       return;
     }
 
-    const preferGLIF =
-      !localStorage.getItem(CLIPBOARD_FORMAT_KEY) ||
-      localStorage.getItem(CLIPBOARD_FORMAT_KEY) === "glif";
     const svgString = pathToSVG(path, bounds);
-
     const glyphName = this.sceneController.getSelectedGlyphName();
     const unicodes = this.fontController.glyphMap[glyphName] || [];
     const glifString = staticGlyphToGLIF(glyphName, instance, unicodes);
-
     const jsonString = JSON.stringify(instance);
 
-    const plainTextString = preferGLIF ? glifString : svgString;
+    const clipboardExportFormat =
+      localStorage.getItem("fontra-clipboard-format") || "glif";
 
-    localStorage.setItem("clipboardSelection.text-plain", plainTextString);
+    const plainTextString = () => {
+      switch (clipboardExportFormat) {
+        case "svg":
+          return svgString;
+        case "glif":
+          return glifString;
+        case "fontra-json":
+          return jsonString;
+      }
+    };
+
+    localStorage.setItem("clipboardSelection.text-plain", plainTextString());
     localStorage.setItem("clipboardSelection.glyph", jsonString);
 
     if (event) {


### PR DESCRIPTION
Fixes #316 
Separated settings in their own web component. `<general-settings/>`
My idea is that this can hold all logic which can be further broken down into modules/components. 

*`themeOptions` and `clipboardFormatOptions` are pretty much the same, they can be refactored to use less code but I think it is more convenient for altering them this way while still in the same component.

![Screenshot 2023-03-07 at 13 04 04](https://user-images.githubusercontent.com/11830669/223406551-66b2517d-2880-4bf9-8e2b-adaba0a4cb01.png)

