### PR TITLE
Selection fixes

### DIFF
--- a/src/fontra/views/editor/edit-tools-pointer.js
+++ b/src/fontra/views/editor/edit-tools-pointer.js
@@ -32,7 +32,6 @@ export class PointerTool extends BaseTool {
     }
 
     if (!sceneController.hoverSelection.size && !sceneController.hoverPathHit) {
-      console.log("set hovered glyph");
       sceneController.hoveredGlyph = this.sceneModel.glyphAtPoint(point);
     }
 

--- a/src/fontra/views/editor/edit-tools-pointer.js
+++ b/src/fontra/views/editor/edit-tools-pointer.js
@@ -101,12 +101,14 @@ export class PointerTool extends BaseTool {
       if (!(await shouldInitiateDrag(eventStream, initialEvent))) {
         initiateRectSelect = false;
         initiateDrag = false;
-        const selectedGlyph = this.sceneModel.glyphAtPoint(point);
-        if (selectedGlyph && selectedGlyph != sceneController.selectedGlyph) {
-          sceneController.selectedGlyph = selectedGlyph;
-          sceneController.selectedGlyphIsEditing = false;
-          eventStream.done();
-          return;
+        if (!selection.size) {
+          const selectedGlyph = this.sceneModel.glyphAtPoint(point);
+          if (selectedGlyph && selectedGlyph != sceneController.selectedGlyph) {
+            sceneController.selectedGlyph = selectedGlyph;
+            sceneController.selectedGlyphIsEditing = false;
+            eventStream.done();
+            return;
+          }
         }
       }
     }

--- a/src/fontra/views/editor/edit-tools-pointer.js
+++ b/src/fontra/views/editor/edit-tools-pointer.js
@@ -22,14 +22,20 @@ export class PointerTool extends BaseTool {
     const size = sceneController.mouseClickMargin;
     const selRect = centeredRect(point.x, point.y, size);
     sceneController.hoverSelection = this.sceneModel.selectionAtPoint(point, size);
-    sceneController.hoveredGlyph = this.sceneModel.glyphAtPoint(point);
+    sceneController.hoveredGlyph = undefined;
     sceneController.hoverPathHit = undefined;
-    if (!sceneController.hoverSelection?.size && !sceneController.hoveredGlyph) {
+    if (!sceneController.hoverSelection?.size) {
       const hit = this.sceneModel.pathHitAtPoint(point, size);
       if (hit.contourIndex !== undefined) {
         sceneController.hoverPathHit = hit;
       }
     }
+
+    if (!sceneController.hoverSelection.size && !sceneController.hoverPathHit) {
+      console.log("set hovered glyph");
+      sceneController.hoveredGlyph = this.sceneModel.glyphAtPoint(point);
+    }
+
     this.setCursor();
   }
 

--- a/src/fontra/views/editor/scene-controller.js
+++ b/src/fontra/views/editor/scene-controller.js
@@ -241,7 +241,7 @@ export class SceneController {
   }
 
   get mouseClickMargin() {
-    return this.onePixelUnit * 10;
+    return this.onePixelUnit * 12;
   }
 
   get selection() {

--- a/src/fontra/views/editor/visualization-layer-definitions.js
+++ b/src/fontra/views/editor/visualization-layer-definitions.js
@@ -527,12 +527,7 @@ registerVisualizationLayerDefinition({
     // Under layer
     const underlayOffset = parameters.underlayOffset;
     context.fillStyle = parameters.underColor;
-    for (const pointIndex of selectedPointIndices || []) {
-      const pt = glyph.path.getPoint(pointIndex);
-      if (pt === undefined) {
-        // Selection is not valid
-        continue;
-      }
+    for (const pt of iterPointsByIndex(glyph.path, selectedPointIndices)) {
       fillNode(
         context,
         pt,
@@ -543,22 +538,12 @@ registerVisualizationLayerDefinition({
     }
     // Selected nodes
     context.fillStyle = parameters.selectedColor;
-    for (const pointIndex of selectedPointIndices || []) {
-      const pt = glyph.path.getPoint(pointIndex);
-      if (pt === undefined) {
-        // Selection is not valid
-        continue;
-      }
+    for (const pt of iterPointsByIndex(glyph.path, selectedPointIndices)) {
       fillNode(context, pt, cornerSize, smoothSize, handleSize);
     }
     // Hovered nodes
     const hoverStrokeOffset = parameters.hoverStrokeOffset;
-    for (const pointIndex of hoveredPointIndices || []) {
-      const pt = glyph.path.getPoint(pointIndex);
-      if (pt === undefined) {
-        // Selection is not valid
-        continue;
-      }
+    for (const pt of iterPointsByIndex(glyph.path, hoveredPointIndices)) {
       strokeNode(
         context,
         pt,
@@ -757,6 +742,18 @@ function lenientUnion(setA, setB) {
     return setA || new Set();
   }
   return union(setA, setB);
+}
+
+function* iterPointsByIndex(path, pointIndices) {
+  if (!pointIndices) {
+    return;
+  }
+  for (const index of pointIndices) {
+    const pt = path.getPoint(index);
+    if (pt !== undefined) {
+      yield pt;
+    }
+  }
 }
 
 // {

--- a/src/fontra/views/editor/visualization-layer-definitions.js
+++ b/src/fontra/views/editor/visualization-layer-definitions.js
@@ -98,7 +98,7 @@ registerVisualizationLayerDefinition({
   identifier: "fontra.context.glyphs",
   name: "Context glyphs",
   selectionMode: "unselected",
-  zIndex: 500,
+  zIndex: 200,
   colors: { fillColor: "#000" },
   colorsDarkMode: { fillColor: "#FFF" },
   draw: (context, positionedGlyph, parameters, model, controller) => {
@@ -348,7 +348,7 @@ registerVisualizationLayerDefinition({
   name: "Selected glyph",
   selectionMode: "selected",
   selectionFilter: (positionedGlyph) => !positionedGlyph.isEmpty,
-  zIndex: 500,
+  zIndex: 200,
   screenParameters: { outerStrokeWidth: 10, innerStrokeWidth: 3 },
   colors: { fillColor: "#000", strokeColor: "#7778" },
   colorsDarkMode: { fillColor: "#FFF", strokeColor: "#FFF8" },
@@ -362,7 +362,7 @@ registerVisualizationLayerDefinition({
   name: "Hovered glyph",
   selectionMode: "hovered",
   selectionFilter: (positionedGlyph) => !positionedGlyph.isEmpty,
-  zIndex: 500,
+  zIndex: 200,
   screenParameters: { outerStrokeWidth: 10, innerStrokeWidth: 3 },
   colors: { fillColor: "#000", strokeColor: "#BBB8" },
   colorsDarkMode: { fillColor: "#FFF", strokeColor: "#CCC8" },
@@ -576,6 +576,24 @@ registerVisualizationLayerDefinition({
       const radius = parameters.insertHandlesRadius;
       fillRoundNode(context, point, 2 * radius);
     }
+  },
+});
+
+registerVisualizationLayerDefinition({
+  identifier: "fontra.edit.path.under.stroke",
+  name: "Underlying edit path stroke",
+  selectionMode: "editing",
+  zIndex: 490,
+  screenParameters: {
+    strokeWidth: 3,
+  },
+  colors: { color: "#FFF6" },
+  colorsDarkMode: { color: "#0004" },
+  draw: (context, positionedGlyph, parameters, model, controller) => {
+    context.lineJoin = "round";
+    context.lineWidth = parameters.strokeWidth;
+    context.strokeStyle = parameters.color;
+    context.stroke(positionedGlyph.glyph.flattenedPath2d);
   },
 });
 

--- a/src/fontra/views/editor/visualization-layer-definitions.js
+++ b/src/fontra/views/editor/visualization-layer-definitions.js
@@ -508,7 +508,7 @@ registerVisualizationLayerDefinition({
     handleSize: 6.5,
     strokeWidth: 1,
     hoverStrokeOffset: 4,
-    underlayerOffset: 2,
+    underlayOffset: 2,
   },
   colors: { hoveredColor: "#BBB", selectedColor: "#000", underColor: "#FFFA" },
   colorsDarkMode: { hoveredColor: "#BBB", selectedColor: "#FFF", underColor: "#0008" },
@@ -525,7 +525,7 @@ registerVisualizationLayerDefinition({
     context.lineWidth = parameters.strokeWidth;
 
     // Under layer
-    const underlayerOffset = parameters.underlayerOffset;
+    const underlayOffset = parameters.underlayOffset;
     context.fillStyle = parameters.underColor;
     for (const pointIndex of selectedPointIndices || []) {
       const pt = glyph.path.getPoint(pointIndex);
@@ -536,9 +536,9 @@ registerVisualizationLayerDefinition({
       fillNode(
         context,
         pt,
-        cornerSize + underlayerOffset,
-        smoothSize + underlayerOffset,
-        handleSize + underlayerOffset
+        cornerSize + underlayOffset,
+        smoothSize + underlayOffset,
+        handleSize + underlayOffset
       );
     }
     // Selected nodes

--- a/src/fontra/views/editor/visualization-layer-definitions.js
+++ b/src/fontra/views/editor/visualization-layer-definitions.js
@@ -508,9 +508,10 @@ registerVisualizationLayerDefinition({
     handleSize: 6.5,
     strokeWidth: 1,
     hoverStrokeOffset: 4,
+    underlayerOffset: 2,
   },
-  colors: { hoveredColor: "#BBB", selectedColor: "#000" },
-  colorsDarkMode: { hoveredColor: "#BBB", selectedColor: "#FFF" },
+  colors: { hoveredColor: "#BBB", selectedColor: "#000", underColor: "#FFFA" },
+  colorsDarkMode: { hoveredColor: "#BBB", selectedColor: "#FFF", underColor: "#0008" },
   draw: (context, positionedGlyph, parameters, model, controller) => {
     const glyph = positionedGlyph.glyph;
     const cornerSize = parameters.cornerSize;
@@ -522,9 +523,36 @@ registerVisualizationLayerDefinition({
 
     context.strokeStyle = parameters.hoveredColor;
     context.lineWidth = parameters.strokeWidth;
-    const hoverStrokeOffset = parameters.hoverStrokeOffset;
-    context.fillStyle = parameters.selectedColor;
 
+    // Under layer
+    const underlayerOffset = parameters.underlayerOffset;
+    context.fillStyle = parameters.underColor;
+    for (const pointIndex of selectedPointIndices || []) {
+      const pt = glyph.path.getPoint(pointIndex);
+      if (pt === undefined) {
+        // Selection is not valid
+        continue;
+      }
+      fillNode(
+        context,
+        pt,
+        cornerSize + underlayerOffset,
+        smoothSize + underlayerOffset,
+        handleSize + underlayerOffset
+      );
+    }
+    // Selected nodes
+    context.fillStyle = parameters.selectedColor;
+    for (const pointIndex of selectedPointIndices || []) {
+      const pt = glyph.path.getPoint(pointIndex);
+      if (pt === undefined) {
+        // Selection is not valid
+        continue;
+      }
+      fillNode(context, pt, cornerSize, smoothSize, handleSize);
+    }
+    // Hovered nodes
+    const hoverStrokeOffset = parameters.hoverStrokeOffset;
     for (const pointIndex of hoveredPointIndices || []) {
       const pt = glyph.path.getPoint(pointIndex);
       if (pt === undefined) {
@@ -538,14 +566,6 @@ registerVisualizationLayerDefinition({
         smoothSize + hoverStrokeOffset,
         handleSize + hoverStrokeOffset
       );
-    }
-    for (const pointIndex of selectedPointIndices || []) {
-      const pt = glyph.path.getPoint(pointIndex);
-      if (pt === undefined) {
-        // Selection is not valid
-        continue;
-      }
-      fillNode(context, pt, cornerSize, smoothSize, handleSize);
     }
   },
 });

--- a/src/fontra/views/editor/visualization-layer-definitions.js
+++ b/src/fontra/views/editor/visualization-layer-definitions.js
@@ -521,9 +521,6 @@ registerVisualizationLayerDefinition({
     const { point: hoveredPointIndices } = parseSelection(model.hoverSelection);
     const { point: selectedPointIndices } = parseSelection(model.selection);
 
-    context.strokeStyle = parameters.hoveredColor;
-    context.lineWidth = parameters.strokeWidth;
-
     // Under layer
     const underlayOffset = parameters.underlayOffset;
     context.fillStyle = parameters.underColor;
@@ -542,6 +539,8 @@ registerVisualizationLayerDefinition({
       fillNode(context, pt, cornerSize, smoothSize, handleSize);
     }
     // Hovered nodes
+    context.strokeStyle = parameters.hoveredColor;
+    context.lineWidth = parameters.strokeWidth;
     const hoverStrokeOffset = parameters.hoverStrokeOffset;
     for (const pt of iterPointsByIndex(glyph.path, hoveredPointIndices)) {
       strokeNode(


### PR DESCRIPTION
Misc fixes regarding edit selection near/at neighboring glyphs:
- Clicking on selectable items of the edited glyph always has priority over clicking on a neighbor glyph
- Make hover behavior consistent with click behavior
- Keep path and nodes visible even if they are on top of a neighboring glyph

Unrelated: increase the "mouse click margin" a bit, so it's easier to grab things.