### PR TITLE
Fix wrong display string after creating new glyph.

### DIFF
--- a/src/fontra/client/web-components/ui-list.js
+++ b/src/fontra/client/web-components/ui-list.js
@@ -178,7 +178,7 @@ export class UIList extends UnlitElement {
     this.items = items;
     this._updateVisibility();
     this._itemsBackLog = Array.from(items);
-    this.setSelectedItem(selectedItem, true);
+    this.setSelectedItem(selectedItem, false);
     this._addMoreItemsIfNeeded();
   }
 

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -647,6 +647,9 @@ export class EditorController {
   }
 
   async glyphNameChangedCallback(glyphName) {
+    if (!glyphName) {
+      return;
+    }
     const codePoint = this.fontController.codePointForGlyph(glyphName);
     const glyphInfo = { glyphName: glyphName };
     if (codePoint !== undefined) {


### PR DESCRIPTION
What happened:
- UIList started to dispatch selection changed events if the items list was replaced
- this happens when you create a new glyph (the glyphs list changes after all)
- this triggered an even that made it behave as if the user clicked that glyph
- which would replace the new glyph that had just been created

Fixes #497.