### PR TITLE
Improve overlapping glyph selection

### DIFF
--- a/src/fontra/client/core/convex-hull.js
+++ b/src/fontra/client/core/convex-hull.js
@@ -163,11 +163,11 @@ export function simplePolygonArea(points) {
   // (A convex polygon is also a simple polygon.)
   // This uses the Shoelace formula: https://en.wikipedia.org/wiki/Shoelace_formula
   let areaX2 = 0;
-  for (let i = 0; i < points.length; i++) {
-    const pt0 = points.at(i - 1);
-    const pt1 = points[i];
+  let pt0 = points.at(-1);
+  for (const pt1 of points) {
     areaX2 += pt0.x * pt1.y;
     areaX2 -= pt0.y * pt1.x;
+    pt0 = pt1;
   }
   return areaX2 / 2;
 }

--- a/src/fontra/client/core/convex-hull.js
+++ b/src/fontra/client/core/convex-hull.js
@@ -157,3 +157,17 @@ function ccw(p1, p2, p3) {
   // A.k.a. compute the cross product
   return (p2.x - p1.x) * (p3.y - p1.y) - (p2.y - p1.y) * (p3.x - p1.x);
 }
+
+export function simplePolygonArea(points) {
+  // Compute the area of a simple (non-self-intersecting) polygon.
+  // (A convex polygon is also a simple polygon.)
+  // This uses the Shoelace formula: https://en.wikipedia.org/wiki/Shoelace_formula
+  let areaX2 = 0;
+  for (let i = 0; i < points.length; i++) {
+    const pt0 = points.at(i - 1);
+    const pt1 = points[i];
+    areaX2 += pt0.x * pt1.y;
+    areaX2 -= pt0.y * pt1.x;
+  }
+  return areaX2 / 2;
+}

--- a/src/fontra/client/core/glyph-controller.js
+++ b/src/fontra/client/core/glyph-controller.js
@@ -1,3 +1,4 @@
+import { simplePolygonArea } from "./convex-hull.js";
 import { PathHitTester } from "./path-hit-tester.js";
 import {
   getRepresentation,
@@ -302,6 +303,10 @@ export class StaticGlyphController {
     return getRepresentation(this, "convexHull");
   }
 
+  get convexHullArea() {
+    return getRepresentation(this, "convexHullArea");
+  }
+
   get pathHitTester() {
     return getRepresentation(this, "pathHitTester");
   }
@@ -346,6 +351,10 @@ registerRepresentationFactory(StaticGlyphController, "controlBounds", (glyph) =>
 
 registerRepresentationFactory(StaticGlyphController, "convexHull", (glyph) => {
   return glyph.flattenedPath.getConvexHull();
+});
+
+registerRepresentationFactory(StaticGlyphController, "convexHullArea", (glyph) => {
+  return Math.abs(simplePolygonArea(glyph.convexHull));
 });
 
 registerRepresentationFactory(StaticGlyphController, "pathHitTester", (glyph) => {

--- a/src/fontra/views/editor/scene-model.js
+++ b/src/fontra/views/editor/scene-model.js
@@ -438,7 +438,7 @@ export class SceneModel {
       // convex hull area, as that's the one most likely to be hard to
       // hit otherwise.
       // These heuristics should help selecting the glyph intended by the
-      // user, independently of their order in the string.
+      // user, regardless of its order in the string.
       const decoratedMatches = matches.map(([i, j]) => {
         const positionedGlyph = this.positionedLines[i].glyphs[j];
         return {


### PR DESCRIPTION
Previously, if the shape of a glyph was completely contained within the convex hull of its right-hand neighbor, it would be impossible to click on (the right one always won).

This PR changes this behavior to be more useful by applying point-inside tests and a heuristic:

- check which glyph shape the user actually clicking on (do proper "point inside" testing)
- if that still doesn't resolve the issue (the target point is inside both shapes, or inside neither), take the glyph with the smallest area of its convex hull