### PR TITLE
ObservableObject: replace "skip listener" with "sender info"

### DIFF
--- a/src/fontra/client/core/observable-object.js
+++ b/src/fontra/client/core/observable-object.js
@@ -39,11 +39,11 @@ export class ObservableController {
     );
   }
 
-  setItem(key, newValue, skipListener) {
+  setItem(key, newValue, senderInfo) {
     const oldValue = this._rawModel[key];
     if (newValue !== oldValue) {
       this._rawModel[key] = newValue;
-      this._dispatchChange(key, newValue, oldValue, skipListener);
+      this._dispatchChange(key, newValue, oldValue, senderInfo);
     }
   }
 
@@ -51,16 +51,13 @@ export class ObservableController {
     synchronizeWithLocalStorage(this, prefix);
   }
 
-  _dispatchChange(key, newValue, oldValue, skipListener) {
+  _dispatchChange(key, newValue, oldValue, senderInfo) {
     // Schedule the calls in the event loop rather than call immediately
-    const event = { key, newValue, oldValue };
+    const event = { key, newValue, oldValue, senderInfo };
     for (const listener of chain(
       this._generalListeners,
       this._keyListeners[key] || []
     )) {
-      if (skipListener && skipListener === listener) {
-        continue;
-      }
       setTimeout(() => listener(event), 0);
     }
   }

--- a/src/fontra/client/web-components/designspace-location.js
+++ b/src/fontra/client/web-components/designspace-location.js
@@ -62,6 +62,7 @@ export class DesignspaceLocation extends UnlitElement {
     this._controller = controller;
     this._modelListener = (event) => {
       if (event.senderInfo === this) {
+        // Event was triggered by us -- ignore
         return;
       }
       const slider = this.shadowRoot.querySelector(`range-slider[name="${event.key}"]`);

--- a/src/fontra/client/web-components/designspace-location.js
+++ b/src/fontra/client/web-components/designspace-location.js
@@ -61,6 +61,9 @@ export class DesignspaceLocation extends UnlitElement {
     }
     this._controller = controller;
     this._modelListener = (event) => {
+      if (event.senderInfo === this) {
+        return;
+      }
       const slider = this.shadowRoot.querySelector(`range-slider[name="${event.key}"]`);
       if (slider) {
         slider.value = event.newValue;
@@ -151,7 +154,7 @@ export class DesignspaceLocation extends UnlitElement {
 
   _dispatchLocationChangedEvent(slider) {
     if (this.controller) {
-      this.controller.setItem(slider.name, slider.value, this._modelListener);
+      this.controller.setItem(slider.name, slider.value, this);
     } else {
       this.values[slider.name] = slider.value;
       const event = new CustomEvent("locationChanged", {

--- a/src/fontra/client/web-components/simple-settings.js
+++ b/src/fontra/client/web-components/simple-settings.js
@@ -27,6 +27,9 @@ export class SimpleSettings extends UnlitElement {
     }
     this._controller = controller;
     this._modelListener = (event) => {
+      if (event.senderInfo == this) {
+        return;
+      }
       if (this._keys.has(event.key)) {
         this.requestUpdate();
       }
@@ -51,21 +54,21 @@ export class SimpleSettings extends UnlitElement {
     }
 
     return this._descriptions.map((description) =>
-      uiTypes[description.ui](this._modelListener, description, this.controller)
+      uiTypes[description.ui](this, description, this.controller)
     );
   }
 }
 
 const uiTypes = {
-  header(modelListener, description, controller) {
+  header(settingsElement, description, controller) {
     return div({ class: "header" }, [description.displayName]);
   },
 
-  plain(modelListener, description, controller) {
+  plain(settingsElement, description, controller) {
     return div({ class: "plain" }, [description.displayName]);
   },
 
-  checkbox(modelListener, description, controller) {
+  checkbox(settingsElement, description, controller) {
     const id = `simple-settings.${description.key}`;
 
     return div({}, [
@@ -73,14 +76,14 @@ const uiTypes = {
         type: "checkbox",
         id: id,
         onchange: (event) =>
-          controller.setItem(description.key, event.target.checked, modelListener),
+          controller.setItem(description.key, event.target.checked, settingsElement),
         checked: controller.model[description.key],
       }),
       label({ for: id }, [description.displayName]),
     ]);
   },
 
-  radio(modelListener, description, controller) {
+  radio(settingsElement, description, controller) {
     const id = `simple-settings.${description.key}`;
 
     return [
@@ -96,7 +99,7 @@ const uiTypes = {
             name: id,
             value: option.key,
             onchange: (event) =>
-              controller.setItem(description.key, event.target.value, modelListener),
+              controller.setItem(description.key, event.target.value, settingsElement),
             checked: controller.model[description.key] == option.key,
           }),
           label({ for: itemID }, [option.displayName]),

--- a/src/fontra/client/web-components/simple-settings.js
+++ b/src/fontra/client/web-components/simple-settings.js
@@ -27,7 +27,8 @@ export class SimpleSettings extends UnlitElement {
     }
     this._controller = controller;
     this._modelListener = (event) => {
-      if (event.senderInfo == this) {
+      if (event.senderInfo === this) {
+        // Event was triggered by us -- ignore
         return;
       }
       if (this._keys.has(event.key)) {

--- a/src/fontra/views/editor/sidebar-text-entry.js
+++ b/src/fontra/views/editor/sidebar-text-entry.js
@@ -29,11 +29,7 @@ export class SidebarTextEntry {
     this.textEntryElement.addEventListener(
       "input",
       () => {
-        this.textSettingsController.setItem(
-          "text",
-          this.textEntryElement.value,
-          updateTextEntryElementFromModel
-        );
+        this.textSettings.text = this.textEntryElement.value;
       },
       false
     );

--- a/test-js/test-observable-object.js
+++ b/test-js/test-observable-object.js
@@ -88,17 +88,20 @@ describe("ObservableObject Tests", () => {
     expect(result).to.deep.equal({ a: 300, b: 2 });
   });
 
-  it("setItem skipListener test", async () => {
+  it("setItem senderInfo test", async () => {
     const controller = new ObservableController({ a: 1, b: 2 });
     const result = { ...controller.model };
+    const senderInfo = {}; // arbitrary unique object
     const callback = (event) => {
-      result[event.key] = event.newValue;
+      if (event.senderInfo !== senderInfo) {
+        result[event.key] = event.newValue;
+      }
     };
     controller.addListener(callback);
     controller.setItem("a", 300);
     await asyncTimeout(0);
     expect(result).to.deep.equal({ a: 300, b: 2 });
-    controller.setItem("b", 300, callback); // skipListener
+    controller.setItem("b", 300, senderInfo);
     await asyncTimeout(0);
     expect(result).to.deep.equal({ a: 300, b: 2 });
   });


### PR DESCRIPTION
This moves the responsibility of ignoring an event to the event listener, and provides a more flexible way of communicating information from sender to listener.