### PR TITLE
Reverse selection at point

### DIFF
--- a/src/fontra/client/core/path-hit-tester.js
+++ b/src/fontra/client/core/path-hit-tester.js
@@ -1,6 +1,6 @@
 import { Bezier } from "../third-party/bezier-js.js";
 import { centeredRect, sectRect } from "./rectangle.js";
-import { enumerate, range } from "./utils.js";
+import { range, reversedEnumerate } from "./utils.js";
 
 export class PathHitTester {
   constructor(path) {
@@ -16,12 +16,12 @@ export class PathHitTester {
 
   hitTest(point, margin) {
     const targetRect = centeredRect(point.x, point.y, margin * 2);
-    for (const [contourIndex, contour] of enumerate(this.contours)) {
+    for (const [contourIndex, contour] of reversedEnumerate(this.contours)) {
       if (!sectRect(targetRect, contour.bounds)) {
         continue;
       }
       this._ensureContourIsLoaded(contourIndex, contour);
-      for (const [segmentIndex, segment] of enumerate(contour.segments)) {
+      for (const [segmentIndex, segment] of reversedEnumerate(contour.segments)) {
         if (!sectRect(targetRect, segment.bounds)) {
           continue;
         }

--- a/src/fontra/client/core/utils.js
+++ b/src/fontra/client/core/utils.js
@@ -144,6 +144,12 @@ export function* enumerate(iterable, start = 0) {
   }
 }
 
+export function* reversedEnumerate(seq) {
+  for (let i = seq.length - 1; i >= 0; i--) {
+    yield [i, seq[i]];
+  }
+}
+
 export function* range(start, stop, step = 1) {
   if (stop === undefined) {
     stop = start;

--- a/src/fontra/client/core/var-path.js
+++ b/src/fontra/client/core/var-path.js
@@ -372,18 +372,18 @@ export class VarPackedPath {
     return 0;
   }
 
-  firstPointIndexNearPoint(point, margin, skipPointIndex = undefined) {
+  pointIndexNearPoint(point, margin, skipPointIndex = undefined) {
     //
     // Given `point` and a `margin`, return the index of the first point
-    // that is within `margin` of `point`. Return undefined if no such
-    // point was found.
+    // that is within `margin` of `point`, searching from the *end* of the
+    // points list. Return undefined if no such point was found.
     //
     // If `skipPointIndex` is given, skip that particular point index.
     // This is useful if you want to find a point that is not a specific
     // point nearby.
     //
     const rect = centeredRect(point.x, point.y, margin);
-    for (const hit of this.iterPointsInRect(rect)) {
+    for (const hit of this.reverseIterPointsInRect(rect)) {
       // TODO: we may have to filter or sort for the case when a handle coincides with
       // its anchor, to get a consistent result despite which of the two comes first.
       if (hit.pointIndex !== skipPointIndex) {
@@ -454,6 +454,15 @@ export class VarPackedPath {
     for (const [pointIndex, point] of enumerate(this.iterPoints())) {
       if (pointInRect(point.x, point.y, rect)) {
         yield { ...point, pointIndex: pointIndex };
+      }
+    }
+  }
+
+  *reverseIterPointsInRect(rect) {
+    for (let index = this.pointTypes.length - 1; index >= 0; index--) {
+      const point = this.getPoint(index);
+      if (pointInRect(point.x, point.y, rect)) {
+        yield { ...point, pointIndex: index };
       }
     }
   }

--- a/src/fontra/views/editor/scene-controller.js
+++ b/src/fontra/views/editor/scene-controller.js
@@ -652,7 +652,7 @@ class PathConnectDetector {
 
     const sceneController = this.sceneController;
     const connectSourcePoint = this.path.getPoint(this.connectSourcePointIndex);
-    const connectTargetPointIndex = this.path.firstPointIndexNearPoint(
+    const connectTargetPointIndex = this.path.pointIndexNearPoint(
       connectSourcePoint,
       sceneController.mouseClickMargin,
       this.connectSourcePointIndex

--- a/src/fontra/views/editor/scene-model.js
+++ b/src/fontra/views/editor/scene-model.js
@@ -323,10 +323,7 @@ export class SceneModel {
       x: point.x - positionedGlyph.x,
       y: point.y - positionedGlyph.y,
     };
-    const pointIndex = positionedGlyph.glyph.path.firstPointIndexNearPoint(
-      glyphPoint,
-      size
-    );
+    const pointIndex = positionedGlyph.glyph.path.pointIndexNearPoint(glyphPoint, size);
     if (pointIndex !== undefined) {
       return new Set([`point/${pointIndex}`]);
     }

--- a/test-js/test-path-hit-tester.js
+++ b/test-js/test-path-hit-tester.js
@@ -10,7 +10,7 @@ describe("PathHitTester Tests", () => {
     [
       { x: 10, y: 10 },
       20,
-      { contourIndex: 0, segmentIndex: 0, d: 10, t: 0.1, x: 0, y: 10 },
+      { contourIndex: 0, segmentIndex: 3, d: 10, t: 0.95, x: 10.000000000000009, y: 0 },
     ],
     [
       { x: 100, y: 10 },
@@ -20,7 +20,14 @@ describe("PathHitTester Tests", () => {
     [
       { x: 190, y: 10 },
       20,
-      { contourIndex: 0, segmentIndex: 2, d: 14.142135623730951, t: 1, x: 200, y: 0 },
+      {
+        contourIndex: 0,
+        segmentIndex: 3,
+        d: 10,
+        t: 0.05000000000000001,
+        x: 190,
+        y: 0,
+      },
     ],
     [{ x: 190, y: 49 }, 20, {}],
     [
@@ -38,7 +45,14 @@ describe("PathHitTester Tests", () => {
     [
       { x: 10, y: 210 },
       20,
-      { contourIndex: 1, segmentIndex: 0, d: 10, t: 0.1, x: 0, y: 210 },
+      {
+        contourIndex: 1,
+        segmentIndex: 3,
+        d: 10,
+        t: 0.95,
+        x: 10.000000000000009,
+        y: 200,
+      },
     ],
     [
       { x: 100, y: 210 },


### PR DESCRIPTION
When searching a point or segment under the mouse pointer, search from the *end*, so we'll find the topmost item in case there are multiple matches.