### PR TITLE
Remove use of :host-context CSS

### DIFF
--- a/src/fontra/client/css/core.css
+++ b/src/fontra/client/css/core.css
@@ -21,55 +21,57 @@
 }
 
 :root {
-  --fontra-red-color: #f11759;
-
-  --foreground-color-light: black;
-  --background-color-light: #f6f6f6;
-  --foreground-color-dark: white;
-  --background-color-dark: #333;
-
-  --ui-element-background-color-light: white;
-  --ui-element-background-color-dark: #484848;
-  --text-input-foreground-color-light: black;
-  --text-input-background-color-light: #eee;
-  --text-input-foreground-color-dark: white;
-  --text-input-background-color-dark: #333;
-
-  --foreground-color: var(--foreground-color-light);
-  --background-color: var(--background-color-light);
-
-  --ui-element-background-color: var(--ui-element-background-color-light);
-  --text-input-foreground-color: var(--text-input-foreground-color-light);
-  --text-input-background-color: var(--text-input-background-color-light);
+  /* https://css-tricks.com/the-css-custom-property-toggle-trick/ */
+  --fontra-theme-marker: ; /* a space, which is valid */
 }
 
 :root.dark-theme {
-  --foreground-color: var(--foreground-color-dark);
-  --background-color: var(--background-color-dark);
-
-  --ui-element-background-color: var(--ui-element-background-color-dark);
-  --text-input-foreground-color: var(--text-input-foreground-color-dark);
-  --text-input-background-color: var(--text-input-background-color-dark);
+  --fontra-theme-marker: initial; /* invalidates the "light" variables */
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --foreground-color: var(--foreground-color-dark);
-    --background-color: var(--background-color-dark);
-
-    --ui-element-background-color: var(--ui-element-background-color-dark);
-    --text-input-foreground-color: var(--text-input-foreground-color-dark);
-    --text-input-background-color: var(--text-input-background-color-dark);
+    --fontra-theme-marker: initial; /* invalidates the "light" variables */
   }
 
   :root.light-theme {
-    --foreground-color: var(--foreground-color-light);
-    --background-color: var(--background-color-light);
-
-    --ui-element-background-color: var(--ui-element-background-color-light);
-    --text-input-foreground-color: var(--text-input-foreground-color-light);
-    --text-input-background-color: var(--text-input-background-color-light);
+    --fontra-theme-marker: ; /* a space, which is valid */
   }
+}
+
+:root {
+  --fontra-red-color: #f11759;
+
+  --foreground-color-light: var(--fontra-theme-marker) black;
+  --foreground-color-dark: white;
+
+  --background-color-light: var(--fontra-theme-marker) #f6f6f6;
+  --background-color-dark: #333;
+
+  --ui-element-background-color-light: var(--fontra-theme-marker) white;
+  --ui-element-background-color-dark: #484848;
+
+  --text-input-foreground-color-light: var(--fontra-theme-marker) black;
+  --text-input-foreground-color-dark: white;
+
+  --text-input-background-color-light: var(--fontra-theme-marker) #eee;
+  --text-input-background-color-dark: #333;
+
+  --foreground-color: var(--foreground-color-light, var(--foreground-color-dark));
+  --background-color: var(--background-color-light, var(--background-color-dark));
+
+  --ui-element-background-color: var(
+    --ui-element-background-color-light,
+    var(--ui-element-background-color-dark)
+  );
+  --text-input-foreground-color: var(
+    --text-input-foreground-color-light,
+    var(--text-input-foreground-color-dark)
+  );
+  --text-input-background-color: var(
+    --text-input-background-color-light,
+    var(--text-input-background-color-dark)
+  );
 }
 
 html,

--- a/src/fontra/client/web-components/dialog-overlay.js
+++ b/src/fontra/client/web-components/dialog-overlay.js
@@ -21,7 +21,7 @@ export function dialog(
 export class DialogOverlay extends UnlitElement {
   static styles = `
     :host {
-      display: none;
+      display: none;  /* switched to "grid" on show, back to "none" on hide */
       position: absolute;
       grid-template-rows: 5fr 1fr;
       align-items: center;
@@ -32,10 +32,6 @@ export class DialogOverlay extends UnlitElement {
       align-content: center;
       justify-content: center;
       white-space: normal;
-    }
-
-    :host-context(.visible) {
-      display: grid;
     }
 
     .dialog-box {
@@ -136,8 +132,8 @@ export class DialogOverlay extends UnlitElement {
 
     return {
       cancel: () => this._dialogDone(null),
-      hide: () => this.classList.remove("visible"),
-      show: () => this.classList.add("visible"),
+      hide: () => this.hide(),
+      show: () => this.show(),
       then: this._resultPromise.then.bind(this._resultPromise),
     };
   }
@@ -170,7 +166,7 @@ export class DialogOverlay extends UnlitElement {
       );
     }
 
-    this.classList.add("visible");
+    this.show();
     this.shadowRoot.appendChild(dialogBox);
     dialogBox.focus();
   }
@@ -221,6 +217,14 @@ export class DialogOverlay extends UnlitElement {
     }
   }
 
+  show() {
+    this.style.display = "grid";
+  }
+
+  hide() {
+    this.style.display = "none";
+  }
+
   _handleKeyDown(event) {
     if (event.key == "Enter") {
       if (!this._defaultButtonElement?.classList.contains("disabled")) {
@@ -241,7 +245,7 @@ export class DialogOverlay extends UnlitElement {
       this._dismissTimeoutID = undefined;
     }
     this.innerHTML = "";
-    this.classList.remove("visible");
+    this.hide();
     this._currentActiveElement?.focus();
     this._resolveDialogResult(result);
   }

--- a/src/fontra/client/web-components/theme-support.js
+++ b/src/fontra/client/web-components/theme-support.js
@@ -3,30 +3,15 @@ export function themeColorCSS(colors) {
   const lightMode = [];
   const darkMode = [];
   for (const [colorName, [lightColor, darkColor]] of Object.entries(colors)) {
-    definitions.push(`--${colorName}-light: ${lightColor};`);
+    definitions.push(`--${colorName}-light: var(--fontra-theme-marker) ${lightColor};`);
     definitions.push(`--${colorName}-dark: ${darkColor};`);
-    lightMode.push(`--${colorName}: var(--${colorName}-light);`);
-    darkMode.push(`--${colorName}: var(--${colorName}-dark);`);
+    definitions.push(
+      `--${colorName}: var(--${colorName}-light, var(--${colorName}-dark));`
+    );
   }
   return `
 :host {
 ${indentLines(definitions, 2)}
-
-${indentLines(lightMode, 2)}
-}
-
-:host-context(html.dark-theme) {
-${indentLines(darkMode, 2)}
-}
-
-@media (prefers-color-scheme: dark) {
-  :host {
-${indentLines(darkMode, 4)}
-  }
-
-  :host-context(html.light-theme) {
-${indentLines(lightMode, 4)}
-  }
 }
 `;
 }

--- a/src/fontra/client/web-components/ui-list.js
+++ b/src/fontra/client/web-components/ui-list.js
@@ -21,10 +21,6 @@ export class UIList extends UnlitElement {
       border: solid 1px var(--border-color);
     }
 
-    :host-context(.empty) {
-      display: none;
-    }
-
     .contents {
       display: flex;
       flex-direction: column;
@@ -68,7 +64,7 @@ export class UIList extends UnlitElement {
     this.itemEqualFunc = null;
 
     this.contents = html.div({
-      class: "contents empty",
+      class: "contents",
       onclick: (event) => this._clickHandler(event),
       ondblclick: (event) => this._dblClickHandler(event),
     });
@@ -93,7 +89,7 @@ export class UIList extends UnlitElement {
   }
 
   setItems(items) {
-    this.classList.toggle("empty", !items.length);
+    this.style.display = items?.length ? "initial" : "none";
     this.contents.innerHTML = "";
     this.items = items;
     this._itemsBackLog = Array.from(items);


### PR DESCRIPTION
...as this turned out to be Chrome-only. Oops.

This also reworks the way the light/dark theme colors are switched, which makes it possible to use a global theme override in all web components without using :host-context.