### PR TITLE
Load all glyphs in parallel before we build the layout

### DIFF
--- a/src/fontra/client/core/font-controller.js
+++ b/src/fontra/client/core/font-controller.js
@@ -107,6 +107,8 @@ export class FontController {
     // Load all glyphs named in the glyphNames array, as well as
     // all of their dependencies (made-of). Return a promise that
     // will resolve once all requested glyphs have been loaded.
+    // The loading will be done in parallel: this is much faster if
+    // the server supports parallelism (for example fontra-rcjk).
     const done = new Set();
     const loading = new Set();
 

--- a/src/fontra/client/core/font-controller.js
+++ b/src/fontra/client/core/font-controller.js
@@ -103,6 +103,51 @@ export class FontController {
     return glyphName in this.glyphMap;
   }
 
+  async loadGlyphs(glyphNames) {
+    // Load all glyphs named in the glyphNames array, as well as
+    // all of their dependencies (made-of). Return a promise that
+    // will resolve once all requested glyphs have been loaded.
+    const done = new Set();
+    const loading = new Set();
+
+    let allDoneFunc;
+    let allDonePromise = new Promise((resolve) => {
+      allDoneFunc = resolve;
+    });
+
+    function checkAllDone() {
+      if (!loading.length) {
+        allDoneFunc();
+      }
+    }
+
+    function reportError(error) {
+      console.error(error);
+      allDoneFunc();
+    }
+
+    const loadGlyph = async (glyphName) => {
+      if (done.has(glyphName)) {
+        return;
+      }
+      done.add(glyphName);
+      loading.add(glyphName);
+      await this.getGlyph(glyphName);
+      for (const subGlyphName of this.iterGlyphMadeOf(glyphName)) {
+        loadGlyph(subGlyphName).then(checkAllDone).catch(reportError);
+      }
+      loading.delete(glyphName);
+    };
+
+    glyphNames.forEach((glyphName) =>
+      loadGlyph(glyphName).then(checkAllDone).catch(reportError)
+    );
+
+    if (glyphNames.length) {
+      return allDonePromise;
+    }
+  }
+
   getGlyph(glyphName) {
     if (!this.hasGlyph(glyphName)) {
       return Promise.resolve(null);

--- a/src/fontra/views/editor/scene-model.js
+++ b/src/fontra/views/editor/scene-model.js
@@ -240,6 +240,7 @@ export class SceneModel {
 
   async updateScene() {
     this.updateBackgroundGlyphs();
+    // const startTime = performance.now();
     [this.positionedLines, this.longestLineLength] = await buildScene(
       this.fontController,
       this.glyphLines,
@@ -247,6 +248,8 @@ export class SceneModel {
       this._localLocations,
       this.textAlignment
     );
+    // const elapsed = performance.now() - startTime;
+    // console.log("buildScene", elapsed);
 
     const usedGlyphNames = getUsedGlyphNames(this.fontController, this.positionedLines);
     const cachedGlyphNames = difference(
@@ -597,6 +600,14 @@ async function buildScene(
   const lineDistance = 1.1 * fontController.unitsPerEm; // TODO make factor user-configurable
   const positionedLines = [];
   let longestLineLength = 0;
+
+  const neededGlyphs = new Set(
+    glyphLines
+      .map((glyphLine) => glyphLine.map((glyphInfo) => glyphInfo.glyphName))
+      .flat()
+  );
+  await fontController.loadGlyphs([...neededGlyphs]);
+
   for (const glyphLine of glyphLines) {
     const positionedLine = { glyphs: [] };
     let x = 0;


### PR DESCRIPTION
- Adds a `loadGlyphs()` method to the font controller class
- Call `loadGlyphs()` from `buildScene()`

Fixes #553.