### PR TITLE
Use web api instead of 'static' calls over the web socket

### DIFF
--- a/src/fontra/client/core/font-controller.js
+++ b/src/fontra/client/core/font-controller.js
@@ -86,19 +86,6 @@ export class FontController {
     return undefined;
   }
 
-  async getSuggestedGlyphName(codePoint) {
-    return await this.font.getSuggestedGlyphName(codePoint);
-  }
-
-  async getUnicodeFromGlyphName(glyphName) {
-    return await this.font.getUnicodeFromGlyphName(glyphName);
-  }
-
-  async parseClipboard(data) {
-    const result = await this.font.parseClipboard(data);
-    return result ? StaticGlyph.fromObject(result) : undefined;
-  }
-
   hasGlyph(glyphName) {
     return glyphName in this.glyphMap;
   }

--- a/src/fontra/client/core/server-utils.js
+++ b/src/fontra/client/core/server-utils.js
@@ -1,0 +1,24 @@
+export async function callServerAPI(functionName, kwargs) {
+  const response = await fetch(`/api/${functionName}`, {
+    method: "POST",
+    body: JSON.stringify(kwargs),
+  });
+
+  const result = await response.json();
+  if (result.error) {
+    throw new Error(result.error);
+  }
+  return result.returnValue;
+}
+
+export async function getSuggestedGlyphName(codePoint) {
+  return await callServerAPI("getSuggestedGlyphName", { codePoint });
+}
+
+export async function getUnicodeFromGlyphName(glyphName) {
+  return await callServerAPI("getUnicodeFromGlyphName", { glyphName });
+}
+
+export async function parseClipboard(data) {
+  return await callServerAPI("parseClipboard", { data });
+}

--- a/src/fontra/core/fonthandler.py
+++ b/src/fontra/core/fonthandler.py
@@ -19,8 +19,6 @@ from .changes import (
     patternUnion,
 )
 from .classes import Font
-from .clipboard import parseClipboard
-from .glyphnames import getSuggestedGlyphName, getUnicodeFromGlyphName
 from .lrucache import LRUCache
 
 logger = logging.getLogger(__name__)
@@ -441,18 +439,6 @@ class FontHandler:
             for key in [LIVE_CHANGES_PATTERN_KEY, CHANGES_PATTERN_KEY]
         ]
         return patternUnion(patternA, patternB)
-
-    @remoteMethod
-    async def getSuggestedGlyphName(self, codePoint, *, connection):
-        return getSuggestedGlyphName(codePoint)
-
-    @remoteMethod
-    async def getUnicodeFromGlyphName(self, glyphName, *, connection):
-        return getUnicodeFromGlyphName(glyphName)
-
-    @remoteMethod
-    async def parseClipboard(self, data, *, connection):
-        return parseClipboard(data)
 
 
 def _iterAllComponentNames(glyph):

--- a/src/fontra/core/serverutils.py
+++ b/src/fontra/core/serverutils.py
@@ -1,0 +1,25 @@
+from dataclasses import asdict
+
+from . import clipboard, glyphnames
+
+apiFunctions = {}
+
+
+def api(func):
+    apiFunctions[func.__name__] = func
+    return func
+
+
+@api
+def getSuggestedGlyphName(codePoint):
+    return glyphnames.getSuggestedGlyphName(codePoint)
+
+
+@api
+def getUnicodeFromGlyphName(glyphName):
+    return glyphnames.getUnicodeFromGlyphName(glyphName)
+
+
+@api
+def parseClipboard(data):
+    return asdict(clipboard.parseClipboard(data))

--- a/src/fontra/filesystem/projectmanager.py
+++ b/src/fontra/filesystem/projectmanager.py
@@ -83,7 +83,8 @@ class FileSystemProjectManager:
         return "yes"  # arbitrary non-false string token
 
     async def projectPageHandler(self, request, filterContent=None):
-        html = resources.read_text("fontra.filesystem", "landing.html")
+        htmlPath = resources.files("fontra") / "filesystem" / "landing.html"
+        html = htmlPath.read_text()
         if filterContent is not None:
             html = filterContent(html, "text/html")
         return web.Response(text=html, content_type="text/html")


### PR DESCRIPTION
This fixes #629 

Remove 'static' remote functions from FontController/FontHandler, and create a new server-utils web api mechanism

This simplifies some client code, and makes it easier to add similar server-based helpers.