### PR TITLE
Refine selecting components

### DIFF
--- a/src/fontra/client/core/glyph-controller.js
+++ b/src/fontra/client/core/glyph-controller.js
@@ -1,5 +1,6 @@
-import { simplePolygonArea } from "./convex-hull.js";
+import { rectIntersectsPolygon, simplePolygonArea } from "./convex-hull.js";
 import { PathHitTester } from "./path-hit-tester.js";
+import { sectRect } from "./rectangle.js";
 import {
   getRepresentation,
   registerRepresentationFactory,
@@ -472,6 +473,31 @@ class ComponentController {
       this._convexHull = this.path.getConvexHull();
     }
     return this._convexHull;
+  }
+
+  get unpackedContours() {
+    if (this._unpackedContours === undefined) {
+      const unpackedContours = [];
+      for (let i = 0; i < this.path.numContours; i++) {
+        const contour = this.path.getUnpackedContour(i);
+        contour.controlBounds = this.path.getControlBoundsForContour(i);
+        unpackedContours.push(contour);
+      }
+      this._unpackedContours = unpackedContours;
+    }
+    return this._unpackedContours;
+  }
+
+  intersectsRect(rect) {
+    return (
+      sectRect(rect, this.controlBounds) &&
+      rectIntersectsPolygon(rect, this.convexHull) &&
+      this.unpackedContours.some(
+        (contour) =>
+          sectRect(rect, contour.controlBounds) &&
+          rectIntersectsPolygon(rect, contour.points)
+      )
+    );
   }
 }
 

--- a/src/fontra/views/editor/scene-model.js
+++ b/src/fontra/views/editor/scene-model.js
@@ -376,11 +376,7 @@ export class SceneModel {
       }
       if (
         pointInRect(x, y, component.controlBounds) &&
-        pointInConvexPolygon(x, y, component.convexHull)
-        // The following refines component hit detection further,
-        // but I'm not sure I like it, as then you can no longer
-        // click inside a counter
-        // && this.isPointInPath(component.path2d, x, y)
+        this.isPointInPath(component.path2d, x, y)
       ) {
         componentHullMatches.push({ index: i, component: component });
       }

--- a/src/fontra/views/editor/scene-model.js
+++ b/src/fontra/views/editor/scene-model.js
@@ -377,6 +377,10 @@ export class SceneModel {
       if (
         pointInRect(x, y, component.controlBounds) &&
         pointInConvexPolygon(x, y, component.convexHull)
+        // The following refines component hit detection further,
+        // but I'm not sure I like it, as then you can no longer
+        // click inside a counter
+        // && this.isPointInPath(component.path2d, x, y)
       ) {
         componentHullMatches.push({ index: i, component: component });
       }
@@ -410,10 +414,7 @@ export class SceneModel {
     }
     const components = positionedGlyph.glyph.components;
     for (let i = 0; i < components.length; i++) {
-      if (
-        sectRect(selRect, components[i].controlBounds) &&
-        rectIntersectsPolygon(selRect, components[i].convexHull)
-      ) {
+      if (components[i].intersectsRect(selRect)) {
         selection.add(`component/${i}`);
       }
     }


### PR DESCRIPTION
- Click-select component: require the user to click on the actual shape
- Rect-select component: don't use the convex hull, but use the contour control polygons

Doing proper rect-shape intersection requires more work to implement and will be slower. Could still be a future refinement, via beziers.js, which implements line-curve intersection.

Fixes #524.