### PR TITLE
Fix z index

### DIFF
--- a/src/fontra/views/editor/visualization-layer-definitions.js
+++ b/src/fontra/views/editor/visualization-layer-definitions.js
@@ -9,14 +9,16 @@ import { subVectors } from "../core/vector.js";
 export const visualizationLayerDefinitions = [];
 
 export function registerVisualizationLayerDefinition(newLayerDef) {
-  let index = -1;
+  let index = 0;
   let layerDef;
-  for ([index, layerDef] of enumerate(visualizationLayerDefinitions)) {
-    if (newLayerDef.zIndex > layerDef.zIndex) {
+  for (index = 0; index < visualizationLayerDefinitions.length; index++) {
+    layerDef = visualizationLayerDefinitions[index];
+    if (newLayerDef.zIndex < layerDef.zIndex) {
       break;
     }
   }
-  visualizationLayerDefinitions.splice(index + 1, 0, newLayerDef);
+  console.log(index);
+  visualizationLayerDefinitions.splice(index, 0, newLayerDef);
 }
 
 registerVisualizationLayerDefinition({
@@ -25,7 +27,7 @@ registerVisualizationLayerDefinition({
   selectionMode: "editing",
   userSwitchable: true,
   defaultOn: true,
-  zIndex: 500,
+  zIndex: 0,
   dontTranslate: true,
   screenParameters: { strokeWidth: 2 },
   colors: { strokeColor: "#FFF" },


### PR DESCRIPTION
The intention was to insert new layer defs in a way that:
- keeps the layer defs sorted by z index
- inserts *before* the item with a *higher* z-index, if any, else insert at the end

This PR makes the code behave as intended.