### PR TITLE
Various fixes related to sidebar resizing.

### DIFF
--- a/src/fontra/client/web-components/designspace-location.js
+++ b/src/fontra/client/web-components/designspace-location.js
@@ -7,7 +7,7 @@ export class DesignspaceLocation extends UnlitElement {
   static styles = `
     :host {
       display: grid;
-      grid-template-columns: 25% auto;
+      grid-template-columns: max-content auto;
       gap: 0.4em;
       overflow: scroll;
     }

--- a/src/fontra/client/web-components/designspace-location.js
+++ b/src/fontra/client/web-components/designspace-location.js
@@ -7,7 +7,7 @@ export class DesignspaceLocation extends UnlitElement {
   static styles = `
     :host {
       display: grid;
-      grid-template-columns: max-content auto;
+      grid-template-columns: 25% auto;
       gap: 0.4em;
       overflow: scroll;
     }

--- a/src/fontra/client/web-components/range-slider.js
+++ b/src/fontra/client/web-components/range-slider.js
@@ -38,6 +38,7 @@ export class RangeSlider extends LitElement {
 
     .range-container {
       position: relative;
+      flex-grow: 1;
     }
 
     /* Chrome, Safari, Edge, Opera */

--- a/src/fontra/views/editor/editor.html
+++ b/src/fontra/views/editor/editor.html
@@ -32,6 +32,13 @@
       --sidebar-tab-width: 3em;
       --sidebar-content-width-left: 20em;
       --sidebar-content-width-right: 22em;
+      --resize-cursor: col-resize;
+    }
+
+    :root.--resize {
+      user-select: none;
+      -webkit-user-select: none;
+      cursor: var(--resize-cursor);
     }
 
     .editor-container {
@@ -310,7 +317,7 @@
     .sidebar-resize-gutter {
       height: 100%;
       width: 8px;
-      cursor: col-resize;
+      cursor: var(--resize-cursor);
       position: absolute;
     }
 

--- a/src/fontra/views/editor/editor.html
+++ b/src/fontra/views/editor/editor.html
@@ -316,17 +316,17 @@
 
     .sidebar-resize-gutter {
       height: 100%;
-      width: 6px;
+      width: 4px;
       cursor: var(--resize-cursor);
       position: absolute;
     }
 
     .sidebar-container.left .sidebar-resize-gutter {
-      right: -4px;
+      right: -2px;
     }
 
     .sidebar-container.right .sidebar-resize-gutter {
-      left: -4px;
+      left: -2px;
     }
 
     .sidebar-tab > inline-svg {

--- a/src/fontra/views/editor/editor.html
+++ b/src/fontra/views/editor/editor.html
@@ -47,8 +47,7 @@
       background-color: var(--ui-element-background-color);
       height: 100%;
       width: 0;
-      display: flex;
-      justify-content: space-between;
+      position: relative;
     }
 
     .sidebar-container.animating {
@@ -312,6 +311,11 @@
       height: 100%;
       width: 8px;
       cursor: col-resize;
+      position: absolute;
+    }
+
+    .sidebar-container.left .sidebar-resize-gutter {
+      right: 0;
     }
 
     .sidebar-tab > inline-svg {

--- a/src/fontra/views/editor/editor.html
+++ b/src/fontra/views/editor/editor.html
@@ -35,7 +35,7 @@
       --resize-cursor: col-resize;
     }
 
-    :root.--resize {
+    :root.resizing {
       user-select: none;
       -webkit-user-select: none;
       cursor: var(--resize-cursor);
@@ -316,13 +316,17 @@
 
     .sidebar-resize-gutter {
       height: 100%;
-      width: 8px;
+      width: 6px;
       cursor: var(--resize-cursor);
       position: absolute;
     }
 
     .sidebar-container.left .sidebar-resize-gutter {
-      right: 0;
+      right: -4px;
+    }
+
+    .sidebar-container.right .sidebar-resize-gutter {
+      left: -4px;
     }
 
     .sidebar-tab > inline-svg {

--- a/src/fontra/views/editor/editor.html
+++ b/src/fontra/views/editor/editor.html
@@ -28,19 +28,6 @@
       height: 100vh;
     }
 
-    :root {
-      --sidebar-tab-width: 3em;
-      --sidebar-content-width-left: 20em;
-      --sidebar-content-width-right: 22em;
-      --resize-cursor: col-resize;
-    }
-
-    :root.resizing {
-      user-select: none;
-      -webkit-user-select: none;
-      cursor: var(--resize-cursor);
-    }
-
     .editor-container {
       display: grid;
       position: relative;
@@ -55,6 +42,19 @@
       height: 100%;
       width: 0;
       position: relative;
+    }
+
+    :root {
+      --sidebar-tab-width: 3em;
+      --sidebar-content-width-left: 20em;
+      --sidebar-content-width-right: 22em;
+      --resize-cursor: col-resize;
+    }
+
+    :root.sidebar-resizing {
+      user-select: none;
+      -webkit-user-select: none;
+      cursor: var(--resize-cursor);
     }
 
     .sidebar-container.animating {

--- a/src/fontra/views/editor/editor.html
+++ b/src/fontra/views/editor/editor.html
@@ -44,10 +44,11 @@
 
     .sidebar-container {
       z-index: 100;
-
       background-color: var(--ui-element-background-color);
       height: 100%;
-      display: none;
+      width: 0;
+      display: flex;
+      justify-content: space-between;
     }
 
     .sidebar-container.animating {
@@ -60,11 +61,6 @@
 
     .sidebar-container.right.visible {
       width: var(--sidebar-content-width-right);
-    }
-
-    .sidebar-container.visible {
-      display: flex;
-      justify-content: space-between;
     }
 
     .main-container {

--- a/src/fontra/views/editor/editor.html
+++ b/src/fontra/views/editor/editor.html
@@ -58,7 +58,7 @@
     }
 
     .sidebar-container.animating {
-      transition: 120ms; /* timing should match timer in tabClick() */
+      transition: 120ms;
     }
 
     .sidebar-container.left.visible {
@@ -202,10 +202,12 @@
 
     .sidebar-container.left > .sidebar-content {
       float: right;
+      width: var(--sidebar-content-width-left);
     }
 
     .sidebar-container.right > .sidebar-content {
       float: left;
+      width: var(--sidebar-content-width-right);
     }
 
     .sidebar-container > .sidebar-content.selected {

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -471,13 +471,12 @@ export class EditorController {
       }
     };
     const onPointerUp = () => {
-      sidebarResizing.style.removeProperty("userSelect");
       sidebarResizing.classList.add("animating");
       sidebarResizing = undefined;
       initialWidth = undefined;
       growDirection = undefined;
       initialPointerCoordinateX = undefined;
-      document.body.style.removeProperty("cursor");
+      document.querySelector(":root").classList.remove("--resize");
       document.removeEventListener("pointermove", onPointerMove);
     };
     for (const gutter of document.querySelectorAll(".sidebar-resize-gutter")) {
@@ -486,9 +485,8 @@ export class EditorController {
         initialWidth = sidebarResizing.getBoundingClientRect().width;
         initialPointerCoordinateX = event.clientX;
         sidebarResizing.classList.remove("animating");
-        sidebarResizing.style.userSelect = "none";
         growDirection = gutter.dataset.growDirection;
-        document.body.style.cursor = getComputedStyle(gutter).cursor;
+        document.querySelector(":root").classList.add("--resize");
         document.addEventListener("pointermove", onPointerMove);
         document.addEventListener("pointerup", onPointerUp, { once: true });
       });

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -461,13 +461,13 @@ export class EditorController {
         let cssProperty;
         if (growDirection === "left") {
           width = initialWidth + (initialPointerCoordinateX - event.clientX);
-          cssProperty = '--sidebar-content-width-right';
+          cssProperty = "--sidebar-content-width-right";
         } else if (growDirection === "right") {
           width = initialWidth + (event.clientX - initialPointerCoordinateX);
-          cssProperty = '--sidebar-content-width-left';
+          cssProperty = "--sidebar-content-width-left";
         }
         width = clamp(width, 200, 500);
-        document.querySelector(":root").style.setProperty(cssProperty, `${width}px`)
+        document.querySelector(":root").style.setProperty(cssProperty, `${width}px`);
       }
     };
     const onPointerUp = () => {

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -524,10 +524,14 @@ export class EditorController {
           `.tab-overlay-container.${side} > .sidebar-shadow-box`
         );
         if (isSelected) {
-          setTimeout(() => {
-            sidebarContent?.classList.remove("selected");
-            shadowBox?.classList.remove("visible");
-          }, 120); // timing should match sidebar-container transition
+          sidebarContainer.addEventListener(
+            "transitionend",
+            () => {
+              sidebarContent?.classList.remove("selected");
+              shadowBox?.classList.remove("visible");
+            },
+            { once: true }
+          );
         } else {
           sidebarContent?.classList.add("selected");
           shadowBox?.classList.add("visible");

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -458,13 +458,16 @@ export class EditorController {
     const onPointerMove = (event) => {
       if (sidebarResizing) {
         let width;
+        let cssProperty;
         if (growDirection === "left") {
           width = initialWidth + (initialPointerCoordinateX - event.clientX);
+          cssProperty = '--sidebar-content-width-right';
         } else if (growDirection === "right") {
           width = initialWidth + (event.clientX - initialPointerCoordinateX);
+          cssProperty = '--sidebar-content-width-left';
         }
         width = clamp(width, 200, 500);
-        sidebarResizing.style.width = `${width}px`;
+        document.querySelector(":root").style.setProperty(cssProperty, `${width}px`)
       }
     };
     const onPointerUp = () => {

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -467,7 +467,7 @@ export class EditorController {
           cssProperty = "--sidebar-content-width-left";
         }
         width = clamp(width, 200, 500);
-        document.querySelector(":root").style.setProperty(cssProperty, `${width}px`);
+        document.documentElement.style.setProperty(cssProperty, `${width}px`);
       }
     };
     const onPointerUp = () => {
@@ -476,7 +476,7 @@ export class EditorController {
       initialWidth = undefined;
       growDirection = undefined;
       initialPointerCoordinateX = undefined;
-      document.querySelector(":root").classList.remove("resizing");
+      document.documentElement.classList.remove("sidebar-resizing");
       document.removeEventListener("pointermove", onPointerMove);
     };
     for (const gutter of document.querySelectorAll(".sidebar-resize-gutter")) {
@@ -486,7 +486,7 @@ export class EditorController {
         initialPointerCoordinateX = event.clientX;
         sidebarResizing.classList.remove("animating");
         growDirection = gutter.dataset.growDirection;
-        document.querySelector(":root").classList.add("resizing");
+        document.documentElement.classList.add("sidebar-resizing");
         document.addEventListener("pointermove", onPointerMove);
         document.addEventListener("pointerup", onPointerUp, { once: true });
       });

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -462,7 +462,7 @@ export class EditorController {
         if (growDirection === "left") {
           width = initialWidth + (initialPointerCoordinateX - event.clientX);
           cssProperty = "--sidebar-content-width-right";
-        } else if (growDirection === "right") {
+        } else {
           width = initialWidth + (event.clientX - initialPointerCoordinateX);
           cssProperty = "--sidebar-content-width-left";
         }
@@ -476,7 +476,7 @@ export class EditorController {
       initialWidth = undefined;
       growDirection = undefined;
       initialPointerCoordinateX = undefined;
-      document.querySelector(":root").classList.remove("--resize");
+      document.querySelector(":root").classList.remove("resizing");
       document.removeEventListener("pointermove", onPointerMove);
     };
     for (const gutter of document.querySelectorAll(".sidebar-resize-gutter")) {
@@ -486,7 +486,7 @@ export class EditorController {
         initialPointerCoordinateX = event.clientX;
         sidebarResizing.classList.remove("animating");
         growDirection = gutter.dataset.growDirection;
-        document.querySelector(":root").classList.add("--resize");
+        document.querySelector(":root").classList.add("resizing");
         document.addEventListener("pointermove", onPointerMove);
         document.addEventListener("pointerup", onPointerUp, { once: true });
       });


### PR DESCRIPTION
This fixes #590.

- [x] Toggling the sidebar doesn't animate anymore (the "animating" class)
- [x] The "gutter" should not take additional space in sidebar
- [x] Sliders in settings tab should grow with sidebar
- [x] User select should be disabled on the root document when resizing
