### PR TITLE
Opt-in experimental scaling edit tool

### DIFF
--- a/src/fontra/client/core/convex-hull.js
+++ b/src/fontra/client/core/convex-hull.js
@@ -171,3 +171,23 @@ export function simplePolygonArea(points) {
   }
   return areaX2 / 2;
 }
+
+export function polygonIsConvex(points) {
+  let gotNegative = false;
+  let gotPositive = false;
+  for (let i = 0; i < points.length; i++) {
+    const A = points.at(i - 2);
+    const B = points.at(i - 1);
+    const C = points[i];
+    const prod = ccw(A, B, C);
+    if (prod < 0) {
+      gotNegative = true;
+    } else if (prod > 0) {
+      gotPositive = true;
+    }
+    if (gotNegative && gotPositive) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/src/fontra/views/editor/edit-behavior.js
+++ b/src/fontra/views/editor/edit-behavior.js
@@ -415,13 +415,13 @@ function makeContourPointEditFuncs(contour, behavior) {
 }
 
 function makeInterpolateEditFuncs(contour, editPoints) {
-  const originalPoints = contour.points;
+  const points = contour.points;
   const editFuncs = [];
   const participatingPointIndices = [];
-  for (const segment of iterSegmentPointIndices(originalPoints, contour.isClosed)) {
+  for (const segment of iterSegmentPointIndices(points, contour.isClosed)) {
     if (
       segment.length < 4 ||
-      (!originalPoints[segment[0]].selected && !originalPoints[segment.at(-1)].selected)
+      (!points[segment[0]].selected && !points[segment.at(-1)].selected)
     ) {
       continue;
     }

--- a/src/fontra/views/editor/edit-behavior.js
+++ b/src/fontra/views/editor/edit-behavior.js
@@ -492,7 +492,7 @@ function makeSegmentTransform(points, pointIndices, allowConcave) {
   if (!allowConcave && !polygonIsConvex([pt0, pt1, pt2, pt3])) {
     return;
   }
-  const [intersection, t1, t2] = vector.intersect(pt0, pt1, pt2, pt3);
+  const intersection = vector.intersect(pt0, pt1, pt2, pt3);
   if (!intersection) {
     return undefined;
   }

--- a/src/fontra/views/editor/edit-behavior.js
+++ b/src/fontra/views/editor/edit-behavior.js
@@ -16,7 +16,7 @@ import {
 } from "./edit-behavior-support.js";
 
 export class EditBehaviorFactory {
-  constructor(instance, selection, enableScaleEdit = false) {
+  constructor(instance, selection, enableScalingEdit = false) {
     const {
       point: pointSelection,
       component: componentSelection,
@@ -37,7 +37,7 @@ export class EditBehaviorFactory {
     this.componentOriginIndices = componentOriginIndices || [];
     this.componentTCenterIndices = componentTCenterSelection || [];
     this.behaviors = {};
-    this.enableScaleEdit = enableScaleEdit;
+    this.enableScalingEdit = enableScalingEdit;
   }
 
   getBehavior(behaviorName) {
@@ -48,8 +48,8 @@ export class EditBehaviorFactory {
         console.log(`invalid behavior name: "${behaviorName}"`);
         behaviorType = behaviorTypes["default"];
       }
-      if (this.enableScaleEdit && behaviorType.canDoScaleEdit) {
-        behaviorType = { ...behaviorType, enableScaleEdit: true };
+      if (this.enableScalingEdit && behaviorType.canDoScalingEdit) {
+        behaviorType = { ...behaviorType, enableScalingEdit: true };
       }
       behavior = new EditBehavior(
         this.contours,
@@ -345,7 +345,7 @@ function makeContourPointEditFuncs(contour, behavior) {
   const startIndex = contour.startIndex;
   const originalPoints = contour.points;
   const editPoints = Array.from(originalPoints); // will be modified
-  const scaleEditPoints = Array.from(originalPoints); // will be modified
+  const scalingEditPoints = Array.from(originalPoints); // will be modified
   const numPoints = originalPoints.length;
   let participatingPointIndices = [];
   const editFuncsTransform = [];
@@ -393,7 +393,7 @@ function makeContourPointEditFuncs(contour, behavior) {
           originalPoints[nextNext]
         );
         editPoints[thePoint] = point;
-        scaleEditPoints[thePoint] = point;
+        scalingEditPoints[thePoint] = point;
         return [thePoint + startIndex, point.x, point.y];
       });
     } else {
@@ -408,31 +408,31 @@ function makeContourPointEditFuncs(contour, behavior) {
           editPoints[next],
           editPoints[nextNext]
         );
-        scaleEditPoints[thePoint] = point;
+        scalingEditPoints[thePoint] = point;
         return [thePoint + startIndex, point.x, point.y];
       });
     }
   }
-  let editFuncsScaleEdit = [];
-  if (behavior.enableScaleEdit) {
-    let scaleEditPointIndices;
-    [editFuncsScaleEdit, scaleEditPointIndices] = makeScaleEditFuncs(
+  let editFuncsScalingEdit = [];
+  if (behavior.enableScalingEdit) {
+    let scalingEditPointIndices;
+    [editFuncsScalingEdit, scalingEditPointIndices] = makeScalingEditFuncs(
       contour,
-      scaleEditPoints
+      scalingEditPoints
     );
-    if (scaleEditPointIndices.length) {
+    if (scalingEditPointIndices.length) {
       participatingPointIndices = [
-        ...new Set([...participatingPointIndices, ...scaleEditPointIndices]),
+        ...new Set([...participatingPointIndices, ...scalingEditPointIndices]),
       ].sort((a, b) => a - b);
     }
   }
   return [
-    [...editFuncsTransform, ...editFuncsConstrain, ...editFuncsScaleEdit],
+    [...editFuncsTransform, ...editFuncsConstrain, ...editFuncsScalingEdit],
     participatingPointIndices,
   ];
 }
 
-function makeScaleEditFuncs(contour, editPoints) {
+function makeScalingEditFuncs(contour, editPoints) {
   const points = contour.points;
   const editFuncs = [];
   const participatingPointIndices = [];
@@ -444,7 +444,7 @@ function makeScaleEditFuncs(contour, editPoints) {
     ) {
       continue;
     }
-    const [segmentEditFunc, pointIndices] = makeSegmentScaleEditFuncs(
+    const [segmentEditFunc, pointIndices] = makeSegmentScalingEditFuncs(
       segment,
       contour,
       editPoints
@@ -455,7 +455,7 @@ function makeScaleEditFuncs(contour, editPoints) {
   return [editFuncs, participatingPointIndices];
 }
 
-function makeSegmentScaleEditFuncs(segment, contour, editPoints) {
+function makeSegmentScalingEditFuncs(segment, contour, editPoints) {
   const originalPoints = contour.points;
   const startIndex = contour.startIndex;
   const editFuncs = [];
@@ -935,14 +935,14 @@ const behaviorTypes = {
   "default": {
     matchTree: buildPointMatchTree(defaultRules),
     actions: actionFactories,
-    canDoScaleEdit: true,
+    canDoScalingEdit: true,
   },
 
   "constrain": {
     matchTree: buildPointMatchTree(constrainRules),
     actions: actionFactories,
     constrainDelta: constrainHorVerDiag,
-    canDoScaleEdit: true,
+    canDoScalingEdit: true,
   },
 
   "alternate": {

--- a/src/fontra/views/editor/edit-behavior.js
+++ b/src/fontra/views/editor/edit-behavior.js
@@ -503,6 +503,7 @@ function makeSegmentTransform(points, pointIndices, allowConcave) {
 }
 
 function* iterSegmentPointIndices(originalPoints, isClosed) {
+  const lastPointIndex = originalPoints.length - 1;
   const firstOnCurve = findFirstOnCurvePoint(originalPoints, isClosed);
   if (firstOnCurve === undefined) {
     return;
@@ -512,9 +513,15 @@ function* iterSegmentPointIndices(originalPoints, isClosed) {
     const indices = [
       ...iterUntilNextOnCurvePoint(originalPoints, currentOnCurve, isClosed),
     ];
+    if (!indices.length) {
+      break;
+    }
     yield indices;
     currentOnCurve = indices.at(-1);
-    if (currentOnCurve == firstOnCurve) {
+    if (
+      (isClosed && currentOnCurve == firstOnCurve) ||
+      (!isClosed && currentOnCurve == lastPointIndex)
+    ) {
       break;
     }
   }

--- a/src/fontra/views/editor/edit-behavior.js
+++ b/src/fontra/views/editor/edit-behavior.js
@@ -16,7 +16,7 @@ import {
 } from "./edit-behavior-support.js";
 
 export class EditBehaviorFactory {
-  constructor(instance, selection) {
+  constructor(instance, selection, enableScaleEdit = false) {
     const {
       point: pointSelection,
       component: componentSelection,
@@ -37,9 +37,10 @@ export class EditBehaviorFactory {
     this.componentOriginIndices = componentOriginIndices || [];
     this.componentTCenterIndices = componentTCenterSelection || [];
     this.behaviors = {};
+    this.enableScaleEdit = enableScaleEdit;
   }
 
-  getBehavior(behaviorName, enableScaleEdit = true) {
+  getBehavior(behaviorName) {
     let behavior = this.behaviors[behaviorName];
     if (!behavior) {
       let behaviorType = behaviorTypes[behaviorName];
@@ -47,7 +48,7 @@ export class EditBehaviorFactory {
         console.log(`invalid behavior name: "${behaviorName}"`);
         behaviorType = behaviorTypes["default"];
       }
-      if (enableScaleEdit && behaviorType.canDoScaleEdit) {
+      if (this.enableScaleEdit && behaviorType.canDoScaleEdit) {
         behaviorType = { ...behaviorType, enableScaleEdit: true };
       }
       behavior = new EditBehavior(

--- a/src/fontra/views/editor/edit-behavior.js
+++ b/src/fontra/views/editor/edit-behavior.js
@@ -399,22 +399,22 @@ function makeContourPointEditFuncs(contour, behavior) {
       });
     }
   }
-  const [editFuncsInterpolate, additionalPointIndices] = makeInterpolateEditFuncs(
+  const [editFuncsScaleEdit, scaleEditPointIndices] = makeScaleEditFuncs(
     contour,
     editPoints
   );
-  if (additionalPointIndices.length) {
+  if (scaleEditPointIndices.length) {
     participatingPointIndices = [
-      ...new Set([...participatingPointIndices, ...additionalPointIndices]),
+      ...new Set([...participatingPointIndices, ...scaleEditPointIndices]),
     ].sort((a, b) => a - b);
   }
   return [
-    [...editFuncsTransform, ...editFuncsConstrain, ...editFuncsInterpolate],
+    [...editFuncsTransform, ...editFuncsConstrain, ...editFuncsScaleEdit],
     participatingPointIndices,
   ];
 }
 
-function makeInterpolateEditFuncs(contour, editPoints) {
+function makeScaleEditFuncs(contour, editPoints) {
   const points = contour.points;
   const editFuncs = [];
   const participatingPointIndices = [];

--- a/src/fontra/views/editor/edit-tools-pointer.js
+++ b/src/fontra/views/editor/edit-tools-pointer.js
@@ -285,7 +285,8 @@ export class PointerTool extends BaseTool {
 
       const behaviorFactory = new EditBehaviorFactory(
         instance,
-        sceneController.selection
+        sceneController.selection,
+        sceneController.experimentalFeaturesController.model.scaleEditBehavior
       );
 
       let behaviorName = getBehaviorName(initialEvent);

--- a/src/fontra/views/editor/edit-tools-pointer.js
+++ b/src/fontra/views/editor/edit-tools-pointer.js
@@ -286,7 +286,7 @@ export class PointerTool extends BaseTool {
       const behaviorFactory = new EditBehaviorFactory(
         instance,
         sceneController.selection,
-        sceneController.experimentalFeaturesController.model.scalingEditBehavior
+        sceneController.experimentalFeatures.scalingEditBehavior
       );
 
       let behaviorName = getBehaviorName(initialEvent);

--- a/src/fontra/views/editor/edit-tools-pointer.js
+++ b/src/fontra/views/editor/edit-tools-pointer.js
@@ -286,7 +286,7 @@ export class PointerTool extends BaseTool {
       const behaviorFactory = new EditBehaviorFactory(
         instance,
         sceneController.selection,
-        sceneController.experimentalFeaturesController.model.scaleEditBehavior
+        sceneController.experimentalFeaturesController.model.scalingEditBehavior
       );
 
       let behaviorName = getBehaviorName(initialEvent);

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -96,7 +96,7 @@ export class EditorController {
     this.clipboardFormatController.synchronizeWithLocalStorage("fontra-clipboard-");
 
     this.experimentalFeaturesController = new ObservableController({
-      scaleEditBehavior: false,
+      scalingEditBehavior: false,
     });
     this.experimentalFeaturesController.synchronizeWithLocalStorage(
       "fontra-editor-experimental-features."
@@ -295,8 +295,8 @@ export class EditorController {
       controller: this.experimentalFeaturesController,
       descriptions: [
         {
-          key: "scaleEditBehavior",
-          displayName: "Scale edit tool behavior",
+          key: "scalingEditBehavior",
+          displayName: "Scaling edit tool behavior",
           ui: "checkbox",
         },
       ],

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -95,6 +95,13 @@ export class EditorController {
     this.clipboardFormatController = new ObservableController({ format: "glif" });
     this.clipboardFormatController.synchronizeWithLocalStorage("fontra-clipboard-");
 
+    this.experimentalFeaturesController = new ObservableController({
+      scaleEditBehavior: false,
+    });
+    this.experimentalFeaturesController.synchronizeWithLocalStorage(
+      "fontra-editor-experimental-features."
+    );
+
     this.visualizationLayers = new VisualizationLayers(
       visualizationLayerDefinitions,
       this.isThemeDark
@@ -125,7 +132,11 @@ export class EditorController {
       this.cleanGlyphsLayers.drawVisualizationLayers(model, controller);
     });
 
-    this.sceneController = new SceneController(sceneModel, canvasController);
+    this.sceneController = new SceneController(
+      sceneModel,
+      canvasController,
+      this.experimentalFeaturesController
+    );
     // TODO move event stuff out of here
     this.sceneController.addEventListener(
       "selectedGlyphIsEditingChanged",
@@ -274,6 +285,19 @@ export class EditorController {
             { key: "svg", displayName: "SVG" },
             { key: "fontra-json", displayName: "JSON (Fontra)" },
           ],
+        },
+      ],
+    });
+
+    // Experimental feature settings
+    items.push({
+      displayName: "Experimental features",
+      controller: this.experimentalFeaturesController,
+      descriptions: [
+        {
+          key: "scaleEditBehavior",
+          displayName: "Scale edit tool behavior",
+          ui: "checkbox",
         },
       ],
     });

--- a/src/fontra/views/editor/scene-controller.js
+++ b/src/fontra/views/editor/scene-controller.js
@@ -91,7 +91,7 @@ export class SceneController {
       const behaviorFactory = new EditBehaviorFactory(
         instance,
         this.selection,
-        this.experimentalFeaturesController.model.scaleEditBehavior
+        this.experimentalFeaturesController.model.scalingEditBehavior
       );
       const editBehavior = behaviorFactory.getBehavior(
         event.altKey ? "alternate" : "default"

--- a/src/fontra/views/editor/scene-controller.js
+++ b/src/fontra/views/editor/scene-controller.js
@@ -18,7 +18,7 @@ export class SceneController {
   constructor(sceneModel, canvasController, experimentalFeaturesController) {
     this.sceneModel = sceneModel;
     this.canvasController = canvasController;
-    this.experimentalFeaturesController = experimentalFeaturesController;
+    this.experimentalFeatures = experimentalFeaturesController.model;
 
     this.mouseTracker = new MouseTracker({
       drag: async (eventStream, initialEvent) =>
@@ -91,7 +91,7 @@ export class SceneController {
       const behaviorFactory = new EditBehaviorFactory(
         instance,
         this.selection,
-        this.experimentalFeaturesController.model.scalingEditBehavior
+        this.experimentalFeatures.scalingEditBehavior
       );
       const editBehavior = behaviorFactory.getBehavior(
         event.altKey ? "alternate" : "default"

--- a/src/fontra/views/editor/scene-controller.js
+++ b/src/fontra/views/editor/scene-controller.js
@@ -15,9 +15,10 @@ import { dialog } from "/web-components/dialog-overlay.js";
 import { EditBehaviorFactory } from "./edit-behavior.js";
 
 export class SceneController {
-  constructor(sceneModel, canvasController) {
+  constructor(sceneModel, canvasController, experimentalFeaturesController) {
     this.sceneModel = sceneModel;
     this.canvasController = canvasController;
+    this.experimentalFeaturesController = experimentalFeaturesController;
 
     this.mouseTracker = new MouseTracker({
       drag: async (eventStream, initialEvent) =>
@@ -87,7 +88,11 @@ export class SceneController {
     }
     const delta = { x: dx, y: dy };
     await this.editInstance((sendIncrementalChange, instance) => {
-      const behaviorFactory = new EditBehaviorFactory(instance, this.selection);
+      const behaviorFactory = new EditBehaviorFactory(
+        instance,
+        this.selection,
+        this.experimentalFeaturesController.model.scaleEditBehavior
+      );
       const editBehavior = behaviorFactory.getBehavior(
         event.altKey ? "alternate" : "default"
       );


### PR DESCRIPTION
Towards implementing #386

This adds:
- User settings for experimental features
- Add opt-in "Scale edit tool behavior" experimental feature

The behavior is not great in some cases, and needs improvement. I label it "experimental" for now, so we can gather experience with it anyway.