### PR TITLE
Apply classes schema to incoming change data

### DIFF
--- a/src/fontra/client/core/classes.js
+++ b/src/fontra/client/core/classes.js
@@ -1,0 +1,65 @@
+import { fetchJSON } from "./utils.js";
+
+const classSchema = {};
+
+let schemaPromise;
+
+export function getClassSchema(rawSchema) {
+  if (!schemaPromise) {
+    let resolvePromise;
+    schemaPromise = new Promise((resolve) => (resolvePromise = resolve));
+    if (rawSchema) {
+      populateSchema(rawSchema);
+      resolvePromise(classSchema);
+    } else {
+      fetchJSON("/core/classes.json").then((result) => {
+        populateSchema(result);
+        resolvePromise(classSchema);
+      });
+    }
+  }
+  return schemaPromise;
+}
+
+function populateSchema(rawSchema) {
+  for (const className in rawSchema) {
+    classSchema[className] = new ClassDef(rawSchema[className], className);
+  }
+}
+
+class ClassDef {
+  constructor(rawClassDef, className, subType) {
+    this.rawClassDef = rawClassDef;
+    this.className = className;
+    this.subType = subType;
+    this.subTypeMapping = {};
+  }
+
+  getSubType(property) {
+    if (this.subType) {
+      return this.subType;
+    }
+    let subType = this.subTypeMapping[property];
+    if (!subType) {
+      const rawSubDef = this.rawClassDef[property];
+      if (!rawSubDef) {
+        throw TypeError(`Unknown subType ${property} of ${this.className}`);
+      }
+      if (rawSubDef.subtype) {
+        // type<subType>
+        if (!classSchema[rawSubDef.subtype]) {
+          classSchema[rawSubDef.subtype] = new ClassDef(null, rawSubDef.subtype);
+        }
+        subType = new ClassDef(
+          null,
+          `${rawSubDef.type}<${rawSubDef.subtype}>`,
+          classSchema[rawSubDef.subtype]
+        );
+      } else {
+        subType = classSchema[rawSubDef.type];
+      }
+      this.subTypeMapping[property] = subType;
+    }
+    return subType;
+  }
+}

--- a/src/fontra/client/core/classes.js
+++ b/src/fontra/client/core/classes.js
@@ -30,40 +30,40 @@ function populateSchema(rawSchema) {
 }
 
 const castDefinitions = {
-  VariableGlyph(value, classDef) {
+  VariableGlyph(classDef, value) {
     if (value.constructor !== VariableGlyph) {
       value = VariableGlyph.fromObject(value);
     }
     return value;
   },
 
-  Layer(value, classDef) {
+  Layer(classDef, value) {
     if (value.constructor !== Layer) {
       value = Layer.fromObject(value);
     }
     return value;
   },
 
-  StaticGlyph(value, classDef) {
+  StaticGlyph(classDef, value) {
     if (value.constructor !== StaticGlyph) {
       value = StaticGlyph.fromObject(value);
     }
     return value;
   },
 
-  PackedPath(value, classDef) {
+  PackedPath(classDef, value) {
     if (value.constructor !== VarPackedPath) {
       value = VarPackedPath.fromObject(value);
     }
     return value;
   },
 
-  list(value, classDef) {
+  list(classDef, value) {
     value = [...value.map(classDef.itemCast)];
     return value;
   },
 
-  dict(value, classDef) {
+  dict(classDef, value) {
     value = Object.fromEntries(
       Object.entries(value).map(([k, v]) => [k, classDef.itemCast(v)])
     );
@@ -115,7 +115,7 @@ class ClassDef {
   cast(value) {
     const caster = castDefinitions[this.className];
     if (caster) {
-      value = caster(value, this);
+      value = caster(this, value);
     }
     return value;
   }

--- a/src/fontra/client/core/classes.js
+++ b/src/fontra/client/core/classes.js
@@ -56,6 +56,9 @@ class ClassDef {
           classSchema[rawSubDef.subtype]
         );
       } else {
+        if (!classSchema[rawSubDef.type]) {
+          classSchema[rawSubDef.type] = new ClassDef(null, rawSubDef.type);
+        }
         subType = classSchema[rawSubDef.type];
       }
       this.subTypeMapping[property] = subType;

--- a/src/fontra/client/core/classes.js
+++ b/src/fontra/client/core/classes.js
@@ -64,7 +64,9 @@ const castDefinitions = {
   },
 
   dict(value, classDef) {
-    value = Object.fromEntries(Object.entries(value).map(classDef.itemCast));
+    value = Object.fromEntries(
+      Object.entries(value).map(([k, v]) => [k, classDef.itemCast(v)])
+    );
     return value;
   },
 };

--- a/src/fontra/client/core/classes.js
+++ b/src/fontra/client/core/classes.js
@@ -32,6 +32,9 @@ class ClassDef {
     this.rawClassDef = rawClassDef;
     this.className = className;
     this.subType = subType;
+    this.compositeName = this.subType
+      ? `${className}<${this.subType.className}>`
+      : className;
     this.subTypeMapping = {};
   }
 
@@ -50,11 +53,7 @@ class ClassDef {
         if (!classSchema[rawSubDef.subtype]) {
           classSchema[rawSubDef.subtype] = new ClassDef(null, rawSubDef.subtype);
         }
-        subType = new ClassDef(
-          null,
-          `${rawSubDef.type}<${rawSubDef.subtype}>`,
-          classSchema[rawSubDef.subtype]
-        );
+        subType = new ClassDef(null, rawSubDef.type, classSchema[rawSubDef.subtype]);
       } else {
         if (!classSchema[rawSubDef.type]) {
           classSchema[rawSubDef.type] = new ClassDef(null, rawSubDef.type);

--- a/src/fontra/client/core/classes.json
+++ b/src/fontra/client/core/classes.json
@@ -1,0 +1,175 @@
+{
+  "Font": {
+    "unitsPerEm": {
+      "type": "int"
+    },
+    "glyphs": {
+      "type": "dict",
+      "subtype": "VariableGlyph"
+    },
+    "glyphMap": {
+      "type": "dict",
+      "subtype": "list"
+    },
+    "axes": {
+      "type": "list",
+      "subtype": "GlobalAxis"
+    }
+  },
+  "VariableGlyph": {
+    "name": {
+      "type": "str"
+    },
+    "axes": {
+      "type": "list",
+      "subtype": "LocalAxis"
+    },
+    "sources": {
+      "type": "list",
+      "subtype": "Source"
+    },
+    "layers": {
+      "type": "list",
+      "subtype": "Layer"
+    }
+  },
+  "LocalAxis": {
+    "name": {
+      "type": "str"
+    },
+    "minValue": {
+      "type": "float"
+    },
+    "defaultValue": {
+      "type": "float"
+    },
+    "maxValue": {
+      "type": "float"
+    }
+  },
+  "Source": {
+    "name": {
+      "type": "str"
+    },
+    "layerName": {
+      "type": "str"
+    },
+    "location": {
+      "type": "dict",
+      "subtype": "float"
+    }
+  },
+  "Layer": {
+    "name": {
+      "type": "str"
+    },
+    "glyph": {
+      "type": "StaticGlyph"
+    }
+  },
+  "StaticGlyph": {
+    "path": {
+      "type": "PackedPath"
+    },
+    "components": {
+      "type": "list",
+      "subtype": "Component"
+    },
+    "xAdvance": {
+      "type": "float",
+      "optional": true
+    },
+    "yAdvance": {
+      "type": "float",
+      "optional": true
+    },
+    "verticalOrigin": {
+      "type": "float",
+      "optional": true
+    }
+  },
+  "PackedPath": {
+    "coordinates": {
+      "type": "list",
+      "subtype": "float"
+    },
+    "pointTypes": {
+      "type": "list",
+      "subtype": "PointType"
+    },
+    "contourInfo": {
+      "type": "list",
+      "subtype": "ContourInfo"
+    }
+  },
+  "ContourInfo": {
+    "endPoint": {
+      "type": "int"
+    },
+    "isClosed": {
+      "type": "bool"
+    }
+  },
+  "Component": {
+    "name": {
+      "type": "str"
+    },
+    "transformation": {
+      "type": "Transformation"
+    },
+    "location": {
+      "type": "dict",
+      "subtype": "float"
+    }
+  },
+  "Transformation": {
+    "translateX": {
+      "type": "float"
+    },
+    "translateY": {
+      "type": "float"
+    },
+    "rotation": {
+      "type": "float"
+    },
+    "scaleX": {
+      "type": "float"
+    },
+    "scaleY": {
+      "type": "float"
+    },
+    "skewX": {
+      "type": "float"
+    },
+    "skewY": {
+      "type": "float"
+    },
+    "tCenterX": {
+      "type": "float"
+    },
+    "tCenterY": {
+      "type": "float"
+    }
+  },
+  "GlobalAxis": {
+    "name": {
+      "type": "str"
+    },
+    "tag": {
+      "type": "str"
+    },
+    "minValue": {
+      "type": "float"
+    },
+    "defaultValue": {
+      "type": "float"
+    },
+    "maxValue": {
+      "type": "float"
+    },
+    "mapping": {
+      "type": "list",
+      "subtype": "tuple"
+    }
+  }
+}

--- a/src/fontra/client/core/font-controller.js
+++ b/src/fontra/client/core/font-controller.js
@@ -5,6 +5,7 @@ import {
   filterChangePattern,
   matchChangePath,
 } from "./changes.js";
+import { getClassSchema } from "../core/classes.js";
 import { getGlyphMapProxy, makeCharacterMapFromGlyphMap } from "./cmap.js";
 import { StaticGlyphController, VariableGlyphController } from "./glyph-controller.js";
 import { LRUCache } from "./lru-cache.js";
@@ -38,6 +39,7 @@ export class FontController {
     this._rootObject["axes"] = await this.font.getGlobalAxes();
     this._rootObject["unitsPerEm"] = await this.font.getUnitsPerEm();
     this._rootObject["lib"] = await this.font.getFontLib();
+    this._rootClassDef = (await getClassSchema())["Font"];
     this._resolveInitialized();
   }
 
@@ -280,7 +282,7 @@ export class FontController {
       glyphSet[glyphName] = (await this.getGlyph(glyphName)).glyph;
     }
     this._rootObject["glyphs"] = glyphSet;
-    applyChange(this._rootObject, change);
+    applyChange(this._rootObject, change, this._rootClassDef);
     delete this._rootObject["glyphs"];
     for (const glyphName of glyphNames) {
       this.glyphChanged(glyphName);

--- a/src/fontra/client/core/var-glyph.js
+++ b/src/fontra/client/core/var-glyph.js
@@ -9,12 +9,7 @@ export class VariableGlyph {
         return { ...axis };
       }) || [];
     glyph.sources = obj.sources.map((source) => Source.fromObject(source));
-    glyph.layers = obj.layers.map((layer) => {
-      return {
-        name: layer.name,
-        glyph: StaticGlyph.fromObject(layer.glyph),
-      };
-    });
+    glyph.layers = obj.layers.map((layer) => Layer.fromObject(layer));
     return glyph;
   }
 
@@ -38,6 +33,15 @@ export class VariableGlyph {
         return layerIndex;
       }
     }
+  }
+}
+
+export class Layer {
+  static fromObject(obj) {
+    const layer = new Layer();
+    layer.name = obj.name;
+    layer.glyph = StaticGlyph.fromObject(obj.glyph);
+    return layer;
   }
 }
 

--- a/src/fontra/core/classes.py
+++ b/src/fontra/core/classes.py
@@ -166,10 +166,12 @@ classSchema = makeSchema(Font)
 classCastFuncs = makeCastFuncs(classSchema, config=_castConfig)
 
 
-if __name__ == "__main__":
+def printSchemaAsJSON():
     import json
 
     schema = classesToStrings(classSchema)
-    print("// This file is generated, don't edit!")
-    schemaJSON = json.dumps(schema, indent=2)
-    print(f"export const classSchema = {schemaJSON};")
+    print(json.dumps(schema, indent=2))
+
+
+if __name__ == "__main__":
+    printSchemaAsJSON()

--- a/src/fontra/core/server.py
+++ b/src/fontra/core/server.py
@@ -31,7 +31,7 @@ class FontraServer:
     versionToken: Optional[str] = None
     cookieMaxAge: int = 7 * 24 * 60 * 60
     allowedFileExtensions: frozenset[str] = frozenset(
-        ["css", "html", "ico", "js", "svg", "woff2"]
+        ["css", "html", "ico", "js", "json", "svg", "woff2"]
     )
 
     def setup(self):

--- a/test-js/test-classes.js
+++ b/test-js/test-classes.js
@@ -74,6 +74,12 @@ describe("schema tests", () => {
       outValue: VariableGlyph.fromObject({ name: "A", sources: [], layers: [] }),
     },
     {
+      rootClass: "Font",
+      path: ["glyphs"],
+      inValue: { A: { name: "A", sources: [], layers: [] } },
+      outValue: { A: VariableGlyph.fromObject({ name: "A", sources: [], layers: [] }) },
+    },
+    {
       rootClass: "StaticGlyph",
       path: [],
       inValue: { xAdvance: 500 },

--- a/test-js/test-classes.js
+++ b/test-js/test-classes.js
@@ -1,9 +1,15 @@
 import chai from "chai";
 const expect = chai.expect;
 
-import { enumerate } from "../src/fontra/client/core/utils.js";
+import { enumerate, range } from "../src/fontra/client/core/utils.js";
 import classesSchema from "../src/fontra/client/core/classes.json" assert { type: "json" };
 import { getClassSchema } from "../src/fontra/client/core/classes.js";
+import {
+  Layer,
+  StaticGlyph,
+  VariableGlyph,
+} from "../src/fontra/client/core/var-glyph.js";
+import { VarPackedPath } from "../src/fontra/client/core/var-path.js";
 
 describe("schema tests", () => {
   const testPaths = [
@@ -54,6 +60,67 @@ describe("schema tests", () => {
           expect(() => {
             subjectType.getSubType(pathElement);
           }).to.throw("Unknown subType nonExistingProperty of Font");
+        }
+      }
+    });
+  }
+
+  const castTestCases = [
+    { rootClass: "Font", path: ["unitsPerEm"], inValue: 123, outValue: 123 },
+    {
+      rootClass: "Font",
+      path: ["glyphs", "A"],
+      inValue: { name: "A", sources: [], layers: [] },
+      outValue: VariableGlyph.fromObject({ name: "A", sources: [], layers: [] }),
+    },
+    {
+      rootClass: "StaticGlyph",
+      path: [],
+      inValue: { xAdvance: 500 },
+      outValue: StaticGlyph.fromObject({
+        xAdvance: 500,
+        path: { coordinates: [], pointTypes: [], contourInfo: [] },
+      }),
+    },
+    {
+      rootClass: "StaticGlyph",
+      path: ["path"],
+      inValue: {
+        coordinates: [],
+        pointTypes: [],
+        contourInfo: [],
+      },
+      outValue: VarPackedPath.fromObject({
+        coordinates: [],
+        pointTypes: [],
+        contourInfo: [],
+      }),
+    },
+    {
+      rootClass: "VariableGlyph",
+      path: ["layers"],
+      inValue: [{ name: "default", glyph: {} }],
+      outValue: [Layer.fromObject({ name: "default", glyph: {} })],
+    },
+  ];
+
+  for (const [testIndex, testCase] of enumerate(castTestCases)) {
+    it(`cast test ${testIndex}`, async () => {
+      const schema = await getClassSchema(classesSchema);
+      let subjectType = schema[testCase.rootClass]; // Root
+      for (const pathElement of testCase.path) {
+        subjectType = subjectType.getSubType(pathElement);
+      }
+      const castValue = subjectType.cast(testCase.inValue);
+      expect(castValue.constructor).to.equal(testCase.outValue.constructor);
+      expect(castValue).to.deep.equal(testCase.outValue);
+      if (Array.isArray(testCase.outValue)) {
+        expect(testCase.outValue.length).to.equal(castValue.length);
+        for (const i of range(castValue.length)) {
+          const castItem = castValue[i];
+          const outItem = testCase.outValue[i];
+          expect(castItem.constructor).to.equal(outItem.constructor);
+          expect(castItem).to.deep.equal(outItem);
         }
       }
     });

--- a/test-js/test-classes.js
+++ b/test-js/test-classes.js
@@ -1,0 +1,59 @@
+import chai from "chai";
+const expect = chai.expect;
+
+import { enumerate } from "../src/fontra/client/core/utils.js";
+import classesSchema from "../src/fontra/client/core/classes.json" assert { type: "json" };
+import { getClassSchema } from "../src/fontra/client/core/classes.js";
+
+describe("schema tests", () => {
+  const testPaths = [
+    [
+      ["glyphs", "dict<VariableGlyph>"],
+      ["<anything>", "VariableGlyph"],
+      ["sources", "list<Source>"],
+      [999, "Source"],
+      ["location", "dict<float>"],
+      ["<anything>", "float"],
+    ],
+    [
+      ["glyphs", "dict<VariableGlyph>"],
+      ["<anything>", "VariableGlyph"],
+      ["layers", "list<Layer>"],
+      [999, "Layer"],
+      ["glyph", "StaticGlyph"],
+      ["path", "PackedPath"],
+      ["pointTypes", "list<PointType>"],
+      [999, "PointType"],
+    ],
+    [
+      ["glyphs", "dict<VariableGlyph>"],
+      ["<anything>", "VariableGlyph"],
+      ["layers", "list<Layer>"],
+      [999, "Layer"],
+      ["glyph", "StaticGlyph"],
+      ["components", "list<Component>"],
+      [999, "Component"],
+      ["location", "dict<float>"],
+      ["<anything>", "float"],
+    ],
+    [["nonExistingProperty", null]],
+  ];
+
+  for (const [testIndex, testPath] of enumerate(testPaths)) {
+    it(`test path ${testIndex}`, async () => {
+      const schema = await getClassSchema(classesSchema);
+      let subjectType = schema["Font"]; // Root
+      expect(subjectType.className).to.equal("Font");
+      for (const [pathElement, expectedName] of testPath) {
+        if (expectedName) {
+          subjectType = subjectType.getSubType(pathElement);
+          expect(subjectType.className).to.equal(expectedName);
+        } else {
+          expect(() => {
+            subjectType.getSubType(pathElement);
+          }).to.throw("Unknown subType nonExistingProperty of Font");
+        }
+      }
+    });
+  }
+});

--- a/test-js/test-classes.js
+++ b/test-js/test-classes.js
@@ -45,10 +45,11 @@ describe("schema tests", () => {
       const schema = await getClassSchema(classesSchema);
       let subjectType = schema["Font"]; // Root
       expect(subjectType.className).to.equal("Font");
+      expect(subjectType.compositeName).to.equal("Font");
       for (const [pathElement, expectedName] of testPath) {
         if (expectedName) {
           subjectType = subjectType.getSubType(pathElement);
-          expect(subjectType.className).to.equal(expectedName);
+          expect(subjectType.compositeName).to.equal(expectedName);
         } else {
           expect(() => {
             subjectType.getSubType(pathElement);

--- a/test-js/test-classes.js
+++ b/test-js/test-classes.js
@@ -7,6 +7,7 @@ import { getClassSchema } from "../src/fontra/client/core/classes.js";
 
 describe("schema tests", () => {
   const testPaths = [
+    [["unitsPerEm", "int"]],
     [
       ["glyphs", "dict<VariableGlyph>"],
       ["<anything>", "VariableGlyph"],

--- a/test-js/test-classes.js
+++ b/test-js/test-classes.js
@@ -76,8 +76,10 @@ describe("schema tests", () => {
     {
       rootClass: "Font",
       path: ["glyphs"],
-      inValue: { A: { name: "A", sources: [], layers: [] } },
-      outValue: { A: VariableGlyph.fromObject({ name: "A", sources: [], layers: [] }) },
+      inValue: { A: { name: "A", axes: [], sources: [], layers: [] } },
+      outValue: {
+        A: VariableGlyph.fromObject({ name: "A", axes: [], sources: [], layers: [] }),
+      },
     },
     {
       rootClass: "StaticGlyph",
@@ -125,6 +127,12 @@ describe("schema tests", () => {
         for (const i of range(castValue.length)) {
           const castItem = castValue[i];
           const outItem = testCase.outValue[i];
+          expect(castItem.constructor).to.equal(outItem.constructor);
+          expect(castItem).to.deep.equal(outItem);
+        }
+      } else if (testCase.outValue.constructor === Object) {
+        for (const [k, outItem] of Object.entries(testCase.outValue)) {
+          const castItem = castValue[k];
           expect(castItem.constructor).to.equal(outItem.constructor);
           expect(castItem).to.deep.equal(outItem);
         }


### PR DESCRIPTION
This was long coming, but only became necessary since new sources and layers can be created.

On the Python side, this has been in place for a while, via dataclasses, but this PR implements it for the JS client.

- Add classes.json, exported from classes.py
- Use the class schema to cast incoming raw objects to the appropriate types
