### PR TITLE
Pin selected glyph to its horizontal center when the ds location changes

### DIFF
--- a/src/fontra/views/editor/scene-controller.js
+++ b/src/fontra/views/editor/scene-controller.js
@@ -372,7 +372,18 @@ export class SceneController {
   }
 
   async setLocation(values) {
+    const glyphXBefore = positionedGlyphCenterX(
+      this.sceneModel.getSelectedPositionedGlyph()
+    );
     await this.sceneModel.setLocation(values);
+    if (glyphXBefore !== undefined) {
+      const glyphXAfter = positionedGlyphCenterX(
+        this.sceneModel.getSelectedPositionedGlyph()
+      );
+      const originXDelta =
+        (glyphXAfter - glyphXBefore) * this.canvasController.magnification;
+      this.canvasController.origin.x -= originXDelta;
+    }
     this.canvasController.requestUpdate();
   }
 
@@ -753,4 +764,11 @@ function getSelectedContours(path, pointSelection) {
     selectedContours.add(path.getContourIndex(pointIndex));
   }
   return [...selectedContours];
+}
+
+function positionedGlyphCenterX(positionedGlyph) {
+  if (!positionedGlyph) {
+    return undefined;
+  }
+  return positionedGlyph.x + positionedGlyph.glyph.xAdvance / 2;
 }


### PR DESCRIPTION
Fixes #191 

This keeps the focused / selected / edited glyph better in view when playing around with the location sliders