### PR TITLE
[add source] Suggest a source name based on the location

### DIFF
--- a/src/fontra/views/editor/sidebar-designspace.js
+++ b/src/fontra/views/editor/sidebar-designspace.js
@@ -325,7 +325,7 @@ export class SidebarDesignspace {
 
     const nameController = new ObservableController({
       sourceName: sourceName || suggestedSourceName,
-      layerName: layerName || sourceName || suggestedSourceName,
+      layerName: layerName === sourceName ? "" : layerName,
       suggestedSourceName: suggestedSourceName,
       suggestedLayerName: sourceName || suggestedSourceName,
     });

--- a/src/fontra/views/editor/sidebar-designspace.js
+++ b/src/fontra/views/editor/sidebar-designspace.js
@@ -319,16 +319,16 @@ export class SidebarDesignspace {
     const locationAxes = this._sourcePropertiesLocationAxes(glyph);
     const locationController = new ObservableController({ ...location });
     const layerNames = Object.keys(glyph.layers);
+    const suggestedSourceName = suggestedSourceNameFromLocation(
+      makeSparseLocation(location, locationAxes)
+    );
 
     const nameController = new ObservableController({
       sourceName: sourceName,
       layerName: layerName,
-      suggestedSourceName: suggestedSourceNameFromLocation(
-        makeSparseLocation(location, locationAxes)
-      ),
+      suggestedSourceName: suggestedSourceName,
+      suggestedLayerName: sourceName || suggestedSourceName,
     });
-    nameController.model.suggestedLayerName =
-      layerName || nameController.model.suggestedSourceName;
 
     nameController.addKeyListener("sourceName", (key, newValue) => {
       nameController.model.suggestedLayerName =

--- a/src/fontra/views/editor/sidebar-designspace.js
+++ b/src/fontra/views/editor/sidebar-designspace.js
@@ -337,11 +337,12 @@ export class SidebarDesignspace {
     });
 
     locationController.addListener((key, newValue) => {
-      nameController.model.suggestedSourceName = suggestedSourceNameFromLocation(
+      const suggestedSourceName = suggestedSourceNameFromLocation(
         makeSparseLocation(locationController.model, locationAxes)
       );
+      nameController.model.suggestedSourceName = suggestedSourceName;
       nameController.model.suggestedLayerName =
-        nameController.model.sourceName || nameController.model.suggestedSourceName;
+        nameController.model.sourceName || suggestedSourceName;
       validateInput();
     });
 

--- a/src/fontra/views/editor/sidebar-designspace.js
+++ b/src/fontra/views/editor/sidebar-designspace.js
@@ -549,8 +549,8 @@ function suggestedSourceNameFromLocation(location) {
     Object.entries(location)
       .map(([name, value]) => {
         value = Math.round(value * 10) / 10;
-        return `${name}${value}`;
+        return `${name}=${value}`;
       })
-      .join("_") || "default"
+      .join(",") || "default"
   );
 }

--- a/src/fontra/views/editor/sidebar-designspace.js
+++ b/src/fontra/views/editor/sidebar-designspace.js
@@ -536,10 +536,12 @@ function getAxisInfoFromGlyph(glyph) {
 }
 
 function suggestedSourceNameFromLocation(location) {
-  return Object.entries(location)
-    .map(([name, value]) => {
-      value = Math.round(value * 10) / 10;
-      return `${name}${value}`;
-    })
-    .join("_");
+  return (
+    Object.entries(location)
+      .map(([name, value]) => {
+        value = Math.round(value * 10) / 10;
+        return `${name}${value}`;
+      })
+      .join("_") || "default"
+  );
 }

--- a/src/fontra/views/editor/sidebar-designspace.js
+++ b/src/fontra/views/editor/sidebar-designspace.js
@@ -327,7 +327,8 @@ export class SidebarDesignspace {
         makeSparseLocation(location, locationAxes)
       ),
     });
-    nameController.model.suggestedLayerName = nameController.model.suggestedSourceName;
+    nameController.model.suggestedLayerName =
+      layerName || nameController.model.suggestedSourceName;
 
     nameController.addKeyListener("sourceName", (key, newValue) => {
       nameController.model.suggestedLayerName =
@@ -382,7 +383,8 @@ export class SidebarDesignspace {
 
     sourceName =
       nameController.model.sourceName || nameController.model.suggestedSourceName;
-    layerName = nameController.model.layerName || nameController.model.sourceName;
+    layerName =
+      nameController.model.layerName || nameController.model.suggestedLayerName;
 
     return { location: newLocation, sourceName, layerName, layerNames };
   }

--- a/src/fontra/views/editor/sidebar-designspace.js
+++ b/src/fontra/views/editor/sidebar-designspace.js
@@ -324,8 +324,8 @@ export class SidebarDesignspace {
     );
 
     const nameController = new ObservableController({
-      sourceName: sourceName,
-      layerName: layerName,
+      sourceName: sourceName || suggestedSourceName,
+      layerName: layerName || sourceName || suggestedSourceName,
       suggestedSourceName: suggestedSourceName,
       suggestedLayerName: sourceName || suggestedSourceName,
     });
@@ -340,6 +340,12 @@ export class SidebarDesignspace {
       const suggestedSourceName = suggestedSourceNameFromLocation(
         makeSparseLocation(locationController.model, locationAxes)
       );
+      if (nameController.model.sourceName == nameController.model.suggestedSourceName) {
+        nameController.model.sourceName = suggestedSourceName;
+      }
+      if (nameController.model.layerName == nameController.model.suggestedSourceName) {
+        nameController.model.layerName = suggestedSourceName;
+      }
       nameController.model.suggestedSourceName = suggestedSourceName;
       nameController.model.suggestedLayerName =
         nameController.model.sourceName || suggestedSourceName;


### PR DESCRIPTION
When adding a new source, suggest a name based on the location instead of starting with an empty string.

Fixes #427.

Also, when editing source properties:
- If the source name still is as it was suggested, make it follow the axis sliders settings