### PR TITLE
Add doc string to arrayExtend() to explain its existence

### DIFF
--- a/src/fontra/client/core/utils.js
+++ b/src/fontra/client/core/utils.js
@@ -307,6 +307,12 @@ export function fileNameExtension(name) {
 const ARRAY_EXTEND_CHUNK_SIZE = 1024;
 
 export function arrayExtend(thisArray, itemsArray) {
+  // arrayExtend() is meant as a JS version of Python's list.extend().
+  // array.push(...items) has an implementation-defined upper limit
+  // in terms of numbers of items (the call stack will overflow).
+  // Yet, array.push(...items) is presumably more efficient than pushing
+  // items one by one, therefore we try to compromise: push the items in
+  // chunks of a safe size.
   for (const i of range(0, itemsArray.length, ARRAY_EXTEND_CHUNK_SIZE)) {
     thisArray.push(...itemsArray.slice(i, i + ARRAY_EXTEND_CHUNK_SIZE));
   }


### PR DESCRIPTION
Followup to #508.

Without doc string it is conclear why this function exists at all, as noted in https://github.com/googlefonts/fontra/pull/533/files#r1227005997