### PR TITLE
Add/remove source

### DIFF
--- a/src/fontra/client/core/change-recorder.js
+++ b/src/fontra/client/core/change-recorder.js
@@ -106,7 +106,7 @@ function getProxy(subject, changes) {
       if (method) {
         return method;
       }
-      if (isArray && !isNaN(prop)) {
+      if (isArray && typeof prop !== "symbol" && !isNaN(prop)) {
         prop = parseInt(prop);
       }
       subject = subject[prop];

--- a/src/fontra/client/web-components/add-remove-buttons.js
+++ b/src/fontra/client/web-components/add-remove-buttons.js
@@ -1,17 +1,53 @@
-import { html, css, LitElement } from "../third-party/lit.js";
+import { themeColorCSS } from "./theme-support.js";
+import { html, css, LitElement, unsafeCSS } from "../third-party/lit.js";
+
+const colors = {
+  "button-color": ["#ddd", "#888"],
+  "button-disabled-color": ["#eee", "#555"],
+  "button-hover-color": ["#ccc", "#999"],
+  "button-active-color": ["#bbb", "#bbb"],
+  "text-color": ["#000", "#fff"],
+  "text-disabled-color": ["#aaa", "#888"],
+};
 
 export class AddRemoveButtons extends LitElement {
   static styles = css`
+    ${unsafeCSS(themeColorCSS(colors))}
+
     .buttons-container {
       padding: 0.5em;
       padding-left: 0;
+      display: grid;
+      grid-template-columns: auto auto;
+      justify-content: start;
+      gap: 0.5em;
     }
 
     button {
-      min-width: 2em;
+      font-size: 1.7em;
+      text-align: center;
+      line-height: 1.05em;
+      width: 1em;
+      height: 1em;
+      padding: 0;
+      border-radius: 1em;
+      background-color: var(--button-color);
+      color: var(--text-color);
+      border: none;
+    }
+
+    button:disabled {
+      background-color: var(--button-disabled-color);
+      color: var(--text-disabled-color);
     }
 
     button:enabled:hover {
+      background-color: var(--button-hover-color);
+      cursor: pointer;
+    }
+
+    button:enabled:active {
+      background-color: var(--button-active-color);
       cursor: pointer;
     }
   `;

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -417,6 +417,14 @@ export class EditorController {
       await this.sceneController.sceneModel.getSelectedVariableGlyphController();
 
     const glyph = glyphController.glyph;
+
+    const source = glyph.sources[sourceIndex];
+    const locationController = new ObservableController({ ...source.location });
+    const nameController = new ObservableController({
+      sourceName: source.name,
+      layerName: source.layerName,
+    });
+
     const localAxisNames = glyph.axes.map((axis) => axis.name);
     const globalAxes = mapAxesFromUserSpaceToDesignspace(
       // Don't include global axes that also exist as local axes
@@ -429,12 +437,6 @@ export class EditorController {
       ...(globalAxes.length && glyph.axes.length ? [{ isDivider: true }] : []),
       ...glyph.axes,
     ];
-    const source = glyph.sources[sourceIndex];
-    const locationController = new ObservableController({ ...source.location });
-    const nameController = new ObservableController({
-      sourceName: source.name,
-      layerName: source.layerName,
-    });
 
     const locationElement = html.createDomElement("designspace-location", {
       style: `grid-column: 1 / -1;

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -407,8 +407,10 @@ export class EditorController {
   }
 
   updateRemoveSourceButtonState() {
-    this.addRemoveSourceButtons.disableRemoveButton =
-      this.sourcesList.getSelectedItemIndex() === undefined;
+    setTimeout(() => {
+      this.addRemoveSourceButtons.disableRemoveButton =
+        this.sourcesList.getSelectedItemIndex() === undefined;
+    }, 0);
   }
 
   async removeSource(sourceIndex) {
@@ -915,8 +917,8 @@ export class EditorController {
     const sourceItems = await this.sceneController.getSourcesInfo();
     this.sourcesList.setItems(sourceItems || []);
     this.addRemoveSourceButtons.hidden = !sourceItems;
-    this.updateRemoveSourceButtonState();
     this.updateWindowLocationAndSelectionInfo();
+    this.updateRemoveSourceButtonState();
   }
 
   async doubleClickedComponentsCallback(event) {

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -436,7 +436,9 @@ export class EditorController {
       ]),
       html.br(),
       deleteLayerCheckBox,
-      html.label({ for: "delete-layer" }, ["Also delete associated layer"]),
+      html.label({ for: "delete-layer" }, [
+        `Also delete associated layer “${source.layerName}”`,
+      ]),
     ]);
     dialog.setContent(dialogContent);
 

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -428,7 +428,7 @@ export class EditorController {
       ]),
       html.br(),
       deleteLayerCheckBox,
-      html.label({ for: "delete-layer" }, ["Delete associated layer"]),
+      html.label({ for: "delete-layer" }, ["Also delete associated layer"]),
     ]);
     dialog.setContent(dialogContent);
 

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -20,7 +20,7 @@ import { SceneView } from "../core/scene-view.js";
 import { Form } from "../core/ui-form.js";
 import { StaticGlyph } from "../core/var-glyph.js";
 import { addItemwise, subItemwise, mulScalar } from "../core/var-funcs.js";
-import { piecewiseLinearMap } from "/core/var-model.js";
+import { normalizeLocation, piecewiseLinearMap } from "/core/var-model.js";
 import { joinPaths } from "../core/var-path.js";
 import * as html from "/core/unlit.js";
 import {
@@ -421,8 +421,21 @@ export class EditorController {
     if (!newLocation) {
       return;
     }
-    console.log(sourceName, layerName);
-    console.log(newLocation);
+    const instance = glyphController.instantiate(
+      normalizeLocation(location, glyphController.combinedAxes)
+    );
+    // TODO: round coordinates and component positions
+    await this.sceneController.editGlyphAndRecordChanges((glyph) => {
+      glyph.sources.push({
+        name: sourceName,
+        layerName: layerName,
+        location: newLocation,
+      });
+      glyph.layers.push({ name: layerName, glyph: instance });
+      return "add source";
+    });
+    // Update UI
+    await this.updateSlidersAndSources();
   }
 
   async editSourceProperties(sourceIndex) {

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -260,6 +260,7 @@ export class EditorController {
           await this.sceneController.getSelectedSource()
         );
         this.updateWindowLocationAndSelectionInfo();
+        this.updateRemoveSourceButtonState();
         this.autoViewBox = false;
       })
     );
@@ -397,10 +398,16 @@ export class EditorController {
       this.sliders.values = this.sceneController.getLocation();
       this.updateWindowLocationAndSelectionInfo();
       this.autoViewBox = false;
+      this.updateRemoveSourceButtonState();
     });
     this.sourcesList.addEventListener("rowDoubleClicked", (event) => {
       this.editSourceProperties(event.detail.doubleClickedRowIndex);
     });
+  }
+
+  updateRemoveSourceButtonState() {
+    this.addRemoveSourceButtons.disableRemoveButton =
+      this.sourcesList.getSelectedItemIndex() === undefined;
   }
 
   async removeSource(sourceIndex) {
@@ -886,6 +893,7 @@ export class EditorController {
     const sourceItems = await this.sceneController.getSourcesInfo();
     this.sourcesList.setItems(sourceItems || []);
     this.addRemoveSourceButtons.hidden = !sourceItems;
+    this.updateRemoveSourceButtonState();
     this.updateWindowLocationAndSelectionInfo();
   }
 

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -478,6 +478,7 @@ export class EditorController {
     const instance = glyphController.instantiate(
       normalizeLocation(location, glyphController.combinedAxes)
     );
+    instance.path = instance.path.roundCoordinates();
     // TODO: round coordinates and component positions
     await this.sceneController.editGlyphAndRecordChanges((glyph) => {
       glyph.sources.push({

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -579,16 +579,7 @@ export class EditorController {
       return {};
     }
 
-    const locationModel = locationController.model;
-    const newLocation = Object.fromEntries(
-      locationAxes
-        .filter(
-          (axis) =>
-            locationModel[axis.name] !== undefined &&
-            locationModel[axis.name] !== axis.defaultValue
-        )
-        .map((axis) => [axis.name, locationModel[axis.name]])
-    );
+    const newLocation = makeSparseLocation(locationController.model, locationAxes);
 
     sourceName = nameController.model.sourceName;
     layerName = nameController.model.layerName || nameController.model.sourceName;
@@ -2357,4 +2348,15 @@ function roundComponentOrigins(components) {
       component.transformation.translateY
     );
   });
+}
+
+function makeSparseLocation(location, axes) {
+  return Object.fromEntries(
+    axes
+      .filter(
+        (axis) =>
+          location[axis.name] !== undefined && location[axis.name] !== axis.defaultValue
+      )
+      .map((axis) => [axis.name, location[axis.name]])
+  );
 }

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -478,8 +478,10 @@ export class EditorController {
     const instance = glyphController.instantiate(
       normalizeLocation(location, glyphController.combinedAxes)
     );
+    // Round coordinates and component positions
     instance.path = instance.path.roundCoordinates();
-    // TODO: round coordinates and component positions
+    roundComponentOrigins(instance.components);
+
     await this.sceneController.editGlyphAndRecordChanges((glyph) => {
       glyph.sources.push({
         name: sourceName,
@@ -2313,4 +2315,15 @@ function* labeledTextInput(label, controller, key, options) {
   }
 
   yield inputElement;
+}
+
+function roundComponentOrigins(components) {
+  components.forEach((component) => {
+    component.transformation.translateX = Math.round(
+      component.transformation.translateX
+    );
+    component.transformation.translateY = Math.round(
+      component.transformation.translateY
+    );
+  });
 }

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -417,7 +417,7 @@ export class EditorController {
       location: newLocation,
       sourceName,
       layerName,
-    } = await this._sourcePropertiesRunDialog(glyph, "", "", location);
+    } = await this._sourcePropertiesRunDialog("Add source", glyph, "", "", location);
     if (!newLocation) {
       return;
     }
@@ -438,6 +438,7 @@ export class EditorController {
       sourceName,
       layerName,
     } = await this._sourcePropertiesRunDialog(
+      "Source properties",
       glyph,
       source.name,
       source.layerName,
@@ -464,7 +465,7 @@ export class EditorController {
     await this.updateSlidersAndSources();
   }
 
-  async _sourcePropertiesRunDialog(glyph, sourceName, layerName, location) {
+  async _sourcePropertiesRunDialog(title, glyph, sourceName, layerName, location) {
     const nameController = new ObservableController({
       sourceName: sourceName,
       layerName: layerName,
@@ -481,7 +482,7 @@ export class EditorController {
       locationController
     );
 
-    const dialog = await dialogSetup("Source properties", null, [
+    const dialog = await dialogSetup(title, null, [
       { title: "Cancel", isCancelButton: true },
       { title: "Done", isDefaultButton: true, disabled: !sourceName.length },
     ]);

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -492,7 +492,7 @@ export class EditorController {
       return;
     }
     const instance = glyphController.instantiate(
-      normalizeLocation(location, glyphController.combinedAxes)
+      normalizeLocation(newLocation, glyphController.combinedAxes)
     );
     // Round coordinates and component positions
     instance.path = instance.path.roundCoordinates();

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -550,8 +550,22 @@ export class EditorController {
       if (sourceName !== source.name) {
         source.name = sourceName;
       }
+      const oldLayerName = source.layerName;
       if (layerName !== source.layerName) {
         source.layerName = layerName;
+      }
+      if (layerNames.indexOf(layerName) < 0) {
+        // Rename the layer
+        for (const layer of glyph.layers) {
+          if (layer.name === oldLayerName) {
+            layer.name = layerName;
+          }
+        }
+        for (const source of glyph.sources) {
+          if (source.layerName === oldLayerName) {
+            source.layerName = layerName;
+          }
+        }
       }
       return "edit source properties";
     });

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -382,18 +382,12 @@ export class EditorController {
     this.sourcesList = document.querySelector("#sources-list");
     this.sourcesList.columnDescriptions = columnDescriptions;
 
-    // TODO: relocate those to somewhere more appropriate after implementation
-    const addSourceCallback = () => {
-      console.log("add a source");
-    };
-    const removeSourceCallback = () => {
-      console.log("remove a source");
-    };
     this.addRemoveSourceButtons = document.querySelector(
       "#sources-list-add-remove-buttons"
     );
-    this.addRemoveSourceButtons.addButtonCallback = addSourceCallback;
-    this.addRemoveSourceButtons.removeButtonCallback = removeSourceCallback;
+    this.addRemoveSourceButtons.addButtonCallback = () => this.addSource();
+    this.addRemoveSourceButtons.removeButtonCallback = () =>
+      console.log("remove a source");
     this.addRemoveSourceButtons.hidden = true;
 
     this.sourcesList.addEventListener("listSelectionChanged", async (event) => {
@@ -407,6 +401,15 @@ export class EditorController {
     this.sourcesList.addEventListener("rowDoubleClicked", (event) => {
       this.editSourceProperties(event.detail.doubleClickedRowIndex);
     });
+  }
+
+  async addSource() {
+    const glyphController =
+      await this.sceneController.sceneModel.getSelectedVariableGlyphController();
+    const location = glyphController.mapLocationGlobalToLocal(
+      this.sceneController.getLocation()
+    );
+    console.log(location);
   }
 
   async editSourceProperties(sourceIndex) {

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -2318,7 +2318,6 @@ function* labeledTextInput(label, controller, key, options) {
 
   const choices = options?.choices;
   const choicesID = `${key}-choices`;
-  console.log("choices", choices);
 
   const inputElement = htmlToElement(`<input ${choices ? `list="${choicesID}"` : ""}>`);
   inputElement.type = "text";

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -487,6 +487,7 @@ export class EditorController {
       location: newLocation,
       sourceName,
       layerName,
+      layerNames,
     } = await this._sourcePropertiesRunDialog("Add source", glyph, "", "", location);
     if (!newLocation) {
       return;
@@ -504,7 +505,10 @@ export class EditorController {
         layerName: layerName,
         location: newLocation,
       });
-      glyph.layers.push({ name: layerName, glyph: instance });
+      if (layerNames.indexOf(layerName) < 0) {
+        // Only add layer if the name is new
+        glyph.layers.push({ name: layerName, glyph: instance });
+      }
       return "add source";
     });
     // Update UI
@@ -526,6 +530,7 @@ export class EditorController {
       location: newLocation,
       sourceName,
       layerName,
+      layerNames,
     } = await this._sourcePropertiesRunDialog(
       "Source properties",
       glyph,
@@ -625,7 +630,7 @@ export class EditorController {
     sourceName = nameController.model.sourceName;
     layerName = nameController.model.layerName || nameController.model.sourceName;
 
-    return { location: newLocation, sourceName, layerName };
+    return { location: newLocation, sourceName, layerName, layerNames };
   }
 
   _sourcePropertiesLocationAxes(glyph) {

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -559,6 +559,11 @@ export class EditorController {
       const warnings = [];
       if (!nameController.model.sourceName.length) {
         warnings.push("⚠️ The source name must not be empty");
+      } else if (
+        nameController.model.sourceName !== sourceName &&
+        glyph.sources.some((source) => source.name === nameController.model.sourceName)
+      ) {
+        warnings.push("⚠️ The source name should be unique");
       }
       const locStr = locationToString(
         makeSparseLocation(locationController.model, locationAxes)

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -424,10 +424,17 @@ export class EditorController {
       { title: "Delete", isDefaultButton: true, result: "ok" },
     ]);
 
+    const canDeleteLayer =
+      1 ===
+      glyph.sources.reduce(
+        (count, src) => count + (src.layerName === source.layerName ? 1 : 0),
+        0
+      );
     const deleteLayerCheckBox = html.input({
       type: "checkbox",
       id: "delete-layer",
-      checked: true,
+      checked: canDeleteLayer,
+      disabled: !canDeleteLayer,
     });
 
     const dialogContent = html.div({}, [
@@ -436,7 +443,7 @@ export class EditorController {
       ]),
       html.br(),
       deleteLayerCheckBox,
-      html.label({ for: "delete-layer" }, [
+      html.label({ for: "delete-layer", style: canDeleteLayer ? "" : "color: gray;" }, [
         `Also delete associated layer “${source.layerName}”`,
       ]),
     ]);

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -508,7 +508,10 @@ export class EditorController {
       return "add source";
     });
     // Update UI
+    const selectedSourceIndex = glyph.sources.length - 1; /* the newly added source */
+    await this.sceneController.setSelectedSource(selectedSourceIndex);
     await this.updateSlidersAndSources();
+    this.sourcesList.setSelectedItemIndex(selectedSourceIndex, false); /* hmm */
   }
 
   async editSourceProperties(sourceIndex) {


### PR DESCRIPTION
This fixes #409 and fixes #57.

Hook up "add source" button

- Refactor edit source properties so we can reuse it for add source

TODO:
- [x] Hook up remove source button
- [x] safeguard UI against invalid designspace configurations
  - avoid duplicate location & source name
- [x] Make layer creation optional (the new source could refer to an existing layer)
- [x] Round coordinates and component origins (optional?)
- [x] Add options list to layer name field, so it's easy to choose an existing layer name
- [x] Improve +/- button styling (dark mode, flat design, circular?, hover/active)