### PR TITLE
Show/hide the add/remove source buttons dynamically

### DIFF
--- a/src/fontra/client/web-components/add-remove-buttons.js
+++ b/src/fontra/client/web-components/add-remove-buttons.js
@@ -21,6 +21,7 @@ export class AddRemoveButtons extends LitElement {
     removeButtonCallback: { type: Function },
     disableAddButton: { type: Boolean },
     disableRemoveButton: { type: Boolean },
+    hidden: { type: Boolean },
   };
 
   constructor() {
@@ -29,27 +30,30 @@ export class AddRemoveButtons extends LitElement {
     this.removeButtonCallback = () => {};
     this.disableAddButton = false;
     this.disableRemoveButton = false;
+    this.hidden = false;
   }
 
   render() {
-    return html`
-      <div class="buttons-container">
-        <button
-          name="add-button"
-          .disabled=${this.disableAddButton}
-          @click=${() => this.addButtonCallback()}
-        >
-          +
-        </button>
-        <button
-          name="remove-button"
-          .disabled=${this.disableRemoveButton}
-          @click=${() => this.removeButtonCallback()}
-        >
-          &minus;
-        </button>
-      </div>
-    `;
+    return this.hidden
+      ? ""
+      : html`
+          <div class="buttons-container">
+            <button
+              name="add-button"
+              .disabled=${this.disableAddButton}
+              @click=${() => this.addButtonCallback()}
+            >
+              +
+            </button>
+            <button
+              name="remove-button"
+              .disabled=${this.disableRemoveButton}
+              @click=${() => this.removeButtonCallback()}
+            >
+              &minus;
+            </button>
+          </div>
+        `;
   }
 }
 

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -394,10 +394,12 @@ export class EditorController {
     };
 
     const designspaceSliders = document.querySelector(".designspace-sliders");
-    const addRemoveButtonsElement = new AddRemoveButtons();
-    addRemoveButtonsElement.addButtonCallback = addSourceCallback;
-    addRemoveButtonsElement.removeButtonCallback = removeSourceCallback;
-    designspaceSliders.appendChild(addRemoveButtonsElement);
+    this.addRemoveButtonsElement = new AddRemoveButtons();
+    this.addRemoveButtonsElement.className = "";
+    this.addRemoveButtonsElement.addButtonCallback = addSourceCallback;
+    this.addRemoveButtonsElement.removeButtonCallback = removeSourceCallback;
+    this.addRemoveButtonsElement.hidden = true;
+    designspaceSliders.appendChild(this.addRemoveButtonsElement);
 
     this.sourcesList.addEventListener("listSelectionChanged", async (event) => {
       await this.sceneController.setSelectedSource(
@@ -652,7 +654,9 @@ export class EditorController {
     }
     this.sliders.setSliderDescriptions(axisInfo);
     this.sliders.values = this.sceneController.getLocation();
-    this.sourcesList.setItems(await this.sceneController.getSourcesInfo());
+    const sourceItems = await this.sceneController.getSourcesInfo();
+    this.sourcesList.setItems(sourceItems || []);
+    this.addRemoveButtonsElement.hidden = !sourceItems;
     this.updateWindowLocationAndSelectionInfo();
   }
 

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -394,12 +394,12 @@ export class EditorController {
     };
 
     const designspaceSliders = document.querySelector(".designspace-sliders");
-    this.addRemoveButtonsElement = new AddRemoveButtons();
-    this.addRemoveButtonsElement.className = "";
-    this.addRemoveButtonsElement.addButtonCallback = addSourceCallback;
-    this.addRemoveButtonsElement.removeButtonCallback = removeSourceCallback;
-    this.addRemoveButtonsElement.hidden = true;
-    designspaceSliders.appendChild(this.addRemoveButtonsElement);
+    this.addRemoveSourceButtons = new AddRemoveButtons();
+    this.addRemoveSourceButtons.className = "";
+    this.addRemoveSourceButtons.addButtonCallback = addSourceCallback;
+    this.addRemoveSourceButtons.removeButtonCallback = removeSourceCallback;
+    this.addRemoveSourceButtons.hidden = true;
+    designspaceSliders.appendChild(this.addRemoveSourceButtons);
 
     this.sourcesList.addEventListener("listSelectionChanged", async (event) => {
       await this.sceneController.setSelectedSource(
@@ -656,7 +656,7 @@ export class EditorController {
     this.sliders.values = this.sceneController.getLocation();
     const sourceItems = await this.sceneController.getSourcesInfo();
     this.sourcesList.setItems(sourceItems || []);
-    this.addRemoveButtonsElement.hidden = !sourceItems;
+    this.addRemoveSourceButtons.hidden = !sourceItems;
     this.updateWindowLocationAndSelectionInfo();
   }
 

--- a/src/fontra/views/editor/scene-model.js
+++ b/src/fontra/views/editor/scene-model.js
@@ -208,10 +208,10 @@ export class SceneModel {
   }
 
   async getSourcesInfo() {
-    const sourcesInfo = [];
     if (!this.selectedGlyph) {
-      return sourcesInfo;
+      return null;
     }
+    const sourcesInfo = [];
     const glyph = await this.getSelectedVariableGlyphController();
     for (let i = 0; i < glyph?.sources.length; i++) {
       let name = glyph.sources[i].name;


### PR DESCRIPTION
Previously, the Add/Remove buttons were always visible, even if there were no sources to select. This shows and hides them according to the source list state