### PR TITLE
Work around and fix some datasize-related problems

### DIFF
--- a/src/fontra/client/core/utils.js
+++ b/src/fontra/client/core/utils.js
@@ -312,3 +312,11 @@ function findNestedActiveElement(element) {
 export function fileNameExtension(name) {
   return name.split(".").pop();
 }
+
+const ARRAY_EXTEND_CHUNK_SIZE = 1024;
+
+export function arrayExtend(thisArray, itemsArray) {
+  for (const i of range(0, itemsArray.length, ARRAY_EXTEND_CHUNK_SIZE)) {
+    thisArray.push(...itemsArray.slice(i, i + ARRAY_EXTEND_CHUNK_SIZE));
+  }
+}

--- a/src/fontra/client/core/var-path.js
+++ b/src/fontra/client/core/var-path.js
@@ -2,7 +2,7 @@ import VarArray from "./var-array.js";
 import { VariationError } from "./errors.js";
 import { centeredRect, pointInRect } from "./rectangle.js";
 import { convexHull } from "./convex-hull.js";
-import { enumerate, range } from "./utils.js";
+import { arrayExtend, enumerate, range } from "./utils.js";
 
 export const POINT_TYPE_OFF_CURVE_QUAD = "quad";
 export const POINT_TYPE_OFF_CURVE_CUBIC = "cubic";
@@ -211,13 +211,14 @@ export class VarPackedPath {
   }
 
   appendPath(path) {
-    this.coordinates.push(...path.coordinates);
-    this.pointTypes.push(...path.pointTypes);
+    arrayExtend(this.coordinates, path.coordinates);
+    arrayExtend(this.pointTypes, path.pointTypes);
     const endPointOffset = this.contourInfo.length
       ? this.contourInfo.at(-1).endPoint + 1
       : 0;
-    this.contourInfo.push(
-      ...path.contourInfo.map((contour) => {
+    arrayExtend(
+      this.contourInfo,
+      path.contourInfo.map((contour) => {
         return {
           endPoint: contour.endPoint + endPointOffset,
           isClosed: contour.isClosed,

--- a/src/fontra/core/remote.py
+++ b/src/fontra/core/remote.py
@@ -43,7 +43,17 @@ class RemoteObjectConnection:
     async def _handleConnection(self):
         tasks = []
         async for message in self.websocket:
-            message = message.json()
+            try:
+                message = message.json()
+            except TypeError:
+                # This may be a bug in aiohttp: message.data contains
+                # an exception. Let's raise it, as it's more informative
+                # than the TypeError
+                if isinstance(message.data, Exception):
+                    raise message.data
+                else:
+                    raise
+
             if message.get("connection") == "close":
                 logger.info("client requested connection close")
                 break

--- a/src/fontra/core/remote.py
+++ b/src/fontra/core/remote.py
@@ -49,6 +49,7 @@ class RemoteObjectConnection:
                 # This may be a bug in aiohttp: message.data contains
                 # an exception. Let's raise it, as it's more informative
                 # than the TypeError
+                # https://github.com/aio-libs/aiohttp/issues/7313
                 if isinstance(message.data, Exception):
                     raise message.data
                 else:

--- a/src/fontra/core/server.py
+++ b/src/fontra/core/server.py
@@ -125,7 +125,7 @@ class FontraServer:
         cookies = {k: v.value for k, v in cookies.items()}
         token = cookies.get("fontra-authorization-token")
 
-        websocket = web.WebSocketResponse(heartbeat=55)
+        websocket = web.WebSocketResponse(heartbeat=55, max_msg_size=0x2000000)
         await websocket.prepare(request)
         self._activeWebsockets.add(websocket)
         try:


### PR DESCRIPTION
- Use new `arrayExtend()` util instead of `array.push(...items)`, as the latter can overflow the JS call stack
- Increase the size limit for websocket messages
- Raise a better error if the size limit is exceeded

Fixes #507.