### PR TITLE
Improve server error

### DIFF
--- a/src/fontra/client/core/remote.js
+++ b/src/fontra/client/core/remote.js
@@ -64,8 +64,8 @@ export class RemoteObject {
       this.websocket.onopen = (event) => {
         resolve(event);
         delete this._connectPromise;
-        this.websocket.onerror = (event) => console.log("websocket error", event);
-        this.websocket.onclose = (event) => console.log("websocket closed", event);
+        this.websocket.onclose = (event) => this._onclose(event);
+        this.websocket.onerror = (event) => this._onerror(event);
         const message = {
           "client-uuid": this.clientUUID,
         };
@@ -74,6 +74,22 @@ export class RemoteObject {
       this.websocket.onerror = reject;
     });
     return this._connectPromise;
+  }
+
+  _onclose(event) {
+    if (this.onclose) {
+      this.onclose(event);
+    } else {
+      console.log(`websocket closed`, event);
+    }
+  }
+
+  _onerror(event) {
+    if (this.onerror) {
+      this.onerror(event);
+    } else {
+      console.log(`websocket error`, event);
+    }
   }
 
   async _handleIncomingMessage(event) {

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -66,8 +66,30 @@ export class EditorController {
     const remoteFontEngine = await getRemoteProxy(wsURL);
     const editorController = new EditorController(remoteFontEngine);
     remoteFontEngine.receiver = editorController;
+    remoteFontEngine.onclose = (event) => editorController.handleRemoteClose(event);
+    remoteFontEngine.onerror = (event) => editorController.handleRemoteError(event);
     await editorController.start();
     return editorController;
+  }
+
+  async handleRemoteClose(event) {
+    await dialog(
+      "Connection closed",
+      "The connection to the server closed unexpectedly.",
+      [{ title: "Try again", resultValue: "ok" }]
+    );
+    location.reload();
+  }
+
+  async handleRemoteError(event) {
+    console.log("remote error", event);
+    await dialog(
+      "Connection problem",
+      `There was a problem with the connection to the server.
+      See the JavaScript Console for details.`,
+      [{ title: "Try again", resultValue: "ok" }]
+    );
+    location.reload();
   }
 
   constructor(font) {


### PR DESCRIPTION
When the websocket connection fails or gets closed (for example when the server shuts down), show a dialog with a "Try again" button.