### PR TITLE
Rework point selection

### DIFF
--- a/src/fontra/client/core/utils.js
+++ b/src/fontra/client/core/utils.js
@@ -97,7 +97,10 @@ export function hyphenatedToCamelCase(s) {
 // and the control key ("ctrlKey") on non-macOS. For example short cuts
 // and selection behavior.
 export const commandKeyProperty =
-  navigator.platform.toLowerCase().indexOf("mac") >= 0 ? "metaKey" : "ctrlKey";
+  typeof navigator !== "undefined" &&
+  navigator.platform.toLowerCase().indexOf("mac") >= 0
+    ? "metaKey"
+    : "ctrlKey";
 
 export const arrowKeyDeltas = {
   ArrowUp: [0, 1],

--- a/src/fontra/client/core/utils.js
+++ b/src/fontra/client/core/utils.js
@@ -93,13 +93,11 @@ export function hyphenatedToCamelCase(s) {
   return s.replace(/-([a-z])/g, (m) => m[1].toUpperCase());
 }
 
-export function hasShortcutModifierKey(event) {
-  if (navigator.platform.toLowerCase().indexOf("mac") >= 0) {
-    return event.metaKey;
-  } else {
-    return event.ctrlKey;
-  }
-}
+// For several functions, we use the command key ("metaKey") on macOS,
+// and the control key ("ctrlKey") on non-macOS. For example short cuts
+// and selection behavior.
+export const commandKeyProperty =
+  navigator.platform.toLowerCase().indexOf("mac") >= 0 ? "metaKey" : "ctrlKey";
 
 export const arrowKeyDeltas = {
   ArrowUp: [0, 1],

--- a/src/fontra/views/editor/edit-tools-pointer.js
+++ b/src/fontra/views/editor/edit-tools-pointer.js
@@ -5,6 +5,7 @@ import { centeredRect, normalizeRect, offsetRect } from "../core/rectangle.js";
 import { difference, isSuperset, symmetricDifference, union } from "../core/set-ops.js";
 import {
   boolInt,
+  commandKeyProperty,
   makeUPlusStringFromCodePoint,
   modulo,
   parseSelection,
@@ -393,10 +394,10 @@ function replace(setA, setB) {
 
 function getSelectModeFunction(event) {
   return event.shiftKey
-    ? event.altKey
+    ? event[commandKeyProperty]
       ? difference
       : symmetricDifference
-    : event.altKey
+    : event[commandKeyProperty]
     ? union
     : replace;
 }

--- a/src/fontra/views/editor/edit-tools-pointer.js
+++ b/src/fontra/views/editor/edit-tools-pointer.js
@@ -252,7 +252,10 @@ export class PointerTool extends BaseTool {
         xMax: currentPoint.x,
         yMax: currentPoint.y,
       });
-      const selection = this.sceneModel.selectionAtRect(selRect);
+      const selection = this.sceneModel.selectionAtRect(
+        selRect,
+        event.altKey ? (point) => !!point.type : (point) => !point.type
+      );
       const positionedGlyph = this.sceneModel.getSelectedPositionedGlyph();
       sceneController.selectionRect = offsetRect(
         selRect,

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -20,10 +20,10 @@ import { StaticGlyph } from "../core/var-glyph.js";
 import { addItemwise, subItemwise, mulScalar } from "../core/var-funcs.js";
 import { VarPackedPath, joinPaths } from "../core/var-path.js";
 import {
+  commandKeyProperty,
   enumerate,
   fetchJSON,
   getCharFromUnicode,
-  hasShortcutModifierKey,
   hyphenatedToCamelCase,
   isActiveElementTypeable,
   parseSelection,
@@ -988,7 +988,7 @@ export class EditorController {
       }
       if (
         handlerDef.metaKey !== undefined &&
-        handlerDef.metaKey !== hasShortcutModifierKey(event)
+        handlerDef.metaKey !== event[commandKeyProperty]
       ) {
         continue;
       }

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -1335,7 +1335,7 @@ export class EditorController {
       const glyphComponents = positionedGlyph.glyph.components;
 
       for (const [pointIndex, pointType] of enumerate(glyphPath.pointTypes)) {
-        if (!(pointType & VarPackedPath.POINT_TYPE_MASK)) {
+        if ((pointType & VarPackedPath.POINT_TYPE_MASK) === VarPackedPath.ON_CURVE) {
           newSelection.add(`point/${pointIndex}`);
         }
       }

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -18,8 +18,9 @@ import { getRemoteProxy } from "../core/remote.js";
 import { SceneView } from "../core/scene-view.js";
 import { StaticGlyph } from "../core/var-glyph.js";
 import { addItemwise, subItemwise, mulScalar } from "../core/var-funcs.js";
-import { joinPaths } from "../core/var-path.js";
+import { VarPackedPath, joinPaths } from "../core/var-path.js";
 import {
+  enumerate,
   fetchJSON,
   getCharFromUnicode,
   hasShortcutModifierKey,
@@ -1333,8 +1334,10 @@ export class EditorController {
       const glyphPath = positionedGlyph.glyph.path;
       const glyphComponents = positionedGlyph.glyph.components;
 
-      for (const [pointIndex] of glyphPath.pointTypes.entries()) {
-        newSelection.add(`point/${pointIndex}`);
+      for (const [pointIndex, pointType] of enumerate(glyphPath.pointTypes)) {
+        if (!(pointType & VarPackedPath.POINT_TYPE_MASK)) {
+          newSelection.add(`point/${pointIndex}`);
+        }
       }
 
       for (const [componentIndex] of glyphComponents.entries()) {

--- a/src/fontra/views/editor/scene-controller.js
+++ b/src/fontra/views/editor/scene-controller.js
@@ -7,7 +7,7 @@ import { packContour } from "../core/var-path.js";
 import { lenientIsEqualSet, isSuperset } from "../core/set-ops.js";
 import {
   arrowKeyDeltas,
-  hasShortcutModifierKey,
+  commandKeyProperty,
   parseSelection,
   reversed,
 } from "../core/utils.js";
@@ -70,10 +70,7 @@ export class SceneController {
   }
 
   handleKeyDown(event) {
-    if (
-      (!hasShortcutModifierKey(event) || event.shiftKey) &&
-      event.key in arrowKeyDeltas
-    ) {
+    if ((!event[commandKeyProperty] || event.shiftKey) && event.key in arrowKeyDeltas) {
       this.handleArrowKeys(event);
       event.preventDefault();
       return;

--- a/src/fontra/views/editor/scene-model.js
+++ b/src/fontra/views/editor/scene-model.js
@@ -398,7 +398,7 @@ export class SceneModel {
     return new Set([`component/${componentHullMatches[0].index}`]);
   }
 
-  selectionAtRect(selRect) {
+  selectionAtRect(selRect, pointFilterFunc) {
     const selection = new Set();
     if (!this.selectedGlyph || !this.selectedGlyphIsEditing) {
       return selection;
@@ -406,7 +406,9 @@ export class SceneModel {
     const positionedGlyph = this.getSelectedPositionedGlyph();
     selRect = offsetRect(selRect, -positionedGlyph.x, -positionedGlyph.y);
     for (const hit of positionedGlyph.glyph.path.iterPointsInRect(selRect)) {
-      selection.add(`point/${hit.pointIndex}`);
+      if (!pointFilterFunc || pointFilterFunc(hit)) {
+        selection.add(`point/${hit.pointIndex}`);
+      }
     }
     const components = positionedGlyph.glyph.components;
     for (let i = 0; i < components.length; i++) {

--- a/src/fontra/views/editor/scene-model.js
+++ b/src/fontra/views/editor/scene-model.js
@@ -324,7 +324,10 @@ export class SceneModel {
     const pathHit = this.pathHitAtPoint(point, size);
     if (pathHit.contourIndex !== undefined) {
       const selection = new Set(
-        pathHit.segment.parentPointIndices.map((i) => `point/${i}`)
+        [
+          pathHit.segment.parentPointIndices[0],
+          pathHit.segment.parentPointIndices.at(-1),
+        ].map((i) => `point/${i}`)
       );
       return { selection, pathHit };
     }


### PR DESCRIPTION
Fixes #511 and fixes #512

- [x] Select all will only select on-curve points
- [x] Rect-select will only select on-curve points, or only off-curve points if the alt-key is held
- [x] Segment-click will only select the anchors
- [x] "Add to selection" modifier will become the command key (control on non-macOS)