### PR TITLE
Add isEmptyIsh glyph controller property

### DIFF
--- a/src/fontra/client/core/glyph-controller.js
+++ b/src/fontra/client/core/glyph-controller.js
@@ -337,6 +337,10 @@ export class StaticGlyphController {
     return getRepresentation(this, "controlBounds");
   }
 
+  get isEmptyIsh() {
+    return getRepresentation(this, "isEmptyIsh");
+  }
+
   get convexHull() {
     return getRepresentation(this, "convexHull");
   }
@@ -385,6 +389,19 @@ registerRepresentationFactory(StaticGlyphController, "componentsPath", (glyph) =
 
 registerRepresentationFactory(StaticGlyphController, "controlBounds", (glyph) => {
   return glyph.flattenedPath.getControlBounds();
+});
+
+registerRepresentationFactory(StaticGlyphController, "isEmptyIsh", (glyph) => {
+  let startPoint = 0;
+  for (const contour of glyph.flattenedPath.contourInfo) {
+    const endPoint = contour.endPoint;
+    if (endPoint - startPoint > 1) {
+      // If the contour has more than two points, we consider it not empty-ish
+      return false;
+    }
+    startPoint = endPoint + 1;
+  }
+  return true;
 });
 
 registerRepresentationFactory(StaticGlyphController, "convexHull", (glyph) => {

--- a/src/fontra/views/editor/scene-model.js
+++ b/src/fontra/views/editor/scene-model.js
@@ -638,7 +638,7 @@ async function buildScene(
     // Add bounding boxes
     positionedLine.glyphs.forEach((item) => {
       let bounds = item.glyph.controlBounds;
-      if (!bounds || isEmptyRect(bounds)) {
+      if (!bounds || isEmptyRect(bounds) || item.glyph.isEmptyIsh) {
         // Empty glyph, make up box based on advance so it can still be clickable/hoverable
         // TODO: use font's ascender/descender values
         // If the advance is very small, add a bit of extra space on both sides so it'll be


### PR DESCRIPTION
Add isEmptyIsh glyph controller property, so we can fall back to 'empty' selection behavior if the glyph contains points but is invisible nevertheless.

This fixes #423.