### PR TITLE
Refactor component path

### DIFF
--- a/src/fontra/client/core/glyph-controller.js
+++ b/src/fontra/client/core/glyph-controller.js
@@ -449,7 +449,7 @@ class ComponentController {
   }
 
   async setupPath(getGlyphFunc, parentLocation) {
-    this.path = await getComponentPath(this.compo, getGlyphFunc, parentLocation);
+    this.path = await flattenComponent(this.compo, getGlyphFunc, parentLocation);
   }
 
   get path2d() {
@@ -475,7 +475,7 @@ class ComponentController {
   }
 }
 
-async function getComponentPath(compo, getGlyphFunc, parentLocation) {
+async function flattenComponent(compo, getGlyphFunc, parentLocation) {
   return await joinPathsAsync(
     iterFlattenedComponentPaths(compo, getGlyphFunc, parentLocation)
   );

--- a/src/fontra/client/core/var-path.js
+++ b/src/fontra/client/core/var-path.js
@@ -923,17 +923,18 @@ function coordinatesToPoints(coordinates) {
   return points;
 }
 
-export function joinPaths(paths) {
+export function joinPaths(pathsIterable) {
   const result = new VarPackedPath();
-  for (const path of paths) {
+  for (const path of pathsIterable) {
     result.appendPath(path);
   }
   return result;
 }
 
-export async function joinPathsAsync(paths) {
+export async function joinPathsAsync(pathsIterable) {
+  // This is the same as joinPaths, except it takes an async iterable
   const result = new VarPackedPath();
-  for await (const path of paths) {
+  for await (const path of pathsIterable) {
     result.appendPath(path);
   }
   return result;

--- a/src/fontra/client/core/var-path.js
+++ b/src/fontra/client/core/var-path.js
@@ -924,8 +924,9 @@ function coordinatesToPoints(coordinates) {
 }
 
 export function joinPaths(paths) {
-  if (paths.length) {
-    return paths.reduce((p1, p2) => p1.concat(p2));
+  const result = new VarPackedPath();
+  for (const path of paths) {
+    result.appendPath(path);
   }
-  return new VarPackedPath();
+  return result;
 }

--- a/src/fontra/client/core/var-path.js
+++ b/src/fontra/client/core/var-path.js
@@ -930,3 +930,11 @@ export function joinPaths(paths) {
   }
   return result;
 }
+
+export async function joinPathsAsync(paths) {
+  const result = new VarPackedPath();
+  for await (const path of paths) {
+    result.appendPath(path);
+  }
+  return result;
+}

--- a/test-js/test-var-path.js
+++ b/test-js/test-var-path.js
@@ -6,6 +6,7 @@ import {
   POINT_TYPE_OFF_CURVE_QUAD,
   VarPackedPath,
   joinPaths,
+  joinPathsAsync,
 } from "../src/fontra/client/core/var-path.js";
 import VarArray from "../src/fontra/client/core/var-array.js";
 import { Transform } from "../src/fontra/client/core/transform.js";
@@ -1223,5 +1224,35 @@ describe("VarPackedPath Tests", () => {
   it("test joinPaths empty path", () => {
     const p3 = joinPaths([]);
     expect(p3.unpackedContours()).to.deep.equal([]);
+  });
+
+  it("test joinPathsAsync", async () => {
+    const p1 = simpleTestPath();
+    const p2 = simpleTestPath().transformed(new Transform(1, 0, 0, 1, 20, 50));
+    async function* genPaths() {
+      yield p1;
+      yield p2;
+    }
+    const p3 = await joinPathsAsync(genPaths());
+    expect(p3.unpackedContours()).to.deep.equal([
+      {
+        points: [
+          { x: 0, y: 0 },
+          { x: 0, y: 100 },
+          { x: 100, y: 100 },
+          { x: 100, y: 0 },
+        ],
+        isClosed: true,
+      },
+      {
+        points: [
+          { x: 20, y: 50 },
+          { x: 20, y: 150 },
+          { x: 120, y: 150 },
+          { x: 120, y: 50 },
+        ],
+        isClosed: true,
+      },
+    ]);
   });
 });

--- a/test-js/test-var-path.js
+++ b/test-js/test-var-path.js
@@ -5,6 +5,7 @@ import {
   POINT_TYPE_OFF_CURVE_CUBIC,
   POINT_TYPE_OFF_CURVE_QUAD,
   VarPackedPath,
+  joinPaths,
 } from "../src/fontra/client/core/var-path.js";
 import VarArray from "../src/fontra/client/core/var-array.js";
 import { Transform } from "../src/fontra/client/core/transform.js";
@@ -1172,6 +1173,32 @@ describe("VarPackedPath Tests", () => {
     const p2 = simpleTestPath().transformed(new Transform(1, 0, 0, 1, 20, 50));
     p1.appendPath(p2);
     expect(p1.unpackedContours()).to.deep.equal([
+      {
+        points: [
+          { x: 0, y: 0 },
+          { x: 0, y: 100 },
+          { x: 100, y: 100 },
+          { x: 100, y: 0 },
+        ],
+        isClosed: true,
+      },
+      {
+        points: [
+          { x: 20, y: 50 },
+          { x: 20, y: 150 },
+          { x: 120, y: 150 },
+          { x: 120, y: 50 },
+        ],
+        isClosed: true,
+      },
+    ]);
+  });
+
+  it("test joinPaths", () => {
+    const p1 = simpleTestPath();
+    const p2 = simpleTestPath().transformed(new Transform(1, 0, 0, 1, 20, 50));
+    const p3 = joinPaths([p1, p2]);
+    expect(p3.unpackedContours()).to.deep.equal([
       {
         points: [
           { x: 0, y: 0 },

--- a/test-js/test-var-path.js
+++ b/test-js/test-var-path.js
@@ -1219,4 +1219,9 @@ describe("VarPackedPath Tests", () => {
       },
     ]);
   });
+
+  it("test joinPaths empty path", () => {
+    const p3 = joinPaths([]);
+    expect(p3.unpackedContours()).to.deep.equal([]);
+  });
 });


### PR DESCRIPTION
The code to compute the flattened path for a component was overly complicated. This simplifies it somewhat.