### PR TITLE
Protect against infinite component recursion

### DIFF
--- a/src/fontra/client/core/font-controller.js
+++ b/src/fontra/client/core/font-controller.js
@@ -342,19 +342,37 @@ export class FontController {
     return cachedPattern;
   }
 
-  *iterGlyphMadeOf(glyphName) {
+  *iterGlyphMadeOf(glyphName, seenGlyphNames = null) {
+    if (!seenGlyphNames) {
+      seenGlyphNames = new Set();
+    } else if (seenGlyphNames.has(glyphName)) {
+      return;
+    }
+    seenGlyphNames.add(glyphName);
     for (const dependantGlyphName of this.glyphMadeOf[glyphName] || []) {
       yield dependantGlyphName;
-      for (const deeperGlyphName of this.iterGlyphMadeOf(dependantGlyphName)) {
+      for (const deeperGlyphName of this.iterGlyphMadeOf(
+        dependantGlyphName,
+        seenGlyphNames
+      )) {
         yield deeperGlyphName;
       }
     }
   }
 
-  *iterGlyphUsedBy(glyphName) {
+  *iterGlyphUsedBy(glyphName, seenGlyphNames = null) {
+    if (!seenGlyphNames) {
+      seenGlyphNames = new Set();
+    } else if (seenGlyphNames.has(glyphName)) {
+      return;
+    }
+    seenGlyphNames.add(glyphName);
     for (const dependantGlyphName of this.glyphUsedBy[glyphName] || []) {
       yield dependantGlyphName;
-      for (const deeperGlyphName of this.iterGlyphUsedBy(dependantGlyphName)) {
+      for (const deeperGlyphName of this.iterGlyphUsedBy(
+        dependantGlyphName,
+        seenGlyphNames
+      )) {
         yield deeperGlyphName;
       }
     }

--- a/src/fontra/client/core/glyph-controller.js
+++ b/src/fontra/client/core/glyph-controller.js
@@ -485,8 +485,17 @@ async function getNestedComponentPaths(
   compo,
   getGlyphFunc,
   parentLocation,
-  transformation = null
+  transformation = null,
+  seenGlyphNames = null
 ) {
+  if (!seenGlyphNames) {
+    seenGlyphNames = new Set();
+  } else if (seenGlyphNames.has(compo.name)) {
+    // infinite recursion, let's not
+    return {};
+  }
+  seenGlyphNames.add(compo.name);
+
   const compoLocation = mergeLocations(parentLocation, compo.location) || {};
   const glyph = await getGlyphFunc(compo.name);
   let inst;
@@ -519,7 +528,8 @@ async function getNestedComponentPaths(
     inst.components,
     getGlyphFunc,
     compoLocation,
-    t
+    t,
+    seenGlyphNames
   );
   return componentPaths;
 }
@@ -528,13 +538,20 @@ async function getComponentPaths(
   components,
   getGlyphFunc,
   parentLocation,
-  transformation = null
+  transformation,
+  seenGlyphNames
 ) {
   const paths = [];
 
   for (const compo of components || []) {
     paths.push(
-      await getNestedComponentPaths(compo, getGlyphFunc, parentLocation, transformation)
+      await getNestedComponentPaths(
+        compo,
+        getGlyphFunc,
+        parentLocation,
+        transformation,
+        seenGlyphNames
+      )
     );
   }
   return paths;


### PR DESCRIPTION
Protect against infinite recursion by keeping track of which glyph names we've already seen.

Fixes #509.