### PR TITLE
Detect JSON when pasting plain text

### DIFF
--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -1059,7 +1059,15 @@ export class EditorController {
     if (customJSON) {
       pastedGlyph = StaticGlyph.fromObject(JSON.parse(customJSON));
     } else {
-      pastedGlyph = await this.fontController.parseClipboard(plainText);
+      if (plainText[0] == "{") {
+        try {
+          pastedGlyph = StaticGlyph.fromObject(JSON.parse(plainText));
+        } catch (error) {
+          console.log("couldn't paste from JSON:", error.toString());
+        }
+      } else {
+        pastedGlyph = await this.fontController.parseClipboard(plainText);
+      }
     }
 
     if (!pastedGlyph) {


### PR DESCRIPTION
We already detect SVG and GLIF, this PR adds support for JSON (our internal clipboard format).