### PR TITLE
Remove redundant sign() function, use Math.sign() instead

### DIFF
--- a/src/fontra/client/core/utils.js
+++ b/src/fontra/client/core/utils.js
@@ -114,16 +114,6 @@ export function modulo(v, n) {
   return v >= 0 ? v % n : ((v % n) + n) % n;
 }
 
-export function sign(v) {
-  if (v > 0) {
-    return 1;
-  } else if (v < 0) {
-    return -1;
-  } else {
-    return 0;
-  }
-}
-
 export function boolInt(v) {
   // Return 1 if `v` is true-y, 0 if `v` is false-y
   return v ? 1 : 0;

--- a/src/fontra/client/core/var-model.js
+++ b/src/fontra/client/core/var-model.js
@@ -237,7 +237,7 @@ function getDecoratedMasterLocations(locations, axisOrder) {
         return index != -1 ? index : 0x10000;
       }), // Next, by known axes
       orderedAxes, // Next, by all axes
-      orderedAxes.map((axis) => sign(loc[axis])), // Next, by signs of axis values
+      orderedAxes.map((axis) => Math.sign(loc[axis])), // Next, by signs of axis values
       orderedAxes.map((axis) => Math.abs(loc[axis])), // Next, by absolute value of axis values
     ];
     result[i] = [deco, locations[i]];
@@ -260,10 +260,6 @@ function objectGet(o, k, dflt) {
     return dflt;
   }
   return result;
-}
-
-function sign(v) {
-  return v < 0 ? -1 : v > 0 ? 1 : 0;
 }
 
 function sorted(a) {

--- a/src/fontra/views/editor/edit-behavior.js
+++ b/src/fontra/views/editor/edit-behavior.js
@@ -1,6 +1,6 @@
 import { polygonIsConvex } from "../core/convex-hull.js";
 import { consolidateChanges } from "../core/changes.js";
-import { makeAffineTransform, parseSelection, reversed, sign } from "../core/utils.js";
+import { makeAffineTransform, parseSelection, reversed } from "../core/utils.js";
 import { Transform } from "../core/transform.js";
 import * as vector from "../core/vector.js";
 import {
@@ -570,8 +570,8 @@ export function constrainHorVerDiag(vector) {
   if (0.414 < tan && tan < 2.414) {
     // between 22.5 and 67.5 degrees
     const d = 0.5 * (ax + ay);
-    constrainedVector.x = d * sign(constrainedVector.x);
-    constrainedVector.y = d * sign(constrainedVector.y);
+    constrainedVector.x = d * Math.sign(constrainedVector.x);
+    constrainedVector.y = d * Math.sign(constrainedVector.y);
   } else if (ax > ay) {
     constrainedVector.y = 0;
   } else {


### PR DESCRIPTION
As commented in https://github.com/googlefonts/fontra/issues/510#issuecomment-1585600740, we can just use `Math.sign()`, there's no need for our own implementation(s).