### PR TITLE
Fix segment selection on top of components

### DIFF
--- a/src/fontra/views/editor/edit-tools-pen.js
+++ b/src/fontra/views/editor/edit-tools-pen.js
@@ -205,7 +205,7 @@ function getPenToolBehavior(sceneController, initialEvent, path) {
       appendInfo.contourIndex,
       appendInfo.contourPointIndex
     );
-    const clickedSelection = sceneController.sceneModel.selectionAtPoint(
+    const { selection: clickedSelection } = sceneController.sceneModel.selectionAtPoint(
       sceneController.localPoint(initialEvent),
       sceneController.mouseClickMargin
     );
@@ -528,7 +528,7 @@ function shiftConstrain(anchorPoint, handlePoint) {
 }
 
 function getHoveredPointIndex(sceneController, event) {
-  const hoveredSelection = sceneController.sceneModel.selectionAtPoint(
+  const { selection: hoveredSelection } = sceneController.sceneModel.selectionAtPoint(
     sceneController.localPoint(event),
     sceneController.mouseClickMargin
   );

--- a/src/fontra/views/editor/edit-tools-pointer.js
+++ b/src/fontra/views/editor/edit-tools-pointer.js
@@ -62,7 +62,7 @@ export class PointerTool extends BaseTool {
     let initialClickedPointIndex;
     if (!pathHit) {
       const { point: pointIndices } = parseSelection(selection);
-      if (pointIndices && pointIndices.length) {
+      if (pointIndices?.length) {
         initialClickedPointIndex = pointIndices[0];
       }
     }

--- a/src/fontra/views/editor/edit-tools-pointer.js
+++ b/src/fontra/views/editor/edit-tools-pointer.js
@@ -21,7 +21,7 @@ export class PointerTool extends BaseTool {
     const point = sceneController.localPoint(event);
     const size = sceneController.mouseClickMargin;
     const selRect = centeredRect(point.x, point.y, size);
-    const { selection } = this.sceneModel.selectionAtPoint(
+    const { selection, pathHit } = this.sceneModel.selectionAtPoint(
       point,
       size,
       union(sceneController.selection, sceneController.hoverSelection),
@@ -29,13 +29,7 @@ export class PointerTool extends BaseTool {
     );
     sceneController.hoverSelection = selection;
     sceneController.hoveredGlyph = undefined;
-    sceneController.hoverPathHit = undefined;
-    if (!sceneController.hoverSelection?.size) {
-      const hit = this.sceneModel.pathHitAtPoint(point, size);
-      if (hit.contourIndex !== undefined) {
-        sceneController.hoverPathHit = hit;
-      }
-    }
+    sceneController.hoverPathHit = pathHit;
 
     if (!sceneController.hoverSelection.size && !sceneController.hoverPathHit) {
       sceneController.hoveredGlyph = this.sceneModel.glyphAtPoint(point);
@@ -59,19 +53,14 @@ export class PointerTool extends BaseTool {
     const sceneController = this.sceneController;
     const point = sceneController.localPoint(initialEvent);
     const size = sceneController.mouseClickMargin;
-    const { selection } = this.sceneModel.selectionAtPoint(
+    const { selection, pathHit } = this.sceneModel.selectionAtPoint(
       point,
       size,
       union(sceneController.selection, sceneController.hoverSelection),
       initialEvent.altKey
     );
     let initialClickedPointIndex;
-    if (!selection.size) {
-      const hit = this.sceneModel.pathHitAtPoint(point, size);
-      if (hit.contourIndex !== undefined) {
-        hit.segment.parentPointIndices.forEach((i) => selection.add(`point/${i}`));
-      }
-    } else {
+    if (!pathHit) {
       const { point: pointIndices } = parseSelection(selection);
       if (pointIndices && pointIndices.length) {
         initialClickedPointIndex = pointIndices[0];

--- a/src/fontra/views/editor/edit-tools-pointer.js
+++ b/src/fontra/views/editor/edit-tools-pointer.js
@@ -21,12 +21,13 @@ export class PointerTool extends BaseTool {
     const point = sceneController.localPoint(event);
     const size = sceneController.mouseClickMargin;
     const selRect = centeredRect(point.x, point.y, size);
-    sceneController.hoverSelection = this.sceneModel.selectionAtPoint(
+    const { selection } = this.sceneModel.selectionAtPoint(
       point,
       size,
       union(sceneController.selection, sceneController.hoverSelection),
       event.altKey
     );
+    sceneController.hoverSelection = selection;
     sceneController.hoveredGlyph = undefined;
     sceneController.hoverPathHit = undefined;
     if (!sceneController.hoverSelection?.size) {
@@ -58,7 +59,7 @@ export class PointerTool extends BaseTool {
     const sceneController = this.sceneController;
     const point = sceneController.localPoint(initialEvent);
     const size = sceneController.mouseClickMargin;
-    const selection = this.sceneModel.selectionAtPoint(
+    const { selection } = this.sceneModel.selectionAtPoint(
       point,
       size,
       union(sceneController.selection, sceneController.hoverSelection),

--- a/src/fontra/views/editor/scene-controller.js
+++ b/src/fontra/views/editor/scene-controller.js
@@ -143,7 +143,7 @@ export class SceneController {
     if (!this.selectedGlyphIsEditing) {
       return;
     }
-    const clickedSelection = this.sceneModel.selectionAtPoint(
+    const { selection: clickedSelection } = this.sceneModel.selectionAtPoint(
       this.localPoint(event),
       this.mouseClickMargin
     );

--- a/src/fontra/views/editor/scene-model.js
+++ b/src/fontra/views/editor/scene-model.js
@@ -263,6 +263,28 @@ export class SceneModel {
     if (!this.selectedGlyph || !this.selectedGlyphIsEditing) {
       return { selection: new Set() };
     }
+    const positionedGlyph = this.getSelectedPositionedGlyph();
+
+    // Point selection
+    const glyphPoint = {
+      x: point.x - positionedGlyph.x,
+      y: point.y - positionedGlyph.y,
+    };
+    const pointIndex = positionedGlyph.glyph.path.pointIndexNearPoint(glyphPoint, size);
+    if (pointIndex !== undefined) {
+      return { selection: new Set([`point/${pointIndex}`]) };
+    }
+
+    // Segment hit testing
+    const pathHit = this.pathHitAtPoint(point, size);
+    if (pathHit.contourIndex !== undefined) {
+      const selection = new Set(
+        pathHit.segment.parentPointIndices.map((i) => `point/${i}`)
+      );
+      return { selection, pathHit };
+    }
+
+    // Component selection
     let currentSelectedComponentIndices;
     if (currentSelection) {
       const { component, componentOrigin, componentTCenter } =
@@ -272,15 +294,6 @@ export class SceneModel {
         ...(componentOrigin || []),
         ...(componentTCenter || []),
       ]);
-    }
-    const positionedGlyph = this.getSelectedPositionedGlyph();
-    const glyphPoint = {
-      x: point.x - positionedGlyph.x,
-      y: point.y - positionedGlyph.y,
-    };
-    const pointIndex = positionedGlyph.glyph.path.pointIndexNearPoint(glyphPoint, size);
-    if (pointIndex !== undefined) {
-      return { selection: new Set([`point/${pointIndex}`]) };
     }
     const components = positionedGlyph.glyph.components;
     const x = point.x - positionedGlyph.x;

--- a/src/fontra/views/editor/scene-model.js
+++ b/src/fontra/views/editor/scene-model.js
@@ -261,7 +261,7 @@ export class SceneModel {
 
   selectionAtPoint(point, size, currentSelection, preferTCenter) {
     if (!this.selectedGlyph || !this.selectedGlyphIsEditing) {
-      return new Set();
+      return { selection: new Set() };
     }
     let currentSelectedComponentIndices;
     if (currentSelection) {
@@ -280,7 +280,7 @@ export class SceneModel {
     };
     const pointIndex = positionedGlyph.glyph.path.pointIndexNearPoint(glyphPoint, size);
     if (pointIndex !== undefined) {
-      return new Set([`point/${pointIndex}`]);
+      return { selection: new Set([`point/${pointIndex}`]) };
     }
     const components = positionedGlyph.glyph.components;
     const x = point.x - positionedGlyph.x;
@@ -309,7 +309,7 @@ export class SceneModel {
           if (tCenterMatch && (!originMatch || preferTCenter)) {
             selection.add(`componentTCenter/${i}`);
           }
-          return selection;
+          return { selection };
         }
       }
       if (
@@ -321,19 +321,19 @@ export class SceneModel {
     }
     switch (componentHullMatches.length) {
       case 0:
-        return new Set();
+        return { selection: new Set() };
       case 1:
-        return new Set([`component/${componentHullMatches[0].index}`]);
+        return { selection: new Set([`component/${componentHullMatches[0].index}`]) };
     }
     // If we have multiple matches, take the first that has an actual
     // point inside the path, and not just inside the hull
     for (const match of componentHullMatches) {
       if (this.isPointInPath(match.component.path2d, x, y)) {
-        return new Set([`component/${match.index}`]);
+        return { selection: new Set([`component/${match.index}`]) };
       }
     }
     // Else, fall back to the first match
-    return new Set([`component/${componentHullMatches[0].index}`]);
+    return { selection: new Set([`component/${componentHullMatches[0].index}`]) };
   }
 
   selectionAtRect(selRect) {


### PR DESCRIPTION
Integrate path hit testing into selectionAtPoint. This is better factoring, but also allows me to fix #435, the selection Z order problem.