### PR TITLE
Save viz layer settings to local storage

### DIFF
--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -1783,20 +1783,16 @@ function makeDisplayPath(pathItems) {
 }
 
 function newVisualizationLayersSettings(visualizationLayers) {
-  const storedLayersSettings =
+  const settings =
     JSON.parse(localStorage.getItem("visualization-layers-settings")) || {};
-  const settings = {};
   for (const definition of visualizationLayers.definitions) {
-    if (definition.userSwitchable) {
-      settings[definition.identifier] =
-        definition.identifier in storedLayersSettings
-          ? storedLayersSettings[definition.identifier]
-          : definition.defaultOn;
-      visualizationLayers.toggle(
-        definition.identifier,
-        settings[definition.identifier]
-      );
+    if (!definition.userSwitchable) {
+      continue;
     }
+    if (!(definition.identifier in settings)) {
+      settings[definition.identifier] = !!definition.defaultOn;
+    }
+    visualizationLayers.toggle(definition.identifier, settings[definition.identifier]);
   }
   return newObservableObject(settings);
 }

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -102,6 +102,14 @@ export class EditorController {
       this.visualizationLayers
     );
     this.visualizationLayersSettings.addEventListener("changed", (event) => {
+      const storedLayersSettings =
+        JSON.parse(localStorage.getItem("visualization-layers-settings")) || {};
+      storedLayersSettings[event.key] = event.value;
+      localStorage.setItem(
+        "visualization-layers-settings",
+        JSON.stringify(storedLayersSettings)
+      );
+
       this.visualizationLayers.toggle(event.key, event.value);
       this.canvasController.setNeedsUpdate();
     });
@@ -256,13 +264,8 @@ export class EditorController {
       (layer) => layer.userSwitchable
     );
 
-    const storedLayersSettings =
-      JSON.parse(localStorage.getItem("visualizationLayersSettings")) || {};
-
     const glyphDisplayLayersItems = userSwitchableLayers.map((layer) => {
-      const layerChecked =
-        storedLayersSettings[layer.identifier] ||
-        this.visualizationLayersSettings[layer.identifier];
+      const layerChecked = this.visualizationLayersSettings[layer.identifier];
       return { id: layer.identifier, name: layer.name, isChecked: layerChecked };
     });
 
@@ -278,12 +281,6 @@ export class EditorController {
       const layerIdentifier = event.detail.id;
       const layerChecked = event.detail.checked;
       this.visualizationLayersSettings[layerIdentifier] = layerChecked;
-
-      storedLayersSettings[layerIdentifier] = layerChecked;
-      localStorage.setItem(
-        "visualizationLayersSettings",
-        JSON.stringify(storedLayersSettings)
-      );
     });
   }
 
@@ -1790,10 +1787,17 @@ function makeDisplayPath(pathItems) {
 }
 
 function newVisualizationLayersSettings(visualizationLayers) {
+  const storedLayersSettings =
+    JSON.parse(localStorage.getItem("visualization-layers-settings")) || {};
   const settings = {};
   for (const definition of visualizationLayers.definitions) {
     if (definition.userSwitchable) {
-      settings[definition.identifier] = definition.defaultOn;
+      settings[definition.identifier] =
+        storedLayersSettings[definition.identifier] || definition.defaultOn;
+      visualizationLayers.toggle(
+        definition.identifier,
+        settings[definition.identifier]
+      );
     }
   }
   return newObservableObject(settings);

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -102,14 +102,10 @@ export class EditorController {
       this.visualizationLayers
     );
     this.visualizationLayersSettings.addEventListener("changed", (event) => {
-      const storedLayersSettings =
-        JSON.parse(localStorage.getItem("visualization-layers-settings")) || {};
-      storedLayersSettings[event.key] = event.value;
       localStorage.setItem(
         "visualization-layers-settings",
-        JSON.stringify(storedLayersSettings)
+        JSON.stringify(this.visualizationLayersSettings)
       );
-
       this.visualizationLayers.toggle(event.key, event.value);
       this.canvasController.setNeedsUpdate();
     });

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -1793,7 +1793,9 @@ function newVisualizationLayersSettings(visualizationLayers) {
   for (const definition of visualizationLayers.definitions) {
     if (definition.userSwitchable) {
       settings[definition.identifier] =
-        storedLayersSettings[definition.identifier] || definition.defaultOn;
+        definition.identifier in storedLayersSettings
+          ? storedLayersSettings[definition.identifier]
+          : definition.defaultOn;
       visualizationLayers.toggle(
         definition.identifier,
         settings[definition.identifier]

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -256,9 +256,14 @@ export class EditorController {
       (layer) => layer.userSwitchable
     );
 
+    const storedLayersSettings =
+      JSON.parse(localStorage.getItem("visualizationLayersSettings")) || {};
+
     const glyphDisplayLayersItems = userSwitchableLayers.map((layer) => {
-      let isLayerVisible = this.visualizationLayersSettings[layer.identifier];
-      return { id: layer.identifier, name: layer.name, isChecked: isLayerVisible };
+      const layerChecked =
+        storedLayersSettings[layer.identifier] ||
+        this.visualizationLayersSettings[layer.identifier];
+      return { id: layer.identifier, name: layer.name, isChecked: layerChecked };
     });
 
     optionsList.options = [
@@ -273,6 +278,12 @@ export class EditorController {
       const layerIdentifier = event.detail.id;
       const layerChecked = event.detail.checked;
       this.visualizationLayersSettings[layerIdentifier] = layerChecked;
+
+      storedLayersSettings[layerIdentifier] = layerChecked;
+      localStorage.setItem(
+        "visualizationLayersSettings",
+        JSON.stringify(storedLayersSettings)
+      );
     });
   }
 


### PR DESCRIPTION
This works well, although perhaps I have altered the expected behaviour. What I imagine:
1. You enter for the first time, there are no settings. The defaults are set in the layers themselves. (In the current case both are false)
2. Then you change something > The layers appears on the screen + is stored in LocalStorage
3. Next time you enter we need to check whether anything is stored in LocalStorage. IF there is anything we use it, if not we use the default. 
** I am also triggering the actual layer otherwise all settings are synced but the layers don't show in practice. **