### PR TITLE
Add customData to VarGlyph, Source and Layer

### DIFF
--- a/src/fontra/client/core/classes.json
+++ b/src/fontra/client/core/classes.json
@@ -62,7 +62,7 @@
       "type": "dict",
       "subtype": "float"
     },
-    "active": {
+    "inactive": {
       "type": "bool"
     },
     "customData": {

--- a/src/fontra/client/core/classes.json
+++ b/src/fontra/client/core/classes.json
@@ -31,6 +31,10 @@
     "layers": {
       "type": "dict",
       "subtype": "Layer"
+    },
+    "customData": {
+      "type": "dict",
+      "subtype": "Any"
     }
   },
   "LocalAxis": {
@@ -57,11 +61,22 @@
     "location": {
       "type": "dict",
       "subtype": "float"
+    },
+    "active": {
+      "type": "bool"
+    },
+    "customData": {
+      "type": "dict",
+      "subtype": "Any"
     }
   },
   "Layer": {
     "glyph": {
       "type": "StaticGlyph"
+    },
+    "customData": {
+      "type": "dict",
+      "subtype": "Any"
     }
   },
   "StaticGlyph": {

--- a/src/fontra/client/core/glyph-controller.js
+++ b/src/fontra/client/core/glyph-controller.js
@@ -97,7 +97,7 @@ export class VariableGlyphController {
     location = this.mapLocationGlobalToLocal(location);
     for (let i = 0; i < this.sources.length; i++) {
       const source = this.sources[i];
-      if (!source.active) {
+      if (source.inactive) {
         continue;
       }
       const seen = new Set();
@@ -164,7 +164,7 @@ export class VariableGlyphController {
   get model() {
     if (this._model === undefined) {
       const locations = this.sources
-        .filter((source) => source.active)
+        .filter((source) => !source.inactive)
         .map((source) => source.location);
       this._model = new VariationModel(
         locations.map((location) =>
@@ -178,7 +178,7 @@ export class VariableGlyphController {
   get deltas() {
     if (this._deltas === undefined) {
       const masterValues = this.sources
-        .filter((source) => source.active)
+        .filter((source) => !source.inactive)
         .map((source) => this.layers[source.layerName].glyph);
       this._deltas = this.model.getDeltas(masterValues);
     }

--- a/src/fontra/client/core/glyph-controller.js
+++ b/src/fontra/client/core/glyph-controller.js
@@ -97,6 +97,9 @@ export class VariableGlyphController {
     location = this.mapLocationGlobalToLocal(location);
     for (let i = 0; i < this.sources.length; i++) {
       const source = this.sources[i];
+      if (!source.active) {
+        continue;
+      }
       const seen = new Set();
       let found = true;
       for (const axis of this.axes.concat(this.globalAxes)) {
@@ -160,7 +163,9 @@ export class VariableGlyphController {
 
   get model() {
     if (this._model === undefined) {
-      const locations = this.sources.map((source) => source.location);
+      const locations = this.sources
+        .filter((source) => source.active)
+        .map((source) => source.location);
       this._model = new VariationModel(
         locations.map((location) =>
           sparsifyLocation(normalizeLocation(location, this.combinedAxes))
@@ -172,9 +177,9 @@ export class VariableGlyphController {
 
   get deltas() {
     if (this._deltas === undefined) {
-      const masterValues = this.sources.map(
-        (source) => this.layers[source.layerName].glyph
-      );
+      const masterValues = this.sources
+        .filter((source) => source.active)
+        .map((source) => this.layers[source.layerName].glyph);
       this._deltas = this.model.getDeltas(masterValues);
     }
     return this._deltas;

--- a/src/fontra/client/core/var-glyph.js
+++ b/src/fontra/client/core/var-glyph.js
@@ -36,7 +36,7 @@ class Source {
     source.name = obj.name;
     source.location = { ...obj.location } || {};
     source.layerName = obj.layerName;
-    source.active = obj.active === undefined ? true : !!obj.active;
+    source.inactive = !!obj.inactive;
     source.customData = copyCustomData(obj.customData || {});
     return source;
   }

--- a/src/fontra/client/core/var-glyph.js
+++ b/src/fontra/client/core/var-glyph.js
@@ -12,6 +12,7 @@ export class VariableGlyph {
     glyph.layers = Object.fromEntries(
       Object.entries(obj.layers).map(([name, layer]) => [name, Layer.fromObject(layer)])
     );
+    glyph.customData = copyCustomData(obj.customData || {});
     return glyph;
   }
 
@@ -24,6 +25,7 @@ export class Layer {
   static fromObject(obj) {
     const layer = new Layer();
     layer.glyph = StaticGlyph.fromObject(obj.glyph);
+    layer.customData = copyCustomData(obj.customData || {});
     return layer;
   }
 }
@@ -34,6 +36,8 @@ class Source {
     source.name = obj.name;
     source.location = { ...obj.location } || {};
     source.layerName = obj.layerName;
+    source.active = obj.active === undefined ? true : !!obj.active;
+    source.customData = copyCustomData(obj.customData || {});
     return source;
   }
 }
@@ -64,4 +68,8 @@ function copyComponent(component) {
     transformation: { ...component.transformation },
     location: { ...component.location },
   };
+}
+
+function copyCustomData(data) {
+  return JSON.parse(JSON.stringify(data));
 }

--- a/src/fontra/core/classes.py
+++ b/src/fontra/core/classes.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import sys
 from dataclasses import dataclass, field, is_dataclass
 from functools import partial
-from typing import Optional, get_args, get_type_hints
+from typing import Any, Optional, get_args, get_type_hints
 
 import dacite
 
@@ -24,6 +24,7 @@ class Transformation:
 
 
 Location = dict[str, float]
+CustomData = dict[str, Any]
 
 
 @dataclass
@@ -47,11 +48,14 @@ class Source:
     name: str
     layerName: str
     location: Location = field(default_factory=Location)
+    active: bool = True
+    customData: CustomData = field(default_factory=CustomData)
 
 
 @dataclass
 class Layer:
     glyph: StaticGlyph
+    customData: CustomData = field(default_factory=CustomData)
 
 
 @dataclass
@@ -68,6 +72,7 @@ class VariableGlyph:
     axes: list[LocalAxis] = field(default_factory=list)
     sources: list[Source] = field(default_factory=list)
     layers: dict[str, Layer] = field(default_factory=dict)
+    customData: CustomData = field(default_factory=CustomData)
 
 
 @dataclass

--- a/src/fontra/core/classes.py
+++ b/src/fontra/core/classes.py
@@ -170,10 +170,14 @@ classSchema = makeSchema(Font)
 classCastFuncs = makeCastFuncs(classSchema, config=_castConfig)
 
 
+def serializableClassSchema():
+    return classesToStrings(classSchema)
+
+
 def printSchemaAsJSON():
     import json
 
-    schema = classesToStrings(classSchema)
+    schema = serializableClassSchema()
     print(json.dumps(schema, indent=2))
 
 

--- a/src/fontra/core/classes.py
+++ b/src/fontra/core/classes.py
@@ -48,7 +48,7 @@ class Source:
     name: str
     layerName: str
     location: Location = field(default_factory=Location)
-    active: bool = True
+    inactive: bool = False
     customData: CustomData = field(default_factory=CustomData)
 
 

--- a/test-js/test-var-glyph.js
+++ b/test-js/test-var-glyph.js
@@ -14,7 +14,7 @@ function makeTestGlyphObject() {
         layerName: "default",
         location: {},
         customData: {},
-        active: true,
+        inactive: false,
       },
     ],
     layers: {

--- a/test-js/test-var-glyph.js
+++ b/test-js/test-var-glyph.js
@@ -8,7 +8,15 @@ function makeTestGlyphObject() {
   return {
     name: "a",
     axes: [],
-    sources: [{ name: "default", layerName: "default", location: {} }],
+    sources: [
+      {
+        name: "default",
+        layerName: "default",
+        location: {},
+        customData: {},
+        active: true,
+      },
+    ],
     layers: {
       default: {
         glyph: {
@@ -20,8 +28,10 @@ function makeTestGlyphObject() {
             { name: "test", location: { a: 0.5 }, transformation: { translateX: 0 } },
           ],
         },
+        customData: {},
       },
     },
+    customData: {},
   };
 }
 

--- a/test-py/test_classes.py
+++ b/test-py/test_classes.py
@@ -1,0 +1,14 @@
+import json
+import pathlib
+
+from fontra.core.classes import serializableClassSchema
+
+repoRoot = pathlib.Path(__file__).resolve().parent.parent
+jsonPath = repoRoot / "src" / "fontra" / "client" / "core" / "classes.json"
+
+
+def test_classes_json():
+    with open(jsonPath) as f:
+        classesFromJSON = json.load(f)
+
+    assert serializableClassSchema() == classesFromJSON, "classes.json is stale"

--- a/test-py/test_font.py
+++ b/test-py/test_font.py
@@ -19,6 +19,8 @@ getGlyphTestData = [
                     "location": {},
                     "layerName": "default/foreground",
                     "name": "default",
+                    "active": True,
+                    "customData": {},
                 }
             ],
             "layers": {
@@ -34,6 +36,7 @@ getGlyphTestData = [
                         },
                         "components": [],
                     },
+                    "customData": {},
                 },
                 "default/background": {
                     "glyph": {
@@ -47,8 +50,10 @@ getGlyphTestData = [
                         },
                         "components": [],
                     },
+                    "customData": {},
                 },
             },
+            "customData": {},
         },
     ),
     (
@@ -61,6 +66,8 @@ getGlyphTestData = [
                     "location": {},
                     "layerName": "default/foreground",
                     "name": "default",
+                    "active": True,
+                    "customData": {},
                 }
             ],
             "layers": {
@@ -107,8 +114,10 @@ getGlyphTestData = [
                         "yAdvance": None,
                         "verticalOrigin": None,
                     },
+                    "customData": {},
                 },
             },
+            "customData": {},
         },
     ),
     (
@@ -121,21 +130,29 @@ getGlyphTestData = [
                     "name": "LightCondensed",
                     "location": {"weight": 150.0, "width": 0.0},
                     "layerName": "LightCondensed/foreground",
+                    "active": True,
+                    "customData": {},
                 },
                 {
                     "name": "BoldCondensed",
                     "location": {"weight": 850.0, "width": 0.0},
                     "layerName": "BoldCondensed/foreground",
+                    "active": True,
+                    "customData": {},
                 },
                 {
                     "name": "LightWide",
                     "location": {"weight": 150.0, "width": 1000.0},
                     "layerName": "LightWide/foreground",
+                    "active": True,
+                    "customData": {},
                 },
                 {
                     "name": "BoldWide",
                     "location": {"weight": 850.0, "width": 1000.0},
                     "layerName": "BoldWide/foreground",
+                    "active": True,
+                    "customData": {},
                 },
             ],
             "layers": {
@@ -151,6 +168,7 @@ getGlyphTestData = [
                         },
                         "components": [],
                     },
+                    "customData": {},
                 },
                 "LightCondensed/background": {
                     "glyph": {
@@ -164,6 +182,7 @@ getGlyphTestData = [
                         },
                         "components": [],
                     },
+                    "customData": {},
                 },
                 "BoldCondensed/foreground": {
                     "glyph": {
@@ -177,6 +196,7 @@ getGlyphTestData = [
                         },
                         "components": [],
                     },
+                    "customData": {},
                 },
                 "LightWide/foreground": {
                     "glyph": {
@@ -190,6 +210,7 @@ getGlyphTestData = [
                         },
                         "components": [],
                     },
+                    "customData": {},
                 },
                 "BoldWide/foreground": {
                     "glyph": {
@@ -203,8 +224,10 @@ getGlyphTestData = [
                         },
                         "components": [],
                     },
+                    "customData": {},
                 },
             },
+            "customData": {},
         },
     ),
     (
@@ -217,21 +240,29 @@ getGlyphTestData = [
                     "name": "LightCondensed",
                     "location": {"weight": 150.0, "width": 0.0},
                     "layerName": "LightCondensed/foreground",
+                    "active": True,
+                    "customData": {},
                 },
                 {
                     "name": "BoldCondensed",
                     "location": {"weight": 850.0, "width": 0.0},
                     "layerName": "BoldCondensed/foreground",
+                    "active": True,
+                    "customData": {},
                 },
                 {
                     "name": "LightWide",
                     "location": {"weight": 150.0, "width": 1000.0},
                     "layerName": "LightWide/foreground",
+                    "active": True,
+                    "customData": {},
                 },
                 {
                     "name": "BoldWide",
                     "location": {"weight": 850.0, "width": 1000.0},
                     "layerName": "BoldWide/foreground",
+                    "active": True,
+                    "customData": {},
                 },
             ],
             "layers": {
@@ -278,6 +309,7 @@ getGlyphTestData = [
                         "yAdvance": None,
                         "verticalOrigin": None,
                     },
+                    "customData": {},
                 },
                 "BoldCondensed/foreground": {
                     "glyph": {
@@ -322,6 +354,7 @@ getGlyphTestData = [
                         "yAdvance": None,
                         "verticalOrigin": None,
                     },
+                    "customData": {},
                 },
                 "LightWide/foreground": {
                     "glyph": {
@@ -366,6 +399,7 @@ getGlyphTestData = [
                         "yAdvance": None,
                         "verticalOrigin": None,
                     },
+                    "customData": {},
                 },
                 "BoldWide/foreground": {
                     "glyph": {
@@ -410,8 +444,10 @@ getGlyphTestData = [
                         "yAdvance": None,
                         "verticalOrigin": None,
                     },
+                    "customData": {},
                 },
             },
+            "customData": {},
         },
     ),
     (
@@ -424,6 +460,8 @@ getGlyphTestData = [
                     "name": "LightCondensed",
                     "location": {"weight": 150.0, "width": 0.0},
                     "layerName": "LightCondensed/foreground",
+                    "active": True,
+                    "customData": {},
                 },
             ],
             "layers": {
@@ -485,8 +523,10 @@ getGlyphTestData = [
                         "yAdvance": None,
                         "verticalOrigin": None,
                     },
+                    "customData": {},
                 },
             },
+            "customData": {},
         },
     ),
     (
@@ -502,16 +542,22 @@ getGlyphTestData = [
                     "layerName": "LightCondensed/foreground",
                     "location": {"flip": 0, "flop": 0},
                     "name": "LightCondensed/foreground",
+                    "active": True,
+                    "customData": {},
                 },
                 {
                     "layerName": "LightCondensed/varco_flip",
                     "location": {"flip": 100, "flop": 0},
                     "name": "LightCondensed/varco_flip",
+                    "active": True,
+                    "customData": {},
                 },
                 {
                     "layerName": "LightCondensed/varco_flop",
                     "location": {"flip": 0, "flop": 100},
                     "name": "LightCondensed/varco_flop",
+                    "active": True,
+                    "customData": {},
                 },
             ],
             "layers": {
@@ -544,6 +590,7 @@ getGlyphTestData = [
                         "xAdvance": 500,
                         "yAdvance": None,
                     },
+                    "customData": {},
                 },
                 "LightCondensed/varco_flip": {
                     "glyph": {
@@ -574,6 +621,7 @@ getGlyphTestData = [
                         "xAdvance": 500,
                         "yAdvance": None,
                     },
+                    "customData": {},
                 },
                 "LightCondensed/varco_flop": {
                     "glyph": {
@@ -604,8 +652,10 @@ getGlyphTestData = [
                         "xAdvance": 500,
                         "yAdvance": None,
                     },
+                    "customData": {},
                 },
             },
+            "customData": {},
         },
     ),
     (
@@ -626,6 +676,7 @@ getGlyphTestData = [
                         "yAdvance": None,
                         "verticalOrigin": None,
                     },
+                    "customData": {},
                 },
                 "wdth=1": {
                     "glyph": {
@@ -639,6 +690,7 @@ getGlyphTestData = [
                         "yAdvance": None,
                         "verticalOrigin": None,
                     },
+                    "customData": {},
                 },
                 "wdth=1,wght=1": {
                     "glyph": {
@@ -652,6 +704,7 @@ getGlyphTestData = [
                         "yAdvance": None,
                         "verticalOrigin": None,
                     },
+                    "customData": {},
                 },
                 "wght=1": {
                     "glyph": {
@@ -665,6 +718,7 @@ getGlyphTestData = [
                         "yAdvance": None,
                         "verticalOrigin": None,
                     },
+                    "customData": {},
                 },
             },
             "sources": [
@@ -672,23 +726,32 @@ getGlyphTestData = [
                     "layerName": "<default>",
                     "location": {"wdth": 0, "wght": 0},
                     "name": "<default>",
+                    "active": True,
+                    "customData": {},
                 },
                 {
                     "layerName": "wdth=1",
                     "location": {"wdth": 1.0, "wght": 0},
                     "name": "wdth=1",
+                    "active": True,
+                    "customData": {},
                 },
                 {
                     "layerName": "wdth=1,wght=1",
                     "location": {"wdth": 1.0, "wght": 1.0},
                     "name": "wdth=1,wght=1",
+                    "active": True,
+                    "customData": {},
                 },
                 {
                     "layerName": "wght=1",
                     "location": {"wdth": 0, "wght": 1.0},
                     "name": "wght=1",
+                    "active": True,
+                    "customData": {},
                 },
             ],
+            "customData": {},
         },
     ),
     (
@@ -709,6 +772,7 @@ getGlyphTestData = [
                         "yAdvance": None,
                         "verticalOrigin": None,
                     },
+                    "customData": {},
                 },
                 "wdth=1": {
                     "glyph": {
@@ -731,6 +795,7 @@ getGlyphTestData = [
                         "yAdvance": None,
                         "verticalOrigin": None,
                     },
+                    "customData": {},
                 },
                 "wdth=1,wght=1": {
                     "glyph": {
@@ -753,6 +818,7 @@ getGlyphTestData = [
                         "yAdvance": None,
                         "verticalOrigin": None,
                     },
+                    "customData": {},
                 },
                 "wght=1": {
                     "glyph": {
@@ -775,6 +841,7 @@ getGlyphTestData = [
                         "yAdvance": None,
                         "verticalOrigin": None,
                     },
+                    "customData": {},
                 },
             },
             "sources": [
@@ -782,23 +849,32 @@ getGlyphTestData = [
                     "location": {"wdth": 0, "wght": 0},
                     "name": "<default>",
                     "layerName": "<default>",
+                    "active": True,
+                    "customData": {},
                 },
                 {
                     "location": {"wdth": 1.0, "wght": 0},
                     "name": "wdth=1",
                     "layerName": "wdth=1",
+                    "active": True,
+                    "customData": {},
                 },
                 {
                     "location": {"wdth": 1.0, "wght": 1.0},
                     "name": "wdth=1,wght=1",
                     "layerName": "wdth=1,wght=1",
+                    "active": True,
+                    "customData": {},
                 },
                 {
                     "location": {"wdth": 0, "wght": 1.0},
                     "name": "wght=1",
                     "layerName": "wght=1",
+                    "active": True,
+                    "customData": {},
                 },
             ],
+            "customData": {},
         },
     ),
 ]

--- a/test-py/test_font.py
+++ b/test-py/test_font.py
@@ -49,24 +49,16 @@ getGlyphTestData = [
         "ufo",
         {
             "name": "Aacute",
-            "axes": [],
             "sources": [
                 {
                     "location": {},
                     "layerName": "default/foreground",
                     "name": "default",
-                    "active": True,
-                    "customData": {},
                 }
             ],
             "layers": {
                 "default/foreground": {
                     "glyph": {
-                        "path": {
-                            "contourInfo": [],
-                            "coordinates": [],
-                            "pointTypes": [],
-                        },
                         "components": [
                             {
                                 "name": "A",
@@ -100,168 +92,120 @@ getGlyphTestData = [
                             },
                         ],
                         "xAdvance": 396,
-                        "yAdvance": None,
-                        "verticalOrigin": None,
                     },
-                    "customData": {},
                 },
             },
-            "customData": {},
         },
     ),
     (
         "designspace",
         {
             "name": "period",
-            "axes": [],
             "sources": [
                 {
                     "name": "LightCondensed",
                     "location": {"weight": 150.0, "width": 0.0},
                     "layerName": "LightCondensed/foreground",
-                    "active": True,
-                    "customData": {},
                 },
                 {
                     "name": "BoldCondensed",
                     "location": {"weight": 850.0, "width": 0.0},
                     "layerName": "BoldCondensed/foreground",
-                    "active": True,
-                    "customData": {},
                 },
                 {
                     "name": "LightWide",
                     "location": {"weight": 150.0, "width": 1000.0},
                     "layerName": "LightWide/foreground",
-                    "active": True,
-                    "customData": {},
                 },
                 {
                     "name": "BoldWide",
                     "location": {"weight": 850.0, "width": 1000.0},
                     "layerName": "BoldWide/foreground",
-                    "active": True,
-                    "customData": {},
                 },
             ],
             "layers": {
                 "LightCondensed/foreground": {
                     "glyph": {
                         "xAdvance": 170,
-                        "yAdvance": None,
-                        "verticalOrigin": None,
                         "path": {
                             "contourInfo": [{"endPoint": 3, "isClosed": True}],
                             "coordinates": [60, 0, 110, 0, 110, 120, 60, 120],
                             "pointTypes": [0, 0, 0, 0],
                         },
-                        "components": [],
                     },
-                    "customData": {},
                 },
                 "LightCondensed/background": {
                     "glyph": {
                         "xAdvance": 170,
-                        "yAdvance": None,
-                        "verticalOrigin": None,
                         "path": {
                             "contourInfo": [{"endPoint": 3, "isClosed": True}],
                             "coordinates": [62, 0, 112, 0, 112, 120, 62, 120],
                             "pointTypes": [0, 0, 0, 0],
                         },
-                        "components": [],
                     },
-                    "customData": {},
                 },
                 "BoldCondensed/foreground": {
                     "glyph": {
                         "xAdvance": 250,
-                        "yAdvance": None,
-                        "verticalOrigin": None,
                         "path": {
                             "contourInfo": [{"endPoint": 3, "isClosed": True}],
                             "coordinates": [30, 0, 220, 0, 220, 300, 30, 300],
                             "pointTypes": [0, 0, 0, 0],
                         },
-                        "components": [],
                     },
-                    "customData": {},
                 },
                 "LightWide/foreground": {
                     "glyph": {
                         "xAdvance": 290,
-                        "yAdvance": None,
-                        "verticalOrigin": None,
                         "path": {
                             "contourInfo": [{"endPoint": 3, "isClosed": True}],
                             "coordinates": [120, 0, 170, 0, 170, 220, 120, 220],
                             "pointTypes": [0, 0, 0, 0],
                         },
-                        "components": [],
                     },
-                    "customData": {},
                 },
                 "BoldWide/foreground": {
                     "glyph": {
                         "xAdvance": 310,
-                        "yAdvance": None,
-                        "verticalOrigin": None,
                         "path": {
                             "contourInfo": [{"endPoint": 3, "isClosed": True}],
                             "coordinates": [60, 0, 250, 0, 250, 300, 60, 300],
                             "pointTypes": [0, 0, 0, 0],
                         },
-                        "components": [],
                     },
-                    "customData": {},
                 },
             },
-            "customData": {},
         },
     ),
     (
         "designspace",
         {
             "name": "Aacute",
-            "axes": [],
             "sources": [
                 {
                     "name": "LightCondensed",
                     "location": {"weight": 150.0, "width": 0.0},
                     "layerName": "LightCondensed/foreground",
-                    "active": True,
-                    "customData": {},
                 },
                 {
                     "name": "BoldCondensed",
                     "location": {"weight": 850.0, "width": 0.0},
                     "layerName": "BoldCondensed/foreground",
-                    "active": True,
-                    "customData": {},
                 },
                 {
                     "name": "LightWide",
                     "location": {"weight": 150.0, "width": 1000.0},
                     "layerName": "LightWide/foreground",
-                    "active": True,
-                    "customData": {},
                 },
                 {
                     "name": "BoldWide",
                     "location": {"weight": 850.0, "width": 1000.0},
                     "layerName": "BoldWide/foreground",
-                    "active": True,
-                    "customData": {},
                 },
             ],
             "layers": {
                 "LightCondensed/foreground": {
                     "glyph": {
-                        "path": {
-                            "contourInfo": [],
-                            "coordinates": [],
-                            "pointTypes": [],
-                        },
                         "components": [
                             {
                                 "name": "A",
@@ -295,18 +239,10 @@ getGlyphTestData = [
                             },
                         ],
                         "xAdvance": 396,
-                        "yAdvance": None,
-                        "verticalOrigin": None,
                     },
-                    "customData": {},
                 },
                 "BoldCondensed/foreground": {
                     "glyph": {
-                        "path": {
-                            "contourInfo": [],
-                            "coordinates": [],
-                            "pointTypes": [],
-                        },
                         "components": [
                             {
                                 "name": "A",
@@ -340,18 +276,10 @@ getGlyphTestData = [
                             },
                         ],
                         "xAdvance": 740,
-                        "yAdvance": None,
-                        "verticalOrigin": None,
                     },
-                    "customData": {},
                 },
                 "LightWide/foreground": {
                     "glyph": {
-                        "path": {
-                            "contourInfo": [],
-                            "coordinates": [],
-                            "pointTypes": [],
-                        },
                         "components": [
                             {
                                 "name": "A",
@@ -385,18 +313,10 @@ getGlyphTestData = [
                             },
                         ],
                         "xAdvance": 1190,
-                        "yAdvance": None,
-                        "verticalOrigin": None,
                     },
-                    "customData": {},
                 },
                 "BoldWide/foreground": {
                     "glyph": {
-                        "path": {
-                            "contourInfo": [],
-                            "coordinates": [],
-                            "pointTypes": [],
-                        },
                         "components": [
                             {
                                 "name": "A",
@@ -430,37 +350,25 @@ getGlyphTestData = [
                             },
                         ],
                         "xAdvance": 1290,
-                        "yAdvance": None,
-                        "verticalOrigin": None,
                     },
-                    "customData": {},
                 },
             },
-            "customData": {},
         },
     ),
     (
         "designspace",
         {
             "name": "varcotest1",
-            "axes": [],
             "sources": [
                 {
                     "name": "LightCondensed",
                     "location": {"weight": 150.0, "width": 0.0},
                     "layerName": "LightCondensed/foreground",
-                    "active": True,
-                    "customData": {},
                 },
             ],
             "layers": {
                 "LightCondensed/foreground": {
                     "glyph": {
-                        "path": {
-                            "contourInfo": [],
-                            "coordinates": [],
-                            "pointTypes": [],
-                        },
                         "components": [
                             {
                                 "name": "A",
@@ -509,13 +417,9 @@ getGlyphTestData = [
                             },
                         ],
                         "xAdvance": 900,
-                        "yAdvance": None,
-                        "verticalOrigin": None,
                     },
-                    "customData": {},
                 },
             },
-            "customData": {},
         },
     ),
     (
@@ -531,28 +435,21 @@ getGlyphTestData = [
                     "layerName": "LightCondensed/foreground",
                     "location": {"flip": 0, "flop": 0},
                     "name": "LightCondensed/foreground",
-                    "active": True,
-                    "customData": {},
                 },
                 {
                     "layerName": "LightCondensed/varco_flip",
                     "location": {"flip": 100, "flop": 0},
                     "name": "LightCondensed/varco_flip",
-                    "active": True,
-                    "customData": {},
                 },
                 {
                     "layerName": "LightCondensed/varco_flop",
                     "location": {"flip": 0, "flop": 100},
                     "name": "LightCondensed/varco_flop",
-                    "active": True,
-                    "customData": {},
                 },
             ],
             "layers": {
                 "LightCondensed/foreground": {
                     "glyph": {
-                        "components": [],
                         "path": {
                             "contourInfo": [{"endPoint": 7, "isClosed": True}],
                             "coordinates": [
@@ -575,15 +472,11 @@ getGlyphTestData = [
                             ],
                             "pointTypes": [0, 0, 0, 0, 0, 0, 0, 0],
                         },
-                        "verticalOrigin": None,
                         "xAdvance": 500,
-                        "yAdvance": None,
                     },
-                    "customData": {},
                 },
                 "LightCondensed/varco_flip": {
                     "glyph": {
-                        "components": [],
                         "path": {
                             "contourInfo": [{"endPoint": 7, "isClosed": True}],
                             "coordinates": [
@@ -606,15 +499,11 @@ getGlyphTestData = [
                             ],
                             "pointTypes": [0, 0, 0, 0, 0, 0, 0, 0],
                         },
-                        "verticalOrigin": None,
                         "xAdvance": 500,
-                        "yAdvance": None,
                     },
-                    "customData": {},
                 },
                 "LightCondensed/varco_flop": {
                     "glyph": {
-                        "components": [],
                         "path": {
                             "contourInfo": [{"endPoint": 7, "isClosed": True}],
                             "coordinates": [
@@ -637,21 +526,16 @@ getGlyphTestData = [
                             ],
                             "pointTypes": [0, 0, 0, 0, 0, 0, 0, 0],
                         },
-                        "verticalOrigin": None,
                         "xAdvance": 500,
-                        "yAdvance": None,
                     },
-                    "customData": {},
                 },
             },
-            "customData": {},
         },
     ),
     (
         "ttf",
         {
             "name": "period",
-            "axes": [],
             "layers": {
                 "<default>": {
                     "glyph": {
@@ -660,12 +544,8 @@ getGlyphTestData = [
                             "coordinates": [60, 0, 60, 120, 110, 120, 110, 0],
                             "pointTypes": [0, 0, 0, 0],
                         },
-                        "components": [],
                         "xAdvance": 170,
-                        "yAdvance": None,
-                        "verticalOrigin": None,
                     },
-                    "customData": {},
                 },
                 "wdth=1": {
                     "glyph": {
@@ -674,12 +554,8 @@ getGlyphTestData = [
                             "coordinates": [120, 0, 120, 220, 170, 220, 170, 0],
                             "pointTypes": [0, 0, 0, 0],
                         },
-                        "components": [],
                         "xAdvance": 290,
-                        "yAdvance": None,
-                        "verticalOrigin": None,
                     },
-                    "customData": {},
                 },
                 "wdth=1,wght=1": {
                     "glyph": {
@@ -688,12 +564,8 @@ getGlyphTestData = [
                             "coordinates": [60, 0, 60, 300, 250, 300, 250, 0],
                             "pointTypes": [0, 0, 0, 0],
                         },
-                        "components": [],
                         "xAdvance": 310,
-                        "yAdvance": None,
-                        "verticalOrigin": None,
                     },
-                    "customData": {},
                 },
                 "wght=1": {
                     "glyph": {
@@ -702,12 +574,8 @@ getGlyphTestData = [
                             "coordinates": [30, 0, 30, 300, 220, 300, 220, 0],
                             "pointTypes": [0, 0, 0, 0],
                         },
-                        "components": [],
                         "xAdvance": 250,
-                        "yAdvance": None,
-                        "verticalOrigin": None,
                     },
-                    "customData": {},
                 },
             },
             "sources": [
@@ -715,39 +583,29 @@ getGlyphTestData = [
                     "layerName": "<default>",
                     "location": {"wdth": 0, "wght": 0},
                     "name": "<default>",
-                    "active": True,
-                    "customData": {},
                 },
                 {
                     "layerName": "wdth=1",
                     "location": {"wdth": 1.0, "wght": 0},
                     "name": "wdth=1",
-                    "active": True,
-                    "customData": {},
                 },
                 {
                     "layerName": "wdth=1,wght=1",
                     "location": {"wdth": 1.0, "wght": 1.0},
                     "name": "wdth=1,wght=1",
-                    "active": True,
-                    "customData": {},
                 },
                 {
                     "layerName": "wght=1",
                     "location": {"wdth": 0, "wght": 1.0},
                     "name": "wght=1",
-                    "active": True,
-                    "customData": {},
                 },
             ],
-            "customData": {},
         },
     ),
     (
         "otf",
         {
             "name": "period",
-            "axes": [],
             "layers": {
                 "<default>": {
                     "glyph": {
@@ -756,12 +614,8 @@ getGlyphTestData = [
                             "pointTypes": [0, 0, 0, 0],
                             "contourInfo": [{"endPoint": 3, "isClosed": True}],
                         },
-                        "components": [],
                         "xAdvance": 170,
-                        "yAdvance": None,
-                        "verticalOrigin": None,
                     },
-                    "customData": {},
                 },
                 "wdth=1": {
                     "glyph": {
@@ -779,12 +633,8 @@ getGlyphTestData = [
                             "pointTypes": [0, 0, 0, 0],
                             "contourInfo": [{"endPoint": 3, "isClosed": True}],
                         },
-                        "components": [],
                         "xAdvance": 290.0,
-                        "yAdvance": None,
-                        "verticalOrigin": None,
                     },
-                    "customData": {},
                 },
                 "wdth=1,wght=1": {
                     "glyph": {
@@ -802,12 +652,8 @@ getGlyphTestData = [
                             "pointTypes": [0, 0, 0, 0],
                             "contourInfo": [{"endPoint": 3, "isClosed": True}],
                         },
-                        "components": [],
                         "xAdvance": 310.0,
-                        "yAdvance": None,
-                        "verticalOrigin": None,
                     },
-                    "customData": {},
                 },
                 "wght=1": {
                     "glyph": {
@@ -825,12 +671,8 @@ getGlyphTestData = [
                             "pointTypes": [0, 0, 0, 0],
                             "contourInfo": [{"endPoint": 3, "isClosed": True}],
                         },
-                        "components": [],
                         "xAdvance": 250.0,
-                        "yAdvance": None,
-                        "verticalOrigin": None,
                     },
-                    "customData": {},
                 },
             },
             "sources": [
@@ -838,32 +680,23 @@ getGlyphTestData = [
                     "location": {"wdth": 0, "wght": 0},
                     "name": "<default>",
                     "layerName": "<default>",
-                    "active": True,
-                    "customData": {},
                 },
                 {
                     "location": {"wdth": 1.0, "wght": 0},
                     "name": "wdth=1",
                     "layerName": "wdth=1",
-                    "active": True,
-                    "customData": {},
                 },
                 {
                     "location": {"wdth": 1.0, "wght": 1.0},
                     "name": "wdth=1,wght=1",
                     "layerName": "wdth=1,wght=1",
-                    "active": True,
-                    "customData": {},
                 },
                 {
                     "location": {"wdth": 0, "wght": 1.0},
                     "name": "wght=1",
                     "layerName": "wght=1",
-                    "active": True,
-                    "customData": {},
                 },
             ],
-            "customData": {},
         },
     ),
 ]

--- a/test-py/test_font.py
+++ b/test-py/test_font.py
@@ -5,6 +5,8 @@ from importlib.metadata import entry_points
 
 import pytest
 
+from fontra.core.classes import VariableGlyph, from_dict
+
 dataDir = pathlib.Path(__file__).resolve().parent / "data"
 
 
@@ -13,47 +15,34 @@ getGlyphTestData = [
         "ufo",
         {
             "name": "period",
-            "axes": [],
             "sources": [
                 {
-                    "location": {},
                     "layerName": "default/foreground",
                     "name": "default",
-                    "active": True,
-                    "customData": {},
                 }
             ],
             "layers": {
                 "default/foreground": {
                     "glyph": {
                         "xAdvance": 170,
-                        "yAdvance": None,
-                        "verticalOrigin": None,
                         "path": {
                             "contourInfo": [{"endPoint": 3, "isClosed": True}],
                             "coordinates": [60, 0, 110, 0, 110, 120, 60, 120],
                             "pointTypes": [0, 0, 0, 0],
                         },
-                        "components": [],
                     },
-                    "customData": {},
                 },
                 "default/background": {
                     "glyph": {
                         "xAdvance": 170,
-                        "yAdvance": None,
-                        "verticalOrigin": None,
                         "path": {
                             "contourInfo": [{"endPoint": 3, "isClosed": True}],
                             "coordinates": [62, 0, 112, 0, 112, 120, 62, 120],
                             "pointTypes": [0, 0, 0, 0],
                         },
-                        "components": [],
                     },
-                    "customData": {},
                 },
             },
-            "customData": {},
         },
     ),
     (
@@ -936,6 +925,8 @@ async def test_getGlyphMap(backendName, numGlyphs, testMapping):
 @pytest.mark.asyncio
 @pytest.mark.parametrize("backendName, expectedGlyph", getGlyphTestData)
 async def test_getGlyph(backendName, expectedGlyph):
+    # Fill in default values by round tripping through the dataclass
+    expectedGlyph = asdict(from_dict(VariableGlyph, expectedGlyph))
     font = getTestFont(backendName)
     with contextlib.closing(font):
         glyph = await font.getGlyph(expectedGlyph["name"])

--- a/test-py/test_font.py
+++ b/test-py/test_font.py
@@ -758,13 +758,12 @@ async def test_getGlyphMap(backendName, numGlyphs, testMapping):
 @pytest.mark.asyncio
 @pytest.mark.parametrize("backendName, expectedGlyph", getGlyphTestData)
 async def test_getGlyph(backendName, expectedGlyph):
-    # Fill in default values by round tripping through the dataclass
-    expectedGlyph = asdict(from_dict(VariableGlyph, expectedGlyph))
+    expectedGlyph = from_dict(VariableGlyph, expectedGlyph)
     font = getTestFont(backendName)
     with contextlib.closing(font):
-        glyph = await font.getGlyph(expectedGlyph["name"])
-        glyph = asdict(glyph)
+        glyph = await font.getGlyph(expectedGlyph.name)
         assert glyph == expectedGlyph
+        assert asdict(glyph) == asdict(expectedGlyph)
 
 
 getGlobalAxesTestData = [


### PR DESCRIPTION
Fixes #195, fixes #196, and fixes the Fontra side of https://github.com/googlefonts/fontra-rcjk/issues/25

- Add customData to VarGlyph, Source and Layer
- Add 'active' field to Source
