### PR TITLE
[glyphs search] Search for hex equivalent of char in glyph name / display pseudo char in list

### DIFF
--- a/src/fontra/client/core/unlit.js
+++ b/src/fontra/client/core/unlit.js
@@ -4,6 +4,7 @@
 export class SimpleElement extends HTMLElement {
   constructor() {
     super();
+    this._additionalStyles = [];
     this.attachShadow({ mode: "open" });
     this._postInit();
   }
@@ -14,14 +15,21 @@ export class SimpleElement extends HTMLElement {
 
   _attachStyles() {
     if (this.constructor.styles) {
-      this.appendStyle(this.constructor.styles);
+      this._appendStyle(this.constructor.styles);
+    }
+    for (const style of this._additionalStyles) {
+      this._appendStyle(style);
     }
   }
 
-  appendStyle(cssText) {
+  _appendStyle(cssText) {
     const styleElement = document.createElement("style");
     styleElement.textContent = cssText;
     this.shadowRoot.appendChild(styleElement);
+  }
+
+  appendStyle(cssText) {
+    this._additionalStyles.push(cssText);
   }
 }
 

--- a/src/fontra/client/core/utils.js
+++ b/src/fontra/client/core/utils.js
@@ -274,9 +274,9 @@ export function getCharFromUnicode(codePoint) {
 }
 
 export function guessCharFromGlyphName(glyphName) {
-  // find a 4-6 char hex string in the glyph name. If 6, the first digit must be one.
-  // Interpret the hex string as a unicode code point and convert to a character.
-  // Else, return an empty string.
+  // Search for a 4-6 char hex string in the glyph name. If 6, the first digit must
+  // be one. Interpret the hex string as a unicode code point and convert to a
+  // character. Else, return an empty string.
   const match = glyphName.match(/(^|[^0-9A-F])(1?[0-9A-F]{4,5})($|[^0-9A-F])/);
   return match ? String.fromCodePoint(parseInt(match[2], 16)) : "";
 }

--- a/src/fontra/client/core/utils.js
+++ b/src/fontra/client/core/utils.js
@@ -273,6 +273,14 @@ export function getCharFromUnicode(codePoint) {
   return codePoint !== undefined ? String.fromCodePoint(codePoint) : "";
 }
 
+export function guessCharFromGlyphName(glyphName) {
+  // find a 4-6 char hex string in the glyph name. If 6, the first digit must be one.
+  // Interpret the hex string as a unicode code point and convert to a character.
+  // Else, return an empty string.
+  const match = glyphName.match(/(^|[^0-9A-F])(1?[0-9A-F]{4,5})($|[^0-9A-F])/);
+  return match ? String.fromCodePoint(parseInt(match[2], 16)) : "";
+}
+
 export async function fetchJSON(url) {
   const response = await fetch(url);
   return await response.json();

--- a/src/fontra/client/web-components/glyphs-search.js
+++ b/src/fontra/client/web-components/glyphs-search.js
@@ -1,6 +1,10 @@
 import * as html from "/core/unlit.js";
 import { UnlitElement } from "/core/unlit.js";
-import { getCharFromUnicode, makeUPlusStringFromCodePoint } from "/core/utils.js";
+import {
+  getCharFromUnicode,
+  guessCharFromGlyphName,
+  makeUPlusStringFromCodePoint,
+} from "/core/utils.js";
 import { themeColorCSS } from "./theme-support.js";
 import { UIList } from "./ui-list.js";
 
@@ -53,7 +57,13 @@ export class GlyphsSearch extends UnlitElement {
         key: "char",
         title: " ",
         width: "1.8em",
-        get: (item) => getCharFromUnicode(item.unicodes[0]),
+        cellFactory: (item, description) => {
+          if (item.unicodes[0]) {
+            return getCharFromUnicode(item.unicodes[0]);
+          }
+          const guessedChar = guessCharFromGlyphName(item.glyphName);
+          return guessedChar ? html.span({ style: "color: #999;" }, [guessedChar]) : "";
+        },
       },
       { key: "glyphName", title: "glyph name", width: "10em", isIdentifierKey: true },
       {

--- a/src/fontra/client/web-components/glyphs-search.js
+++ b/src/fontra/client/web-components/glyphs-search.js
@@ -138,6 +138,13 @@ export class GlyphsSearch extends UnlitElement {
   _searchFieldChanged(event) {
     const value = event.target.value;
     const searchItems = value.split(/\s+/).filter((item) => item.length);
+    const hexSearchItems = searchItems
+      .filter(
+        (item) =>
+          item.length === 1 || (item.length === 2 && item.codePointAt(0) > 0xffff)
+      )
+      .map((item) => item.codePointAt(0).toString(16).toUpperCase().padStart(4, "0"));
+    searchItems.push(...hexSearchItems);
     this._glyphNamesListFilterFunc = (item) => glyphFilterFunc(item, searchItems);
     this._setFilteredGlyphNamesListContent();
   }

--- a/src/fontra/client/web-components/glyphs-search.js
+++ b/src/fontra/client/web-components/glyphs-search.js
@@ -139,10 +139,7 @@ export class GlyphsSearch extends UnlitElement {
     const value = event.target.value;
     const searchItems = value.split(/\s+/).filter((item) => item.length);
     const hexSearchItems = searchItems
-      .filter(
-        (item) =>
-          item.length === 1 || (item.length === 2 && item.codePointAt(0) > 0xffff)
-      )
+      .filter((item) => [...item].length === 1) // num chars, not utf16 units!
       .map((item) => item.codePointAt(0).toString(16).toUpperCase().padStart(4, "0"));
     searchItems.push(...hexSearchItems);
     this._glyphNamesListFilterFunc = (item) => glyphFilterFunc(item, searchItems);

--- a/src/fontra/client/web-components/glyphs-search.js
+++ b/src/fontra/client/web-components/glyphs-search.js
@@ -62,7 +62,7 @@ export class GlyphsSearch extends UnlitElement {
             return getCharFromUnicode(item.unicodes[0]);
           }
           const guessedChar = guessCharFromGlyphName(item.glyphName);
-          return guessedChar ? html.span({ style: "color: #999;" }, [guessedChar]) : "";
+          return guessedChar ? html.span({ class: "guessed-char" }, [guessedChar]) : "";
         },
       },
       { key: "glyphName", title: "glyph name", width: "10em", isIdentifierKey: true },
@@ -73,6 +73,11 @@ export class GlyphsSearch extends UnlitElement {
       },
     ];
     this.glyphNamesList = new UIList();
+    this.glyphNamesList.appendStyle(`
+      .guessed-char {
+        color: #999;
+      }
+    `);
     this.glyphNamesList.columnDescriptions = columnDescriptions;
 
     this.glyphNamesList.addEventListener("listSelectionChanged", () => {


### PR DESCRIPTION
This implements two things:

1. If a character is entered in the search field, also search for the hex value of the code point as if it were entered as a search string. For example when entering "口" (U+53E3) in the search field, we also show results as if we'd be searching for the string 53E3, so we'd catch VG_53E3_00 in addition to the encoded uni53E3 character.
2. Parse any unencoded glyph name, and show a matching character if 4-6 char uppercase hex string is present in the glyph name, but in a dimmed color to show it is not a "real" encoded glyph.

Contrary to what I wrote in #499, this assumes hex uppercase in the glyph names, in an attempt to avoid false positives.

Fixes #499.