### PR TITLE
Fix various ruler behaviors, eg. wrong measurements after arrow key nudge

### DIFF
--- a/src/fontra/views/editor/edit-tools-power-ruler.js
+++ b/src/fontra/views/editor/edit-tools-power-ruler.js
@@ -168,7 +168,7 @@ export class PowerRulerTool extends BaseTool {
     }
   }
 
-  recalc() {
+  async recalc() {
     if (!this.active) {
       return;
     }
@@ -176,11 +176,13 @@ export class PowerRulerTool extends BaseTool {
     if (!ruler) {
       return;
     }
-    const positionedGlyph = this.sceneModel.getSelectedPositionedGlyph();
-    const extraLines = this.computeSideBearingLines(positionedGlyph.glyph);
+    const glyphController = await this.sceneModel.getGlyphInstance(
+      this.currentGlyphName
+    );
+    const extraLines = this.computeSideBearingLines(glyphController);
 
     this.glyphRulers[this.currentGlyphName] = this.recalcRulerFromLine(
-      positionedGlyph.glyph,
+      glyphController,
       ruler.basePoint,
       ruler.directionVector,
       extraLines

--- a/src/fontra/views/editor/scene-model.js
+++ b/src/fontra/views/editor/scene-model.js
@@ -241,13 +241,7 @@ export class SceneModel {
   async updateScene() {
     this.updateBackgroundGlyphs();
     // const startTime = performance.now();
-    [this.positionedLines, this.longestLineLength] = await buildScene(
-      this.fontController,
-      this.glyphLines,
-      this.getGlobalLocation(),
-      this._localLocations,
-      this.textAlignment
-    );
+    await this.buildScene();
     // const elapsed = performance.now() - startTime;
     // console.log("buildScene", elapsed);
 
@@ -282,6 +276,102 @@ export class SceneModel {
         wantLiveChanges
       );
     }
+  }
+
+  async buildScene() {
+    const fontController = this.fontController;
+    const glyphLines = this.glyphLines;
+    const globalLocation = this.getGlobalLocation();
+    const localLocations = this._localLocations;
+    const align = this.textAlignment;
+
+    let y = 0;
+    const lineDistance = 1.1 * fontController.unitsPerEm; // TODO make factor user-configurable
+    const positionedLines = [];
+    let longestLineLength = 0;
+
+    const neededGlyphs = new Set(
+      glyphLines
+        .map((glyphLine) => glyphLine.map((glyphInfo) => glyphInfo.glyphName))
+        .flat()
+    );
+    await fontController.loadGlyphs([...neededGlyphs]);
+
+    for (const glyphLine of glyphLines) {
+      const positionedLine = { glyphs: [] };
+      let x = 0;
+      for (const glyphInfo of glyphLine) {
+        const location = { ...localLocations[glyphInfo.glyphName], ...globalLocation };
+        let glyphInstance = await fontController.getGlyphInstance(
+          glyphInfo.glyphName,
+          location
+        );
+        const isUndefined = !glyphInstance;
+        if (isUndefined) {
+          glyphInstance = fontController.getDummyGlyphInstanceController(
+            glyphInfo.glyphName
+          );
+        }
+        positionedLine.glyphs.push({
+          x: x,
+          y: y,
+          glyph: glyphInstance,
+          glyphName: glyphInfo.glyphName,
+          character: glyphInfo.character,
+          isUndefined: isUndefined,
+        });
+        x += glyphInstance.xAdvance;
+      }
+
+      longestLineLength = Math.max(longestLineLength, x);
+
+      let offset = 0;
+      if (align === "center") {
+        offset = -x / 2;
+      } else if (align === "right") {
+        offset = -x;
+      }
+      if (offset) {
+        positionedLine.glyphs.forEach((item) => {
+          item.x += offset;
+        });
+      }
+
+      // Add bounding boxes
+      positionedLine.glyphs.forEach((item) => {
+        let bounds = item.glyph.controlBounds;
+        if (!bounds || isEmptyRect(bounds) || item.glyph.isEmptyIsh) {
+          // Empty glyph, make up box based on advance so it can still be clickable/hoverable
+          // TODO: use font's ascender/descender values
+          // If the advance is very small, add a bit of extra space on both sides so it'll be
+          // clickable even with a zero advance width
+          const extraSpace = item.glyph.xAdvance < 30 ? 20 : 0;
+          bounds = insetRect(
+            normalizeRect({
+              xMin: 0,
+              yMin: -0.2 * fontController.unitsPerEm,
+              xMax: item.glyph.xAdvance,
+              yMax: 0.8 * fontController.unitsPerEm,
+            }),
+            -extraSpace,
+            0
+          );
+          item.isEmpty = true;
+        }
+        item.bounds = offsetRect(bounds, item.x, item.y);
+        item.unpositionedBounds = bounds;
+      });
+
+      y -= lineDistance;
+      if (positionedLine.glyphs.length) {
+        positionedLine.bounds = unionRect(
+          ...positionedLine.glyphs.map((glyph) => glyph.bounds)
+        );
+      }
+      positionedLines.push(positionedLine);
+    }
+    this.positionedLines = positionedLines;
+    this.longestLineLength = longestLineLength;
   }
 
   selectionAtPoint(point, size, currentSelection, preferTCenter) {
@@ -587,101 +677,6 @@ function mergeAxisInfo(axisInfos) {
     }
   }
   return Object.values(mergedAxisInfo);
-}
-
-async function buildScene(
-  fontController,
-  glyphLines,
-  globalLocation,
-  localLocations,
-  align = "center"
-) {
-  let y = 0;
-  const lineDistance = 1.1 * fontController.unitsPerEm; // TODO make factor user-configurable
-  const positionedLines = [];
-  let longestLineLength = 0;
-
-  const neededGlyphs = new Set(
-    glyphLines
-      .map((glyphLine) => glyphLine.map((glyphInfo) => glyphInfo.glyphName))
-      .flat()
-  );
-  await fontController.loadGlyphs([...neededGlyphs]);
-
-  for (const glyphLine of glyphLines) {
-    const positionedLine = { glyphs: [] };
-    let x = 0;
-    for (const glyphInfo of glyphLine) {
-      const location = { ...localLocations[glyphInfo.glyphName], ...globalLocation };
-      let glyphInstance = await fontController.getGlyphInstance(
-        glyphInfo.glyphName,
-        location
-      );
-      const isUndefined = !glyphInstance;
-      if (isUndefined) {
-        glyphInstance = fontController.getDummyGlyphInstanceController(
-          glyphInfo.glyphName
-        );
-      }
-      positionedLine.glyphs.push({
-        x: x,
-        y: y,
-        glyph: glyphInstance,
-        glyphName: glyphInfo.glyphName,
-        character: glyphInfo.character,
-        isUndefined: isUndefined,
-      });
-      x += glyphInstance.xAdvance;
-    }
-
-    longestLineLength = Math.max(longestLineLength, x);
-
-    let offset = 0;
-    if (align === "center") {
-      offset = -x / 2;
-    } else if (align === "right") {
-      offset = -x;
-    }
-    if (offset) {
-      positionedLine.glyphs.forEach((item) => {
-        item.x += offset;
-      });
-    }
-
-    // Add bounding boxes
-    positionedLine.glyphs.forEach((item) => {
-      let bounds = item.glyph.controlBounds;
-      if (!bounds || isEmptyRect(bounds) || item.glyph.isEmptyIsh) {
-        // Empty glyph, make up box based on advance so it can still be clickable/hoverable
-        // TODO: use font's ascender/descender values
-        // If the advance is very small, add a bit of extra space on both sides so it'll be
-        // clickable even with a zero advance width
-        const extraSpace = item.glyph.xAdvance < 30 ? 20 : 0;
-        bounds = insetRect(
-          normalizeRect({
-            xMin: 0,
-            yMin: -0.2 * fontController.unitsPerEm,
-            xMax: item.glyph.xAdvance,
-            yMax: 0.8 * fontController.unitsPerEm,
-          }),
-          -extraSpace,
-          0
-        );
-        item.isEmpty = true;
-      }
-      item.bounds = offsetRect(bounds, item.x, item.y);
-      item.unpositionedBounds = bounds;
-    });
-
-    y -= lineDistance;
-    if (positionedLine.glyphs.length) {
-      positionedLine.bounds = unionRect(
-        ...positionedLine.glyphs.map((glyph) => glyph.bounds)
-      );
-    }
-    positionedLines.push(positionedLine);
-  }
-  return [positionedLines, longestLineLength];
 }
 
 function getUsedGlyphNames(fontController, positionedLines) {

--- a/src/fontra/views/editor/scene-model.js
+++ b/src/fontra/views/editor/scene-model.js
@@ -281,8 +281,6 @@ export class SceneModel {
   async buildScene() {
     const fontController = this.fontController;
     const glyphLines = this.glyphLines;
-    const globalLocation = this.getGlobalLocation();
-    const localLocations = this._localLocations;
     const align = this.textAlignment;
 
     let y = 0;
@@ -301,11 +299,7 @@ export class SceneModel {
       const positionedLine = { glyphs: [] };
       let x = 0;
       for (const glyphInfo of glyphLine) {
-        const location = { ...localLocations[glyphInfo.glyphName], ...globalLocation };
-        let glyphInstance = await fontController.getGlyphInstance(
-          glyphInfo.glyphName,
-          location
-        );
+        let glyphInstance = await this.getGlyphInstance(glyphInfo.glyphName);
         const isUndefined = !glyphInstance;
         if (isUndefined) {
           glyphInstance = fontController.getDummyGlyphInstanceController(
@@ -372,6 +366,14 @@ export class SceneModel {
     }
     this.positionedLines = positionedLines;
     this.longestLineLength = longestLineLength;
+  }
+
+  async getGlyphInstance(glyphName) {
+    const location = {
+      ...this._localLocations[glyphName],
+      ...this.getGlobalLocation(),
+    };
+    return await this.fontController.getGlyphInstance(glyphName, location);
   }
 
   selectionAtPoint(point, size, currentSelection, preferTCenter) {


### PR DESCRIPTION
This fixes #631.

What happened:
- We used the positioned glyph to update the measurement
- But we get called at a time that the glyph lines have not yet been updated, so we'd look at stale data

To fix:
- Add getGlyphInstance(glyphName) method to SceneModel
- Refactor buildScene() as a mehod, which uses getGlyphInstance()
- The ruler now explicitly gets the instance and bypasses the glyph lines