### PR TITLE
Can't edit glyph dialog refinement

### DIFF
--- a/src/fontra/client/core/glyph-controller.js
+++ b/src/fontra/client/core/glyph-controller.js
@@ -281,7 +281,7 @@ export class VariableGlyphController {
     });
   }
 
-  findNearestSourceFromGlobalLocation(location) {
+  findNearestSourceFromGlobalLocation(location, skipInactive) {
     const normalizedLocation = normalizeLocation(
       this.mapLocationGlobalToLocal(location),
       this.combinedAxes
@@ -289,7 +289,8 @@ export class VariableGlyphController {
     const indexInfo = findNearestSourceIndexFromLocation(
       this.glyph,
       normalizedLocation,
-      this.combinedAxes
+      this.combinedAxes,
+      skipInactive
     );
     return indexInfo.index;
   }
@@ -733,13 +734,17 @@ function subsetLocation(location, axes) {
   return subsettedLocation;
 }
 
-function findNearestSourceIndexFromLocation(glyph, location, axes) {
+function findNearestSourceIndexFromLocation(glyph, location, axes, skipInactive) {
   const distances = [];
   if (!glyph.sources.length) {
     throw Error("assert -- glyph has no sources");
   }
   for (let i = 0; i < glyph.sources.length; i++) {
-    const sourceLocation = normalizeLocation(glyph.sources[i].location, axes);
+    const source = glyph.sources[i];
+    if (skipInactive && source.inactive) {
+      continue;
+    }
+    const sourceLocation = normalizeLocation(source.location, axes);
     let distanceSquared = 0;
     for (const [axisName, value] of Object.entries(location)) {
       const sourceValue = sourceLocation[axisName];

--- a/src/fontra/client/core/glyph-controller.js
+++ b/src/fontra/client/core/glyph-controller.js
@@ -281,7 +281,7 @@ export class VariableGlyphController {
     });
   }
 
-  findNearestSourceFromGlobalLocation(location, skipInactive) {
+  findNearestSourceFromGlobalLocation(location, skipInactive = false) {
     const normalizedLocation = normalizeLocation(
       this.mapLocationGlobalToLocal(location),
       this.combinedAxes
@@ -734,7 +734,12 @@ function subsetLocation(location, axes) {
   return subsettedLocation;
 }
 
-function findNearestSourceIndexFromLocation(glyph, location, axes, skipInactive) {
+function findNearestSourceIndexFromLocation(
+  glyph,
+  location,
+  axes,
+  skipInactive = false
+) {
   const distances = [];
   if (!glyph.sources.length) {
     throw Error("assert -- glyph has no sources");

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -421,17 +421,36 @@ export class EditorController {
       this.updateWindowLocationAndSelectionInfo();
       this.autoViewBox = false;
     });
-    this.sceneController.addEventListener("createNewSource", (event) => {
-      this.sidebarDesignspace.addSource();
-    });
-    this.sceneController.addEventListener("goToNearestSource", async (event) => {
-      const glyphController =
-        await this.sceneController.sceneModel.getSelectedVariableGlyphController();
-      const nearestSourceIndex = glyphController.findNearestSourceFromGlobalLocation(
-        this.sceneController.getLocation(),
-        true
+    this.sceneController.addEventListener("cantEditGlyphNotAtSource", async () => {
+      const glyphName = this.sceneController.sceneModel.getSelectedGlyphName();
+      const result = await dialog(
+        `Can’t edit glyph “${glyphName}”`,
+        "Location is not at a source.",
+        [
+          { title: "Cancel", resultValue: "cancel", isCancelButton: true },
+          { title: "New source", resultValue: "createNewSource" },
+          {
+            title: "Go to nearest source",
+            resultValue: "goToNearestSource",
+            isDefaultButton: true,
+          },
+        ]
       );
-      this.sidebarDesignspace.selectSourceByIndex(nearestSourceIndex);
+      switch (result) {
+        case "createNewSource":
+          this.sidebarDesignspace.addSource();
+          break;
+        case "goToNearestSource":
+          const glyphController =
+            await this.sceneController.sceneModel.getSelectedVariableGlyphController();
+          const nearestSourceIndex =
+            glyphController.findNearestSourceFromGlobalLocation(
+              this.sceneController.getLocation(),
+              true
+            );
+          this.sidebarDesignspace.selectSourceByIndex(nearestSourceIndex);
+          break;
+      }
     });
   }
 

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -421,8 +421,8 @@ export class EditorController {
       this.updateWindowLocationAndSelectionInfo();
       this.autoViewBox = false;
     });
-    this.sceneController.addEventListener("createNewSource", async (event) => {
-      await this.sidebarDesignspace.addSource();
+    this.sceneController.addEventListener("createNewSource", (event) => {
+      this.sidebarDesignspace.addSource();
     });
     this.sceneController.addEventListener("goToNearestSource", async (event) => {
       const glyphController =

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -164,7 +164,7 @@ export class EditorController {
     });
 
     this.sceneController.addEventListener("glyphEditLocationNotAtSource", async () => {
-      this.showGlyphEditLocationNotAtSource();
+      this.showDialogGlyphEditLocationNotAtSource();
     });
 
     this.initSidebars();
@@ -362,11 +362,11 @@ export class EditorController {
     userSettings.items = items;
   }
 
-  async showGlyphEditLocationNotAtSource() {
+  async showDialogGlyphEditLocationNotAtSource() {
     const glyphName = this.sceneController.sceneModel.getSelectedGlyphName();
     const result = await dialog(
       `Can’t edit glyph “${glyphName}”`,
-      "Location is not at a source.",
+      "The location is not at a source.",
       [
         { title: "Cancel", resultValue: "cancel", isCancelButton: true },
         { title: "New source", resultValue: "createNewSource" },

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -421,6 +421,17 @@ export class EditorController {
       this.updateWindowLocationAndSelectionInfo();
       this.autoViewBox = false;
     });
+    this.sceneController.addEventListener("createNewSource", async (event) => {
+      await this.sidebarDesignspace.addSource();
+    });
+    this.sceneController.addEventListener("goToNearestSource", async (event) => {
+      const glyphController =
+        await this.sceneController.sceneModel.getSelectedVariableGlyphController();
+      const nearestSource = glyphController.findNearestSourceFromGlobalLocation(
+        this.sceneController.getLocation()
+      );
+      this.designspaceLocationController.model.location = nearestSource;
+    });
   }
 
   async _sidebarDesignspaceResetVarGlyph() {

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -427,10 +427,10 @@ export class EditorController {
     this.sceneController.addEventListener("goToNearestSource", async (event) => {
       const glyphController =
         await this.sceneController.sceneModel.getSelectedVariableGlyphController();
-      const nearestSource = glyphController.findNearestSourceFromGlobalLocation(
+      const nearestSourceIndex = glyphController.findNearestSourceFromGlobalLocation(
         this.sceneController.getLocation()
       );
-      this.designspaceLocationController.model.location = nearestSource;
+      this.sidebarDesignspace.selectSourceByIndex(nearestSourceIndex);
     });
   }
 

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -428,7 +428,8 @@ export class EditorController {
       const glyphController =
         await this.sceneController.sceneModel.getSelectedVariableGlyphController();
       const nearestSourceIndex = glyphController.findNearestSourceFromGlobalLocation(
-        this.sceneController.getLocation()
+        this.sceneController.getLocation(),
+        true
       );
       this.sidebarDesignspace.selectSourceByIndex(nearestSourceIndex);
     });

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -163,8 +163,8 @@ export class EditorController {
       this.doubleClickedComponentsCallback(event);
     });
 
-    this.sceneController.addEventListener("glyphHasNoSource", async () => {
-      this.showGlypHasNoSourceDialog();
+    this.sceneController.addEventListener("glyphEditLocationNotAtSource", async () => {
+      this.showGlyphEditLocationNotAtSource();
     });
 
     this.initSidebars();
@@ -362,7 +362,7 @@ export class EditorController {
     userSettings.items = items;
   }
 
-  async showGlypHasNoSourceDialog() {
+  async showGlyphEditLocationNotAtSource() {
     const glyphName = this.sceneController.sceneModel.getSelectedGlyphName();
     const result = await dialog(
       `Can’t edit glyph “${glyphName}”`,

--- a/src/fontra/views/editor/scene-controller.js
+++ b/src/fontra/views/editor/scene-controller.js
@@ -466,10 +466,6 @@ export class SceneController {
     if (doInstance) {
       const glyphController = this.sceneModel.getSelectedPositionedGlyph().glyph;
       if (!glyphController.canEdit) {
-        // TODO: add options to dialog:
-        // - go to closest source
-        // - insert new source here
-        // - cancel
         const result = await dialog(
           `Can’t edit glyph “${glyphName}”`,
           "Location is not at a source.",

--- a/src/fontra/views/editor/scene-controller.js
+++ b/src/fontra/views/editor/scene-controller.js
@@ -473,9 +473,20 @@ export class SceneController {
         const result = await dialog(
           `Can’t edit glyph “${glyphName}”`,
           "Location is not at a source.",
-          [{ title: "Okay", resultValue: "ok" }],
-          2500 /* auto dismiss after a timeout */
+          [
+            { title: "Cancel", resultValue: "cancel", isCancelButton: true },
+            { title: "Create new source", resultValue: "createNewSource" },
+            {
+              title: "Go to nearest source",
+              isDefaultButton: true,
+              resultValue: "goToNearestSource",
+            },
+          ]
         );
+        if (result === "cancel") {
+          return;
+        }
+        this._dispatchEvent(result);
         return;
       }
 

--- a/src/fontra/views/editor/scene-controller.js
+++ b/src/fontra/views/editor/scene-controller.js
@@ -475,11 +475,11 @@ export class SceneController {
           "Location is not at a source.",
           [
             { title: "Cancel", resultValue: "cancel", isCancelButton: true },
-            { title: "Create new source", resultValue: "createNewSource" },
+            { title: "New source", resultValue: "createNewSource" },
             {
               title: "Go to nearest source",
-              isDefaultButton: true,
               resultValue: "goToNearestSource",
+              isDefaultButton: true,
             },
           ]
         );

--- a/src/fontra/views/editor/scene-controller.js
+++ b/src/fontra/views/editor/scene-controller.js
@@ -466,7 +466,7 @@ export class SceneController {
     if (doInstance) {
       const glyphController = this.sceneModel.getSelectedPositionedGlyph().glyph;
       if (!glyphController.canEdit) {
-        this._dispatchEvent("cantEditGlyphNotAtSource");
+        this._dispatchEvent("glyphHasNoSource");
         return;
       }
 

--- a/src/fontra/views/editor/scene-controller.js
+++ b/src/fontra/views/editor/scene-controller.js
@@ -466,22 +466,7 @@ export class SceneController {
     if (doInstance) {
       const glyphController = this.sceneModel.getSelectedPositionedGlyph().glyph;
       if (!glyphController.canEdit) {
-        const result = await dialog(
-          `Can’t edit glyph “${glyphName}”`,
-          "Location is not at a source.",
-          [
-            { title: "Cancel", resultValue: "cancel", isCancelButton: true },
-            { title: "New source", resultValue: "createNewSource" },
-            {
-              title: "Go to nearest source",
-              resultValue: "goToNearestSource",
-              isDefaultButton: true,
-            },
-          ]
-        );
-        if (result !== "cancel") {
-          this._dispatchEvent(result);
-        }
+        this._dispatchEvent("cantEditGlyphNotAtSource");
         return;
       }
 

--- a/src/fontra/views/editor/scene-controller.js
+++ b/src/fontra/views/editor/scene-controller.js
@@ -479,10 +479,9 @@ export class SceneController {
             },
           ]
         );
-        if (result === "cancel") {
-          return;
+        if (result !== "cancel") {
+          this._dispatchEvent(result);
         }
-        this._dispatchEvent(result);
         return;
       }
 

--- a/src/fontra/views/editor/scene-controller.js
+++ b/src/fontra/views/editor/scene-controller.js
@@ -466,7 +466,7 @@ export class SceneController {
     if (doInstance) {
       const glyphController = this.sceneModel.getSelectedPositionedGlyph().glyph;
       if (!glyphController.canEdit) {
-        this._dispatchEvent("glyphHasNoSource");
+        this._dispatchEvent("glyphEditLocationNotAtSource");
         return;
       }
 

--- a/src/fontra/views/editor/sidebar-designspace.js
+++ b/src/fontra/views/editor/sidebar-designspace.js
@@ -181,6 +181,11 @@ export class SidebarDesignspace {
     this.sourcesList.setSelectedItemIndex(sourceIndex);
   }
 
+  selectSourceByIndex(sourceIndex) {
+    this.sourcesList.setSelectedItemIndex(sourceIndex);
+    this._updateLocationFromSelectedSource();
+  }
+
   _updateLocationFromSelectedSource() {
     const sourceIndex = this.sourcesList.getSelectedItemIndex();
     if (sourceIndex === undefined) {
@@ -296,8 +301,7 @@ export class SidebarDesignspace {
     // Update UI
     await this._updateSources();
     const selectedSourceIndex = glyph.sources.length - 1; /* the newly added source */
-    this.sourcesList.setSelectedItemIndex(selectedSourceIndex);
-    this._updateLocationFromSelectedSource();
+    this.selectSourceByIndex(selectedSourceIndex);
   }
 
   async editSourceProperties(sourceIndex) {
@@ -351,8 +355,7 @@ export class SidebarDesignspace {
     });
     // Update UI
     await this._updateSources();
-    this.sourcesList.setSelectedItemIndex(sourceIndex);
-    this._updateLocationFromSelectedSource();
+    this.selectSourceByIndex(sourceIndex);
   }
 
   async _sourcePropertiesRunDialog(


### PR DESCRIPTION
Work in progress, it will fix #591. 

- [x] Dialog button labels

<img width="542" alt="Screen Shot 2023-07-10 at 06 40 27" src="https://github.com/googlefonts/fontra/assets/92447202/69a067f1-280b-4943-b657-d04ece505b9d">

- [x] Go to nearest skip inactive sources

<img width="683" alt="Screen Shot 2023-07-10 at 06 43 21" src="https://github.com/googlefonts/fontra/assets/92447202/a20ad8c2-85b7-489e-a004-331ef46a55ca">
