### PR TITLE
[cjk design frame] make grid lines one pixel instead of one unit

### DIFF
--- a/src/fontra/views/editor/visualization-layer-definitions.js
+++ b/src/fontra/views/editor/visualization-layer-definitions.js
@@ -112,6 +112,7 @@ registerVisualizationLayerDefinition({
   name: "CJK Design Frame glyphs",
   selectionMode: "editing",
   zIndex: 500,
+  screenParameters: { strokeWidth: 1 },
   colors: {
     strokeColor: "#0004",
     overshootColor: "#00BFFF26",
@@ -145,6 +146,7 @@ registerVisualizationLayerDefinition({
     ];
 
     context.translate(shiftX, shiftY);
+    context.lineWidth = parameters.strokeWidth;
 
     context.strokeStyle = parameters.strokeColor;
     context.lineWidth = parameters.cjkFrameLineWidth;


### PR DESCRIPTION
Currently, the grid lines of the CJK Design Frame are one glyph unit thick, so they get thicker when you zoom in. I consider there a form of guidelines, and think they should be one pixel, regardless of zoom.