### PR TITLE
Change the signature of ObervableObject callbacks

### DIFF
--- a/src/fontra/client/core/observable-object.js
+++ b/src/fontra/client/core/observable-object.js
@@ -53,6 +53,7 @@ export class ObservableController {
 
   _dispatchChange(key, newValue, oldValue, skipListener) {
     // Schedule the calls in the event loop rather than call immediately
+    const event = { key, newValue, oldValue };
     for (const listener of chain(
       this._generalListeners,
       this._keyListeners[key] || []
@@ -60,7 +61,7 @@ export class ObservableController {
       if (skipListener && skipListener === listener) {
         continue;
       }
-      setTimeout(() => listener(key, newValue, oldValue), 0);
+      setTimeout(() => listener(event), 0);
     }
   }
 }
@@ -128,9 +129,9 @@ function synchronizeWithLocalStorage(controller, prefix = "") {
     }
   }
 
-  controller.addListener((key, newValue) => {
-    if (key in mapKeyToStorage) {
-      setItemOnStorage(key, newValue);
+  controller.addListener((event) => {
+    if (event.key in mapKeyToStorage) {
+      setItemOnStorage(event.key, event.newValue);
     }
   });
 

--- a/src/fontra/client/core/theme-settings.js
+++ b/src/fontra/client/core/theme-settings.js
@@ -13,7 +13,7 @@ export const themeController = new ObservableController({ theme: "automatic" });
 
 themeController.synchronizeWithLocalStorage("fontra-");
 
-themeController.addKeyListener("theme", (key, newValue) => {
+themeController.addKeyListener("theme", (event) => {
   setupThemeOverride(themeController.model.theme);
 });
 

--- a/src/fontra/client/web-components/designspace-location.js
+++ b/src/fontra/client/web-components/designspace-location.js
@@ -60,10 +60,10 @@ export class DesignspaceLocation extends UnlitElement {
       this._controller.removeListener(this._modelListener);
     }
     this._controller = controller;
-    this._modelListener = (key, newValue) => {
-      const slider = this.shadowRoot.querySelector(`range-slider[name="${key}"]`);
+    this._modelListener = (event) => {
+      const slider = this.shadowRoot.querySelector(`range-slider[name="${event.key}"]`);
       if (slider) {
-        slider.value = newValue;
+        slider.value = event.newValue;
       }
     };
     this._controller.addListener(this._modelListener);

--- a/src/fontra/client/web-components/simple-settings.js
+++ b/src/fontra/client/web-components/simple-settings.js
@@ -26,8 +26,8 @@ export class SimpleSettings extends UnlitElement {
       this._controller.removeListener(this._modelListener);
     }
     this._controller = controller;
-    this._modelListener = (key, newValue) => {
-      if (this._keys.has(key)) {
+    this._modelListener = (event) => {
+      if (this._keys.has(event.key)) {
         this.requestUpdate();
       }
     };

--- a/src/fontra/views/editor/cjk-design-frame.js
+++ b/src/fontra/views/editor/cjk-design-frame.js
@@ -14,7 +14,7 @@ export class CJKDesignFrame {
       this.updateCJKDesignFrame(cjkDesignFrameGlyphName)
     );
 
-    editor.designspaceLocationController.addKeyListener("location", (key, newValue) => {
+    editor.designspaceLocationController.addKeyListener("location", (event) => {
       // Grrr, timeout needed when the location changes based on a source list click
       setTimeout(() => {
         this.updateCJKDesignFrame(cjkDesignFrameGlyphName);

--- a/src/fontra/views/editor/edit-tools-power-ruler.js
+++ b/src/fontra/views/editor/edit-tools-power-ruler.js
@@ -64,9 +64,9 @@ export class PowerRulerTool extends BaseTool {
 
     editor.visualizationLayersSettings.addKeyListener(
       POWER_RULER_IDENTIFIER,
-      (key, newValue) => {
-        this.active = newValue;
-        if (newValue) {
+      (event) => {
+        this.active = event.newValue;
+        if (event.newValue) {
           this.recalc();
         }
       }
@@ -289,6 +289,7 @@ export class PowerRulerTool extends BaseTool {
       return;
     }
     this.editor.visualizationLayersSettings.model[POWER_RULER_IDENTIFIER] = true;
+
     const positionedGlyph = this.sceneModel.getSelectedPositionedGlyph();
     const point = this.sceneController.localPoint(initialEvent);
     point.x -= positionedGlyph.x;

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -125,8 +125,8 @@ export class EditorController {
     this.visualizationLayersSettings = newVisualizationLayersSettings(
       this.visualizationLayers
     );
-    this.visualizationLayersSettings.addListener((key, newValue) => {
-      this.visualizationLayers.toggle(key, newValue);
+    this.visualizationLayersSettings.addListener((event) => {
+      this.visualizationLayers.toggle(event.key, event.newValue);
       this.canvasController.requestUpdate();
     });
 
@@ -175,7 +175,7 @@ export class EditorController {
     window
       .matchMedia("(prefers-color-scheme: dark)")
       .addListener((event) => this.themeChanged());
-    themeController.addListener((key, newValue) => {
+    themeController.addListener((event) => {
       this.themeChanged();
     });
 
@@ -416,14 +416,11 @@ export class EditorController {
       await this._sidebarDesignspaceResetVarGlyph();
       this.updateWindowLocationAndSelectionInfo();
     });
-    this.designspaceLocationController.addKeyListener(
-      "location",
-      async (key, location) => {
-        await this.sceneController.setLocation(location);
-        this.updateWindowLocationAndSelectionInfo();
-        this.autoViewBox = false;
-      }
-    );
+    this.designspaceLocationController.addKeyListener("location", async (event) => {
+      await this.sceneController.setLocation(event.newValue);
+      this.updateWindowLocationAndSelectionInfo();
+      this.autoViewBox = false;
+    });
   }
 
   async _sidebarDesignspaceResetVarGlyph() {
@@ -594,13 +591,13 @@ export class EditorController {
 
     textSettingsController.addKeyListener(
       "text",
-      (key, newValue) => this.setGlyphLinesFromText(newValue),
+      (event) => this.setGlyphLinesFromText(event.newValue),
       false
     );
 
-    textSettingsController.addListener((key, newValue) => this.updateWindowLocation());
+    textSettingsController.addListener((event) => this.updateWindowLocation());
 
-    textSettingsController.addKeyListener("align", (key, newValue) => {
+    textSettingsController.addKeyListener("align", (event) => {
       this.setTextAlignment(this.textSettings.align);
     });
 
@@ -630,18 +627,15 @@ export class EditorController {
     document.fonts.add(blankFont);
     await blankFont.load();
     const referenceFontElement = document.querySelector("#reference-font");
-    referenceFontElement.controller.addKeyListener(
-      "referenceFontName",
-      (key, newValue) => {
-        if (newValue) {
-          this.visualizationLayersSettings.model["fontra.reference.font"] = true;
-        }
-        this.canvasController.requestUpdate();
+    referenceFontElement.controller.addKeyListener("referenceFontName", (event) => {
+      if (event.newValue) {
+        this.visualizationLayersSettings.model["fontra.reference.font"] = true;
       }
-    );
+      this.canvasController.requestUpdate();
+    });
     let charOverride;
-    referenceFontElement.controller.addKeyListener("charOverride", (key, newValue) => {
-      charOverride = newValue;
+    referenceFontElement.controller.addKeyListener("charOverride", (event) => {
+      charOverride = event.newValue;
       this.canvasController.requestUpdate();
     });
     const referenceFontModel = referenceFontElement.model;

--- a/src/fontra/views/editor/sidebar-designspace.js
+++ b/src/fontra/views/editor/sidebar-designspace.js
@@ -29,7 +29,7 @@ export class SidebarDesignspace {
   }
 
   async setup() {
-    this.dataController.addKeyListener("varGlyphController", (key, newValue) => {
+    this.dataController.addKeyListener("varGlyphController", (event) => {
       this._updateAxes();
       this._updateSources();
       this._updateSelectedSourceFromLocation();
@@ -45,8 +45,8 @@ export class SidebarDesignspace {
       })
     );
 
-    this.dataController.addKeyListener("location", (key, newLocation) => {
-      this.axisSliders.values = newLocation;
+    this.dataController.addKeyListener("location", (event) => {
+      this.axisSliders.values = event.newValue;
       this._updateSelectedSourceFromLocation();
       this._updateRemoveSourceButtonState();
     });
@@ -147,23 +147,23 @@ export class SidebarDesignspace {
         visible: backgroundLayers[layerName] === source.name,
         status: status !== undefined ? status : this.defaultStatusValue,
       });
-      sourceController.addKeyListener("active", async (key, newValue) => {
+      sourceController.addKeyListener("active", async (event) => {
         await this.sceneController.editGlyphAndRecordChanges((glyph) => {
-          glyph.sources[index].inactive = !newValue;
-          return `${newValue ? "" : "de"}activate ${source.name}`;
+          glyph.sources[index].inactive = !event.newValue;
+          return `${event.newValue ? "" : "de"}activate ${source.name}`;
         });
       });
-      sourceController.addKeyListener("visible", async (key, newValue) => {
-        if (newValue) {
+      sourceController.addKeyListener("visible", async (event) => {
+        if (event.newValue) {
           backgroundLayers[layerName] = source.name;
         } else {
           delete backgroundLayers[layerName];
         }
         this.sceneController.backgroundLayers = backgroundLayers;
       });
-      sourceController.addKeyListener("status", async (key, newValue) => {
+      sourceController.addKeyListener("status", async (event) => {
         await this.sceneController.editGlyphAndRecordChanges((glyph) => {
-          glyph.sources[index].customData[FONTRA_STATUS_KEY] = newValue;
+          glyph.sources[index].customData[FONTRA_STATUS_KEY] = event.newValue;
           return `set status ${source.name}`;
         });
       });
@@ -399,13 +399,13 @@ export class SidebarDesignspace {
       suggestedLayerName: sourceName || suggestedSourceName,
     });
 
-    nameController.addKeyListener("sourceName", (key, newValue) => {
+    nameController.addKeyListener("sourceName", (event) => {
       nameController.model.suggestedLayerName =
-        newValue || nameController.model.suggestedSourceName;
+        event.newValue || nameController.model.suggestedSourceName;
       validateInput();
     });
 
-    locationController.addListener((key, newValue) => {
+    locationController.addListener((event) => {
       const suggestedSourceName = suggestedSourceNameFromLocation(
         makeSparseLocation(locationController.model, locationAxes)
       );
@@ -554,13 +554,15 @@ function* labeledTextInput(label, controller, key, options) {
   inputElement.value = controller.model[key];
   inputElement.oninput = () => (controller.model[key] = inputElement.value);
 
-  controller.addKeyListener(key, (key, newValue) => (inputElement.value = newValue));
+  controller.addKeyListener(key, (event) => {
+    inputElement.value = event.newValue;
+  });
 
   if (options && options.placeholderKey) {
     inputElement.placeholder = controller.model[options.placeholderKey];
     controller.addKeyListener(
       options.placeholderKey,
-      (key, newValue) => (inputElement.placeholder = newValue)
+      (event) => (inputElement.placeholder = event.newValue)
     );
   }
 

--- a/src/fontra/views/editor/sidebar-text-entry.js
+++ b/src/fontra/views/editor/sidebar-text-entry.js
@@ -13,9 +13,9 @@ export class SidebarTextEntry {
     this.textEntryElement = document.querySelector("#text-entry-textarea");
     this.textEntryElement.value = this.textSettings.text;
 
-    const updateTextEntryElementFromModel = (key, newValue) => {
-      if (this.textEntryElement.value !== newValue) {
-        this.textEntryElement.value = newValue;
+    const updateTextEntryElementFromModel = (event) => {
+      if (this.textEntryElement.value !== event.newValue) {
+        this.textEntryElement.value = event.newValue;
         this.textEntryElement.setSelectionRange(0, 0);
       }
     };
@@ -40,7 +40,7 @@ export class SidebarTextEntry {
 
     this.textSettingsController.addKeyListener(
       "text",
-      (key, newValue) => this.fixTextEntryHeight(),
+      (event) => this.fixTextEntryHeight(),
       false
     );
   }
@@ -69,7 +69,7 @@ export class SidebarTextEntry {
     this.textAlignElement = document.querySelector("#text-align-menu");
     this.updateAlignElement(this.textSettings.align);
 
-    this.textSettingsController.addKeyListener("align", (key, newValue) => {
+    this.textSettingsController.addKeyListener("align", (event) => {
       this.updateAlignElement(this.textSettings.align);
     });
 

--- a/test-js/test-observable-object.js
+++ b/test-js/test-observable-object.js
@@ -8,8 +8,8 @@ describe("ObservableObject Tests", () => {
     const controller = new ObservableController({ a: 1, b: 2 });
     expect(controller.model).to.deep.equal({ a: 1, b: 2 });
     const result = { ...controller.model };
-    const callback = (key, newValue, oldValue) => {
-      result[key] = newValue;
+    const callback = (event) => {
+      result[event.key] = event.newValue;
     };
     controller.addListener(callback);
     controller.model.b = 200;
@@ -21,9 +21,9 @@ describe("ObservableObject Tests", () => {
     const controller = new ObservableController({ a: 1, b: 2 });
     expect(controller.model).to.deep.equal({ a: 1, b: 2 });
     const result = { ...controller.model };
-    const callback = (key, newValue, oldValue) => {
-      expect(oldValue).to.equal(undefined);
-      result[key] = newValue;
+    const callback = (event) => {
+      expect(event.oldValue).to.equal(undefined);
+      result[event.key] = event.newValue;
     };
     controller.addListener(callback);
     controller.model.c = 200;
@@ -35,9 +35,9 @@ describe("ObservableObject Tests", () => {
     const controller = new ObservableController({ a: 1, b: 2 });
     expect(controller.model).to.deep.equal({ a: 1, b: 2 });
     const result = { ...controller.model };
-    const callback = (key, newValue, oldValue) => {
-      expect(key).to.equal("b");
-      result[key] = newValue;
+    const callback = (event) => {
+      expect(event.key).to.equal("b");
+      result[event.key] = event.newValue;
     };
     controller.addKeyListener("b", callback);
     controller.model.a = 9999;
@@ -50,8 +50,8 @@ describe("ObservableObject Tests", () => {
     const controller = new ObservableController({ a: 1, b: 2 });
     expect(controller.model).to.deep.equal({ a: 1, b: 2 });
     const result = { ...controller.model };
-    const callback = (key, newValue, oldValue) => {
-      result[key] = newValue;
+    const callback = (event) => {
+      result[event.key] = event.newValue;
     };
     controller.addListener(callback);
     controller.setItem("b", 200);
@@ -62,9 +62,9 @@ describe("ObservableObject Tests", () => {
   it("delete item test", async () => {
     const controller = new ObservableController({ a: 1, b: 2 });
     const result = { ...controller.model };
-    const callback = (key, newValue) => {
-      expect(newValue).to.equal(undefined);
-      delete result[key];
+    const callback = (event) => {
+      expect(event.newValue).to.equal(undefined);
+      delete result[event.key];
     };
     controller.addListener(callback);
     delete controller.model.b;
@@ -75,8 +75,8 @@ describe("ObservableObject Tests", () => {
   it("removeEventListener test", async () => {
     const controller = new ObservableController({ a: 1, b: 2 });
     const result = { ...controller.model };
-    const callback = (key, newValue, oldValue) => {
-      result[key] = newValue;
+    const callback = (event) => {
+      result[event.key] = event.newValue;
     };
     controller.addListener(callback);
     controller.model.a = 300;
@@ -91,8 +91,8 @@ describe("ObservableObject Tests", () => {
   it("setItem skipListener test", async () => {
     const controller = new ObservableController({ a: 1, b: 2 });
     const result = { ...controller.model };
-    const callback = (key, newValue, oldValue) => {
-      result[key] = newValue;
+    const callback = (event) => {
+      result[event.key] = event.newValue;
     };
     controller.addListener(callback);
     controller.setItem("a", 300);


### PR DESCRIPTION
Change the signature of ObervableObject callbacks: they will now receive a single event object, with key, newValue and oldValue properties

This will make it easier for (near-) future expansion.