### PR TITLE
Multi column source list

### DIFF
--- a/src/fontra/client/core/font-controller.js
+++ b/src/fontra/client/core/font-controller.js
@@ -205,6 +205,15 @@ export class FontController {
     this.updateGlyphDependencies(await this.getGlyph(glyphName));
   }
 
+  async getLayerGlyphController(glyphName, layerName, sourceIndex) {
+    const varGlyph = await this.getGlyph(glyphName);
+    if (!varGlyph) {
+      return;
+    }
+    const getGlyphFunc = this.getGlyph.bind(this);
+    return varGlyph.getLayerGlyphController(layerName, sourceIndex, getGlyphFunc);
+  }
+
   async getGlyphInstance(glyphName, location, instanceCacheKey) {
     if (!this.hasGlyph(glyphName)) {
       return Promise.resolve(null);

--- a/src/fontra/client/core/glyph-controller.js
+++ b/src/fontra/client/core/glyph-controller.js
@@ -22,6 +22,7 @@ export class VariableGlyphController {
     this.glyph = glyph;
     this.globalAxes = globalAxes;
     this._locationToSourceIndex = {};
+    this._layerGlyphControllers = {};
   }
 
   get name() {
@@ -159,6 +160,7 @@ export class VariableGlyphController {
     delete this._combinedAxes;
     delete this._localToGlobalMapping;
     this._locationToSourceIndex = {};
+    this._layerGlyphControllers = {};
   }
 
   get model() {
@@ -183,6 +185,29 @@ export class VariableGlyphController {
       this._deltas = this.model.getDeltas(masterValues);
     }
     return this._deltas;
+  }
+
+  async getLayerGlyphController(layerName, sourceIndex, getGlyphFunc) {
+    const cacheKey = `${layerName}/${sourceIndex}`;
+    let instanceController = this._layerGlyphControllers[cacheKey];
+    if (instanceController === undefined) {
+      const layer = this.layers[layerName];
+      if (layer) {
+        instanceController = new StaticGlyphController(
+          this.name,
+          layer.glyph,
+          undefined
+        );
+        await instanceController.setupComponents(
+          getGlyphFunc,
+          this.sources[sourceIndex].location
+        );
+      } else {
+        instanceController = null;
+      }
+      this._layerGlyphControllers[cacheKey] = instanceController;
+    }
+    return instanceController;
   }
 
   instantiate(normalizedLocation) {

--- a/src/fontra/client/core/glyph-controller.js
+++ b/src/fontra/client/core/glyph-controller.js
@@ -204,7 +204,7 @@ export class VariableGlyphController {
         instanceController = new StaticGlyphController(
           this.name,
           layer.glyph,
-          undefined
+          sourceIndex
         );
         await instanceController.setupComponents(
           getGlyphFunc,

--- a/src/fontra/client/core/glyph-controller.js
+++ b/src/fontra/client/core/glyph-controller.js
@@ -132,6 +132,14 @@ export class VariableGlyphController {
     return undefined;
   }
 
+  getSourceIndexFromName(sourceName) {
+    for (const [sourceIndex, source] of enumerate(this.sources)) {
+      if (source.name === sourceName) {
+        return sourceIndex;
+      }
+    }
+  }
+
   getAllComponentNames() {
     // Return a set of all component names used by all layers of all sources
     const componentNames = new Set();

--- a/src/fontra/client/core/observable-object.js
+++ b/src/fontra/client/core/observable-object.js
@@ -1,5 +1,7 @@
 import { chain } from "./utils.js";
 
+export const controllerKey = Symbol("controller-key");
+
 export class ObservableController {
   constructor(model) {
     if (!model) {
@@ -75,6 +77,9 @@ function newModelProxy(controller, model) {
     },
 
     get(model, key, receiver) {
+      if (key === controllerKey) {
+        return controller;
+      }
       return model[key];
     },
 

--- a/src/fontra/client/web-components/glyphs-search.js
+++ b/src/fontra/client/web-components/glyphs-search.js
@@ -51,10 +51,11 @@ export class GlyphsSearch extends UnlitElement {
     const columnDescriptions = [
       {
         key: "char",
+        title: " ",
         width: "1.8em",
         get: (item) => getCharFromUnicode(item.unicodes[0]),
       },
-      { key: "glyphName", width: "10em", isIdentifierKey: true },
+      { key: "glyphName", title: "glyph name", width: "10em", isIdentifierKey: true },
       {
         key: "unicode",
         width: "5em",

--- a/src/fontra/client/web-components/glyphs-search.js
+++ b/src/fontra/client/web-components/glyphs-search.js
@@ -51,7 +51,7 @@ export class GlyphsSearch extends UnlitElement {
     const columnDescriptions = [
       {
         key: "char",
-        width: "2em",
+        width: "1.8em",
         get: (item) => getCharFromUnicode(item.unicodes[0]),
       },
       { key: "glyphName", width: "10em", isIdentifierKey: true },

--- a/src/fontra/client/web-components/ui-list.js
+++ b/src/fontra/client/web-components/ui-list.js
@@ -17,13 +17,34 @@ export class UIList extends UnlitElement {
     ${themeColorCSS(colors)}
 
     :host {
+      /* display: grid; */  /* set by code below */
+      gap: 0.2em;
+      min-height: 0;
+      box-sizing: border-box;
+    }
+
+    .container {
       overflow: scroll;
+      height: 100%;
+      box-sizing: border-box;
       border: solid 1px var(--border-color);
     }
 
     .contents {
       display: flex;
       flex-direction: column;
+    }
+
+    .header {
+      display: flex;
+      width: min-content;
+      min-width: 100%;
+      box-sizing: border-box;
+      padding: 0.15em;
+      padding-left: 0.5em;
+      padding-right: 0.5em;
+      cursor: pointer;
+      user-select: none;
     }
 
     .contents > .row {
@@ -62,6 +83,7 @@ export class UIList extends UnlitElement {
         get: (item) => item,
       },
     ];
+    this._showHeader = false;
     this.items = [];
     this.itemEqualFunc = null;
 
@@ -78,7 +100,22 @@ export class UIList extends UnlitElement {
   }
 
   render() {
-    return this.contents;
+    const contents = [];
+    if (this._showHeader) {
+      contents.push(this._makeHeader());
+    }
+    contents.push(html.div({ class: "container" }, [this.contents]));
+    return contents;
+  }
+
+  get showHeader() {
+    return this._showHeader;
+  }
+
+  set showHeader(onOff) {
+    this._showHeader = onOff;
+    this.setItems(this.items);
+    this.requestUpdate();
   }
 
   get columnDescriptions() {
@@ -93,11 +130,12 @@ export class UIList extends UnlitElement {
     );
     this.itemEqualFunc = (a, b) => getters.every((getter) => getter(a) === getter(b));
     this.setItems(this.items);
+    this.requestUpdate();
   }
 
   setItems(items) {
     const selectedItem = this.getSelectedItem();
-    this.style.display = items?.length ? "initial" : "none";
+    this.style.display = items?.length ? "grid" : "none";
     this.contents.innerHTML = "";
     this.items = items;
     this._itemsBackLog = Array.from(items);
@@ -170,6 +208,23 @@ export class UIList extends UnlitElement {
       this.contents.appendChild(row);
       rowIndex++;
     }
+  }
+
+  _makeHeader() {
+    const header = document.createElement("div");
+    header.className = "header";
+
+    for (const colDesc of this.columnDescriptions) {
+      const cell = document.createElement("div");
+      cell.className = "text-cell-header " + colDesc.key;
+      if (colDesc.width) {
+        cell.style.width = colDesc.width;
+      }
+      const value = colDesc.title || colDesc.key;
+      cell.append(value);
+      header.appendChild(cell);
+    }
+    return header;
   }
 
   _clickHandler(event) {

--- a/src/fontra/client/web-components/ui-list.js
+++ b/src/fontra/client/web-components/ui-list.js
@@ -361,10 +361,7 @@ export class UIList extends UnlitElement {
   }
 
   _headerScrollHandler(event) {
-    if (
-      this.headerContainer &&
-      this.container.scrollLeft != this.headerContainer.scrollLeft
-    ) {
+    if (this.container.scrollLeft != this.headerContainer.scrollLeft) {
       this.container.scrollLeft = this.headerContainer.scrollLeft;
     }
     this._addMoreItemsIfNeeded();

--- a/src/fontra/client/web-components/ui-list.js
+++ b/src/fontra/client/web-components/ui-list.js
@@ -20,12 +20,15 @@ export class UIList extends UnlitElement {
       display: grid;  /* also set by code below */
       gap: 0.2em;
       min-height: 0;
+      min-width: 0;
       box-sizing: border-box;
+      overflow: hidden;
     }
 
     .container {
       overflow: scroll;
       height: 100%;
+      width: 100%;
       box-sizing: border-box;
       border: solid 1px var(--border-color);
     }
@@ -34,6 +37,18 @@ export class UIList extends UnlitElement {
       display: flex;
       flex-direction: column;
       outline: none;
+    }
+
+    .header-container::-webkit-scrollbar {
+      display: none;
+    }
+
+    .header-container {
+      overflow: scroll;
+      height: 100%;
+      width: 100%;
+      box-sizing: border-box;
+      scrollbar-width: none;  /* hide scrollbar in FireFox */
     }
 
     .header {
@@ -47,7 +62,7 @@ export class UIList extends UnlitElement {
       user-select: none;
     }
 
-    .contents > .row {
+    .row {
       display: flex;
       width: min-content;
       min-width: 100%;
@@ -66,7 +81,7 @@ export class UIList extends UnlitElement {
       background-color: var(--row-selected-background-color);
     }
 
-    .contents > .row > .text-cell {
+    .text-cell, .text-cell-header {
       overflow: hidden;
       text-overflow: ellipsis;
     }
@@ -206,13 +221,18 @@ export class UIList extends UnlitElement {
       }
 
       for (const colDesc of this.columnDescriptions) {
-        const cell = document.createElement("div");
-        cell.className = "text-cell " + colDesc.key;
-        if (colDesc.width) {
-          cell.style.width = colDesc.width;
+        let cell;
+        if (colDesc.cellFactory) {
+          cell = colDesc.cellFactory(item, colDesc);
+        } else {
+          cell = document.createElement("div");
+          cell.className = "text-cell " + colDesc.key;
+          if (colDesc.width) {
+            cell.style.width = colDesc.width;
+          }
+          const value = colDesc.get ? colDesc.get(item) : item[colDesc.key];
+          cell.append(value);
         }
-        const value = colDesc.get ? colDesc.get(item) : item[colDesc.key];
-        cell.append(value);
         row.appendChild(cell);
       }
 
@@ -222,8 +242,7 @@ export class UIList extends UnlitElement {
   }
 
   _makeHeader() {
-    const header = document.createElement("div");
-    header.className = "header";
+    const header = html.div({ class: "header" });
 
     for (const colDesc of this.columnDescriptions) {
       const cell = document.createElement("div");
@@ -235,7 +254,7 @@ export class UIList extends UnlitElement {
       cell.append(value);
       header.appendChild(cell);
     }
-    return header;
+    return html.div({ class: "header-container" }, [header]);
   }
 
   _clickHandler(event) {

--- a/src/fontra/client/web-components/ui-list.js
+++ b/src/fontra/client/web-components/ui-list.js
@@ -106,7 +106,10 @@ export class UIList extends UnlitElement {
       ondblclick: (event) => this._dblClickHandler(event),
       tabIndex: 1,
     });
-    this.contents.addEventListener(
+
+    this.container = html.div({ class: "container" }, [this.contents]);
+
+    this.container.addEventListener(
       "scroll",
       (event) => this._scrollHandler(event),
       false
@@ -130,7 +133,7 @@ export class UIList extends UnlitElement {
     if (this._showHeader) {
       contents.push(this._makeHeader());
     }
-    contents.push(html.div({ class: "container" }, [this.contents]));
+    contents.push(this.container);
     return contents;
   }
 
@@ -254,7 +257,13 @@ export class UIList extends UnlitElement {
       cell.append(value);
       header.appendChild(cell);
     }
-    return html.div({ class: "header-container" }, [header]);
+    this.headerContainer = html.div({ class: "header-container" }, [header]);
+    this.headerContainer.addEventListener(
+      "scroll",
+      (event) => this._headerScrollHandler(event),
+      false
+    );
+    return this.headerContainer;
   }
 
   _clickHandler(event) {
@@ -351,7 +360,23 @@ export class UIList extends UnlitElement {
     }
   }
 
+  _headerScrollHandler(event) {
+    if (
+      this.headerContainer &&
+      this.container.scrollLeft != this.headerContainer.scrollLeft
+    ) {
+      this.container.scrollLeft = this.headerContainer.scrollLeft;
+    }
+    this._addMoreItemsIfNeeded();
+  }
+
   _scrollHandler(event) {
+    if (
+      this.headerContainer &&
+      this.headerContainer.scrollLeft != this.container.scrollLeft
+    ) {
+      this.headerContainer.scrollLeft = this.container.scrollLeft;
+    }
     this._addMoreItemsIfNeeded();
   }
 }

--- a/src/fontra/client/web-components/ui-list.js
+++ b/src/fontra/client/web-components/ui-list.js
@@ -28,7 +28,9 @@ export class UIList extends UnlitElement {
 
     .contents > .row {
       display: flex;
-      width: content;
+      width: min-content;
+      min-width: 100%;
+      box-sizing: border-box;
       border-top: solid 1px var(--row-border-color);
       color: var(--row-foreground-color);
       background-color: var(--row-background-color);

--- a/src/fontra/client/web-components/ui-list.js
+++ b/src/fontra/client/web-components/ui-list.js
@@ -364,7 +364,6 @@ export class UIList extends UnlitElement {
     if (this.container.scrollLeft != this.headerContainer.scrollLeft) {
       this.container.scrollLeft = this.headerContainer.scrollLeft;
     }
-    this._addMoreItemsIfNeeded();
   }
 
   _scrollHandler(event) {

--- a/src/fontra/client/web-components/ui-list.js
+++ b/src/fontra/client/web-components/ui-list.js
@@ -44,7 +44,6 @@ export class UIList extends UnlitElement {
       padding: 0.15em;
       padding-left: 0.5em;
       padding-right: 0.5em;
-      cursor: pointer;
       user-select: none;
     }
 

--- a/src/fontra/client/web-components/ui-list.js
+++ b/src/fontra/client/web-components/ui-list.js
@@ -227,9 +227,12 @@ export class UIList extends UnlitElement {
       for (const colDesc of this.columnDescriptions) {
         let cell;
         if (colDesc.cellFactory) {
-          cell = html.div({ style: colDesc.width ? `width: ${colDesc.width};` : "" }, [
-            colDesc.cellFactory(item, colDesc),
-          ]);
+          cell = html.div(
+            {
+              style: colDesc.width ? `display: flex; width: ${colDesc.width};` : "",
+            },
+            [colDesc.cellFactory(item, colDesc)]
+          );
         } else {
           cell = document.createElement("div");
           cell.className = "text-cell " + colDesc.key;

--- a/src/fontra/client/web-components/ui-list.js
+++ b/src/fontra/client/web-components/ui-list.js
@@ -18,6 +18,7 @@ export class UIList extends UnlitElement {
 
     :host {
       display: grid;  /* also set by code below */
+      grid-template-rows: auto 1fr;
       gap: 0.2em;
       min-height: 0;
       min-width: 0;

--- a/src/fontra/client/web-components/ui-list.js
+++ b/src/fontra/client/web-components/ui-list.js
@@ -226,7 +226,9 @@ export class UIList extends UnlitElement {
       for (const colDesc of this.columnDescriptions) {
         let cell;
         if (colDesc.cellFactory) {
-          cell = colDesc.cellFactory(item, colDesc);
+          cell = html.div({ style: colDesc.width ? `width: ${colDesc.width};` : "" }, [
+            colDesc.cellFactory(item, colDesc),
+          ]);
         } else {
           cell = document.createElement("div");
           cell.className = "text-cell " + colDesc.key;

--- a/src/fontra/client/web-components/ui-list.js
+++ b/src/fontra/client/web-components/ui-list.js
@@ -33,6 +33,7 @@ export class UIList extends UnlitElement {
     .contents {
       display: flex;
       flex-direction: column;
+      outline: none;
     }
 
     .header {
@@ -75,8 +76,6 @@ export class UIList extends UnlitElement {
   constructor() {
     super();
 
-    this.tabIndex = "1";
-
     this._columnDescriptions = [
       {
         key: "default",
@@ -91,10 +90,23 @@ export class UIList extends UnlitElement {
       class: "contents",
       onclick: (event) => this._clickHandler(event),
       ondblclick: (event) => this._dblClickHandler(event),
+      tabIndex: 1,
     });
-    this.addEventListener("scroll", (event) => this._scrollHandler(event), false);
-    this.addEventListener("keydown", (event) => this._keyDownHandler(event), false);
-    this.addEventListener("keyup", (event) => this._keyUpHandler(event), false);
+    this.contents.addEventListener(
+      "scroll",
+      (event) => this._scrollHandler(event),
+      false
+    );
+    this.contents.addEventListener(
+      "keydown",
+      (event) => this._keyDownHandler(event),
+      false
+    );
+    this.contents.addEventListener(
+      "keyup",
+      (event) => this._keyUpHandler(event),
+      false
+    );
     this.selectedItemIndex = undefined;
     this.allowEmptySelection = true;
   }

--- a/src/fontra/client/web-components/ui-list.js
+++ b/src/fontra/client/web-components/ui-list.js
@@ -144,7 +144,6 @@ export class UIList extends UnlitElement {
 
   set showHeader(onOff) {
     this._showHeader = onOff;
-    this.setItems(this.items);
     this.requestUpdate();
   }
 

--- a/src/fontra/client/web-components/ui-list.js
+++ b/src/fontra/client/web-components/ui-list.js
@@ -17,7 +17,7 @@ export class UIList extends UnlitElement {
     ${themeColorCSS(colors)}
 
     :host {
-      /* display: grid; */  /* set by code below */
+      display: grid;  /* also set by code below */
       gap: 0.2em;
       min-height: 0;
       box-sizing: border-box;

--- a/src/fontra/views/editor/scene-controller.js
+++ b/src/fontra/views/editor/scene-controller.js
@@ -210,6 +210,7 @@ export class SceneController {
 
   setSelectedGlyphState(state) {
     this.sceneModel.setSelectedGlyphState(state);
+    this.sceneModel.updateBackgroundGlyphs();
     this.canvasController.requestUpdate();
     this.notifySelectedGlyphChanged();
   }
@@ -307,6 +308,7 @@ export class SceneController {
       this.canvasController.requestUpdate();
       this.notifySelectedGlyphChanged();
     }
+    this.sceneModel.updateBackgroundGlyphs();
   }
 
   get selectedGlyphIsEditing() {
@@ -319,6 +321,7 @@ export class SceneController {
       this.canvasController.requestUpdate();
       this._dispatchEvent("selectedGlyphIsEditingChanged");
     }
+    this.sceneModel.updateBackgroundGlyphs();
   }
 
   get selectionRect() {
@@ -336,7 +339,7 @@ export class SceneController {
 
   set backgroundLayers(layerNames) {
     this.sceneModel.backgroundLayers = layerNames;
-    this.sceneModel.updateScene();
+    this.sceneModel.updateBackgroundGlyphs();
     this.canvasController.requestUpdate();
   }
 
@@ -347,6 +350,7 @@ export class SceneController {
   async setGlyphLines(glyphLines) {
     await this.sceneModel.setGlyphLines(glyphLines);
     this.notifySelectedGlyphChanged();
+    this.sceneModel.updateBackgroundGlyphs();
     this.canvasController.requestUpdate();
   }
 

--- a/src/fontra/views/editor/scene-controller.js
+++ b/src/fontra/views/editor/scene-controller.js
@@ -330,6 +330,16 @@ export class SceneController {
     this.canvasController.requestUpdate();
   }
 
+  get backgroundLayers() {
+    return this.sceneModel.backgroundLayers || [];
+  }
+
+  set backgroundLayers(layerNames) {
+    this.sceneModel.backgroundLayers = layerNames;
+    this.sceneModel.updateScene();
+    this.canvasController.requestUpdate();
+  }
+
   getGlyphLines() {
     return this.sceneModel.getGlyphLines();
   }

--- a/src/fontra/views/editor/scene-model.js
+++ b/src/fontra/views/editor/scene-model.js
@@ -226,13 +226,7 @@ export class SceneModel {
     }
     for (const [layerName, sourceName] of Object.entries(this.backgroundLayers)) {
       const varGlyph = await this.fontController.getGlyph(glyphName);
-      let sourceIndex = 0;
-      let source;
-      for ([sourceIndex, source] of enumerate(varGlyph.sources)) {
-        if (source.name === sourceName) {
-          break;
-        }
-      }
+      let sourceIndex = varGlyph.getSourceIndexFromName(sourceName) || 0;
       const layerGlyph = await this.fontController.getLayerGlyphController(
         glyphName,
         layerName,

--- a/src/fontra/views/editor/scene-model.js
+++ b/src/fontra/views/editor/scene-model.js
@@ -9,7 +9,7 @@ import {
   unionRect,
 } from "../core/rectangle.js";
 import { pointInConvexPolygon, rectIntersectsPolygon } from "../core/convex-hull.js";
-import { parseSelection } from "../core/utils.js";
+import { enumerate, parseSelection } from "../core/utils.js";
 import { difference, isEqualSet, updateSet } from "../core/set-ops.js";
 
 export class SceneModel {
@@ -29,6 +29,7 @@ export class SceneModel {
     this.longestLineLength = 0;
     this.usedGlyphNames = new Set();
     this.cachedGlyphNames = new Set();
+    this.backgroundLayers = {};
   }
 
   getSelectedPositionedGlyph() {
@@ -217,7 +218,34 @@ export class SceneModel {
     );
   }
 
+  async updateBackgroundGlyphs() {
+    this.backgroundLayerGlyphs = [];
+    const glyphName = await this.getSelectedGlyphName();
+    if (!glyphName) {
+      return;
+    }
+    for (const [layerName, sourceName] of Object.entries(this.backgroundLayers)) {
+      const varGlyph = await this.fontController.getGlyph(glyphName);
+      let sourceIndex = 0;
+      let source;
+      for ([sourceIndex, source] of enumerate(varGlyph.sources)) {
+        if (source.name === sourceName) {
+          break;
+        }
+      }
+      const layerGlyph = await this.fontController.getLayerGlyphController(
+        glyphName,
+        layerName,
+        sourceIndex
+      );
+      if (layerGlyph) {
+        this.backgroundLayerGlyphs.push(layerGlyph);
+      }
+    }
+  }
+
   async updateScene() {
+    this.updateBackgroundGlyphs();
     [this.positionedLines, this.longestLineLength] = await buildScene(
       this.fontController,
       this.glyphLines,

--- a/src/fontra/views/editor/sidebar-designspace.js
+++ b/src/fontra/views/editor/sidebar-designspace.js
@@ -41,8 +41,8 @@ export class SidebarDesignspace {
     });
 
     const columnDescriptions = [
-      { key: "sourceName", width: "14em" },
-      // {"key": "sourceIndex", "width": "2em"},
+      { key: "name", width: "14em" },
+      // { get: (item) => (!item.inactive ? "off" : "on"), width: "2em" },
     ];
     this.sourcesList = document.querySelector("#sources-list");
     this.sourcesList.columnDescriptions = columnDescriptions;
@@ -90,7 +90,7 @@ export class SidebarDesignspace {
   _updateSources() {
     const sources = this.dataModel.varGlyphController?.sources || [];
     const sourceItems = sources.map((source) => {
-      return { sourceName: source.name };
+      return { ...source };
     });
     this.sourcesList.setItems(sourceItems);
     this.addRemoveSourceButtons.hidden = !sourceItems.length;

--- a/src/fontra/views/editor/sidebar-designspace.js
+++ b/src/fontra/views/editor/sidebar-designspace.js
@@ -41,10 +41,11 @@ export class SidebarDesignspace {
     });
 
     const columnDescriptions = [
-      { key: "name", width: "14em" },
-      // { get: (item) => (!item.inactive ? "off" : "on"), width: "2em" },
+      { key: "name", title: "Source name", width: "14em" },
+      { title: "on/off", get: (item) => (!item.inactive ? "off" : "on"), width: "2em" },
     ];
     this.sourcesList = document.querySelector("#sources-list");
+    this.sourcesList.showHeader = true;
     this.sourcesList.columnDescriptions = columnDescriptions;
 
     this.addRemoveSourceButtons = document.querySelector(

--- a/src/fontra/views/editor/sidebar-designspace.js
+++ b/src/fontra/views/editor/sidebar-designspace.js
@@ -45,13 +45,13 @@ export class SidebarDesignspace {
       {
         title: "on",
         get: (item) => !item.inactive,
-        cellFactory: sourceOnOffCheckBox,
+        cellFactory: checkboxListCell,
         width: "2em",
       },
       {
         title: "vis",
         get: (item) => item.visible,
-        cellFactory: sourceOnOffCheckBox,
+        cellFactory: checkboxListCell,
         width: "2em",
       },
     ];
@@ -568,7 +568,7 @@ function suggestedSourceNameFromLocation(location) {
   );
 }
 
-function sourceOnOffCheckBox(item, colDesc) {
+function checkboxListCell(item, colDesc) {
   const value = colDesc.get ? colDesc.get(item) : item[colDesc.key];
   return html.input({
     type: "checkbox",

--- a/src/fontra/views/editor/sidebar-designspace.js
+++ b/src/fontra/views/editor/sidebar-designspace.js
@@ -572,7 +572,7 @@ function sourceOnOffCheckBox(item, colDesc) {
   const value = colDesc.get ? colDesc.get(item) : item[colDesc.key];
   return html.input({
     type: "checkbox",
-    style: `width: auto; margin: 0; padding 0; outline: none;`,
+    style: `width: auto; margin: 0; padding: 0; outline: none;`,
     checked: value,
     onclick: (event) => {
       event.stopImmediatePropagation();

--- a/src/fontra/views/editor/sidebar-designspace.js
+++ b/src/fontra/views/editor/sidebar-designspace.js
@@ -100,19 +100,30 @@ export class SidebarDesignspace {
   }
 
   _updateSources() {
-    const sources = this.dataModel.varGlyphController?.sources || [];
+    const varGlyphController = this.dataModel.varGlyphController;
+    const sources = varGlyphController?.sources || [];
+    let backgroundLayers = { ...this.sceneController.backgroundLayers };
     const sourceItems = [];
     for (const [index, source] of enumerate(sources)) {
+      const layerName = source.layerName;
       const sourceController = new ObservableController({
         name: source.name,
         active: !source.inactive,
-        visible: false,
+        visible: backgroundLayers[layerName] === source.name,
       });
       sourceController.addKeyListener("active", async (key, newValue) => {
         await this.sceneController.editGlyphAndRecordChanges((glyph) => {
           glyph.sources[index].inactive = !newValue;
           return `${newValue ? "" : "de"}activate ${source.name}`;
         });
+      });
+      sourceController.addKeyListener("visible", async (key, newValue) => {
+        if (newValue) {
+          backgroundLayers[layerName] = source.name;
+        } else {
+          delete backgroundLayers[layerName];
+        }
+        this.sceneController.backgroundLayers = backgroundLayers;
       });
       sourceItems.push(sourceController.model);
     }

--- a/src/fontra/views/editor/sidebar-designspace.js
+++ b/src/fontra/views/editor/sidebar-designspace.js
@@ -106,6 +106,7 @@ export class SidebarDesignspace {
     });
     this.sourcesList.setItems(sourceItems);
     this.addRemoveSourceButtons.hidden = !sourceItems.length;
+    this.addRemoveSourceButtons.disableAddButton = !this.axisSliders.axes.length;
   }
 
   _updateSelectedSourceFromLocation() {

--- a/src/fontra/views/editor/sidebar-designspace.js
+++ b/src/fontra/views/editor/sidebar-designspace.js
@@ -49,7 +49,7 @@ export class SidebarDesignspace {
         width: "2em",
       },
       {
-        title: "vis",
+        title: "bg",
         key: "visible",
         cellFactory: checkboxListCell,
         width: "2em",

--- a/src/fontra/views/editor/sidebar-designspace.js
+++ b/src/fontra/views/editor/sidebar-designspace.js
@@ -42,7 +42,18 @@ export class SidebarDesignspace {
 
     const columnDescriptions = [
       { key: "name", title: "Source name", width: "14em" },
-      { title: "on/off", get: (item) => (!item.inactive ? "off" : "on"), width: "2em" },
+      {
+        title: "on",
+        get: (item) => !item.inactive,
+        cellFactory: sourceOnOffCheckBox,
+        width: "2em",
+      },
+      {
+        title: "vis",
+        get: (item) => item.visible,
+        cellFactory: sourceOnOffCheckBox,
+        width: "2em",
+      },
     ];
     this.sourcesList = document.querySelector("#sources-list");
     this.sourcesList.showHeader = true;
@@ -554,4 +565,19 @@ function suggestedSourceNameFromLocation(location) {
       })
       .join(",") || "default"
   );
+}
+
+function sourceOnOffCheckBox(item, colDesc) {
+  const value = colDesc.get ? colDesc.get(item) : item[colDesc.key];
+  return html.input({
+    type: "checkbox",
+    style: `width: auto; margin: 0; padding 0; outline: none;`,
+    checked: value,
+    onclick: (event) => {
+      event.stopImmediatePropagation();
+    },
+    ondblclick: (event) => {
+      event.stopImmediatePropagation();
+    },
+  });
 }

--- a/src/fontra/views/editor/visualization-layer-definitions.js
+++ b/src/fontra/views/editor/visualization-layer-definitions.js
@@ -737,6 +737,26 @@ registerVisualizationLayerDefinition({
 });
 
 registerVisualizationLayerDefinition({
+  identifier: "fontra.edit.background.layers",
+  name: "Background glyph layers",
+  selectionMode: "editing",
+  zIndex: 490,
+  screenParameters: {
+    strokeWidth: 1,
+  },
+  colors: { color: "#BBB" },
+  colorsDarkMode: { color: "#666" },
+  draw: (context, positionedGlyph, parameters, model, controller) => {
+    context.lineJoin = "round";
+    context.lineWidth = parameters.strokeWidth;
+    context.strokeStyle = parameters.color;
+    for (const layerGlyph of Object.values(model.backgroundLayerGlyphs || {})) {
+      context.stroke(layerGlyph.flattenedPath2d);
+    }
+  },
+});
+
+registerVisualizationLayerDefinition({
   identifier: "fontra.edit.path.under.stroke",
   name: "Underlying edit path stroke",
   selectionMode: "editing",


### PR DESCRIPTION
Towards implementing #431.

- Add support for custom cells in ui-list
- Add optional columns header to ui-list
- Adds source list column for the "on" flag (or rather, "inactive", inverted)
- Adds support for drawing arbitrary layers in the background
- Adds "visible in background" column for source list

TODO (as followup PRs):
- Replace generic checkboxes with icons?
- Rethink the source list column titles
- Different colors for background glyphs
- Alignment of background glyph relative to selected? (Thinking of left/center/right, based on metrics)
- Way to easily turn on/off many/all background glyphs?