### PR TITLE
Observable object layer prefs

### DIFF
--- a/src/fontra/client/core/observable-object.js
+++ b/src/fontra/client/core/observable-object.js
@@ -1,0 +1,51 @@
+export function newObservableObject(obj) {
+  if (!obj) {
+    obj = {};
+  }
+  const eventListeners = { changed: [], deleted: [] };
+
+  function dispatchEvent(type, key, value) {
+    const event = {
+      type: type,
+      key: key,
+      value: value,
+    };
+    for (const listener of eventListeners[type]) {
+      // Schedule in the event loop rather than call immediately
+      setTimeout(() => listener(event), 0);
+    }
+  }
+
+  const methods = {
+    addEventListener(type, listener) {
+      eventListeners[type].push(listener);
+    },
+    removeEventListener(type, listener) {
+      eventListeners[type] = eventListeners[type].filter((item) => item !== listener);
+    },
+  };
+
+  const handler = {
+    set(obj, prop, value) {
+      obj[prop] = value;
+      dispatchEvent("changed", prop, value);
+      return true;
+    },
+
+    get(obj, prop) {
+      const method = methods[prop];
+      if (method) {
+        return method;
+      }
+      return obj[prop];
+    },
+
+    deleteProperty(obj, prop) {
+      delete object[prop];
+      dispatchEvent("deleted", prop);
+      return true;
+    },
+  };
+
+  return new Proxy(obj, handler);
+}

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -4,6 +4,7 @@ import { recordChanges } from "../core/change-recorder.js";
 import { ContextMenu, MenuItemDivider } from "../core/context-menu.js";
 import { FontController } from "../core/font-controller.js";
 import { loaderSpinner } from "../core/loader-spinner.js";
+import { newObservableObject } from "../core/observable-object.js";
 import {
   centeredRect,
   insetRect,
@@ -95,6 +96,14 @@ export class EditorController {
       visualizationLayerDefinitions,
       this.isThemeDark
     );
+
+    this.visualizationLayersSettings = newVisualizationLayersSettings(
+      this.visualizationLayers
+    );
+    this.visualizationLayersSettings.addEventListener("changed", (event) => {
+      this.visualizationLayers.toggle(event.key, event.value);
+      this.canvasController.setNeedsUpdate();
+    });
 
     const sceneModel = new SceneModel(this.fontController, isPointInPath);
 
@@ -1821,4 +1830,14 @@ function makeDisplayPath(pathItems) {
     displayPath = [displayPathItems[0], "...", ...displayPathItems.slice(1)].join("/");
   }
   return displayPath;
+}
+
+function newVisualizationLayersSettings(visualizationLayers) {
+  const settings = {};
+  for (const definition of visualizationLayers.definitions) {
+    if (definition.userSwitchable) {
+      settings[definition.identifier] = definition.defaultOn;
+    }
+  }
+  return newObservableObject(settings);
 }

--- a/src/fontra/views/editor/visualization-layers.js
+++ b/src/fontra/views/editor/visualization-layers.js
@@ -48,6 +48,15 @@ export class VisualizationLayers {
     this.setNeedsUpdate();
   }
 
+  toggle(layerID, onOff) {
+    if (onOff) {
+      this._visibleLayerIds.add(layerID);
+    } else {
+      this._visibleLayerIds.remove(layerID);
+    }
+    this.setNeedsUpdate();
+  }
+
   buildLayers() {
     if (!this.needsUpdate) {
       return;


### PR DESCRIPTION
- This adds an object Proxy wrapper allowing to observe shallow changes in an object (set/del property)
- Add a visualization layers settings object (for now: key = layer id, value = on/off)
- Subscribe to changes in the vis layer settings object for automatic redraw

Part of #239, needed for #254/#280

For a followup PR: fetch and store the settings from/to localStorage