### PR TITLE
Update designspace UI when a new glyph is created

### DIFF
--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -1233,6 +1233,7 @@ export class EditorController {
     this.canvasController.setNeedsUpdate();
     this.glyphsSearch.updateGlyphNamesListContent();
     this.updateWindowLocationAndSelectionInfo();
+    await this.updateSlidersAndSources();
   }
 
   async externalChange(change) {
@@ -1251,6 +1252,7 @@ export class EditorController {
         });
       }
       this.glyphsSearch.updateGlyphNamesListContent();
+      await this.updateSlidersAndSources();
     }
     await this.sceneController.sceneModel.updateScene();
     if (


### PR DESCRIPTION
Update designspace UI when a new glyph is created:
- Via an external change
- When the glyph was created here

This fixes #376.