### PR TITLE
Don't skip adding empty positioned lines

### DIFF
--- a/src/fontra/views/editor/scene-model.js
+++ b/src/fontra/views/editor/scene-model.js
@@ -678,8 +678,8 @@ async function buildScene(
       positionedLine.bounds = unionRect(
         ...positionedLine.glyphs.map((glyph) => glyph.bounds)
       );
-      positionedLines.push(positionedLine);
     }
+    positionedLines.push(positionedLine);
   }
   return [positionedLines, longestLineLength];
 }


### PR DESCRIPTION
Fixes #558

Don't skip adding empty positioned lines: else we mess up the relationship with the glyphLines input, which caused #558.