### PR TITLE
Show selection dimensions info

### DIFF
--- a/src/fontra/client/core/glyph-controller.js
+++ b/src/fontra/client/core/glyph-controller.js
@@ -486,6 +486,13 @@ class ComponentController {
     return this._path2d;
   }
 
+  get bounds() {
+    if (this._bounds === undefined) {
+      this._bounds = this.path.getBounds();
+    }
+    return this._bounds;
+  }
+
   get controlBounds() {
     if (this._controlBounds === undefined) {
       this._controlBounds = this.path.getControlBounds();

--- a/src/fontra/client/core/glyph-controller.js
+++ b/src/fontra/client/core/glyph-controller.js
@@ -366,6 +366,10 @@ export class StaticGlyphController {
     return getRepresentation(this, "componentsPath");
   }
 
+  get bounds() {
+    return getRepresentation(this, "bounds");
+  }
+
   get controlBounds() {
     return getRepresentation(this, "controlBounds");
   }
@@ -422,6 +426,10 @@ registerRepresentationFactory(
 
 registerRepresentationFactory(StaticGlyphController, "componentsPath", (glyph) => {
   return joinPaths(glyph.components.map((compo) => compo.path));
+});
+
+registerRepresentationFactory(StaticGlyphController, "bounds", (glyph) => {
+  return glyph.flattenedPath.getBounds();
 });
 
 registerRepresentationFactory(StaticGlyphController, "controlBounds", (glyph) => {

--- a/src/fontra/client/core/path-hit-tester.js
+++ b/src/fontra/client/core/path-hit-tester.js
@@ -121,7 +121,7 @@ export class PathHitTester {
     const segments = [...this.path.iterContourDecomposedSegments(contourIndex)];
     segments.forEach((segment) => {
       segment.bezier = new Bezier(segment.points);
-      segment.bounds = polyBounds(segment.points);
+      segment.bounds = rectFromPoints(segment.points);
     });
     contour.segments = segments;
   }
@@ -135,25 +135,6 @@ export class PathHitTester {
     }
     this.allContoursAreLoaded = true;
   }
-}
-
-function polyBounds(points) {
-  if (!points.length) {
-    return null;
-  }
-  let xMin = points[0].x;
-  let yMin = points[0].y;
-  let xMax = xMin;
-  let yMax = yMin;
-  for (let i = 1; i < points.length; i++) {
-    const x = points[i].x;
-    const y = points[i].y;
-    xMin = Math.min(x, xMin);
-    yMin = Math.min(y, yMin);
-    xMax = Math.max(x, xMax);
-    yMax = Math.max(y, yMax);
-  }
-  return { xMin: xMin, yMin: yMin, xMax: xMax, yMax: yMax };
 }
 
 function findIntersections(bezier, line, direction, info) {

--- a/src/fontra/client/core/rectangle.js
+++ b/src/fontra/client/core/rectangle.js
@@ -152,3 +152,13 @@ export function rectFromPoints(points) {
   }
   return { xMin, yMin, xMax, yMax };
 }
+
+export function updateRect(rect, point) {
+  // Return the smallest rect that includes the original rect and the given point
+  return {
+    xMin: Math.min(rect.xMin, point.x),
+    yMin: Math.min(rect.yMin, point.y),
+    xMax: Math.max(rect.xMax, point.x),
+    yMax: Math.max(rect.yMax, point.y),
+  };
+}

--- a/src/fontra/client/css/ui-styling.css
+++ b/src/fontra/client/css/ui-styling.css
@@ -56,9 +56,11 @@
 
 .ui-form-divider {
   border: none;
-  border-top: 1px solid gray;
-  width: 90%;
+  border-top: 1px solid #8888;
+  width: 100%;
   height: 1px;
+  margin-block-start: 0.2em;
+  margin-block-end: 0.1em;
   grid-column: 1 / span 2;
 }
 

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -200,7 +200,7 @@ export class EditorController {
       200
     );
     this.updateSelectionInfo = throttleCalls(
-      async (event) => await this._updateSelectionInfo(),
+      async (senderID) => await this._updateSelectionInfo(senderID),
       100
     );
     this.updateSidebarDesignspace = throttleCalls(
@@ -1749,20 +1749,16 @@ export class EditorController {
   }
 
   async editListenerCallback(editMethodName, senderID, ...args) {
-    if (senderID === this.sidebarSelectionInfo) {
-      // The edit comes from the selection info box itself, so we shouldn't update it
-      return;
-    }
     if (editMethodName === "editIncremental" || editMethodName === "editFinal") {
-      this.updateSelectionInfo();
+      this.updateSelectionInfo(senderID);
     }
     if (editMethodName === "editFinal") {
       this.sceneController.updateHoverState();
     }
   }
 
-  async _updateSelectionInfo() {
-    await this.sidebarSelectionInfo.update();
+  async _updateSelectionInfo(senderID) {
+    await this.sidebarSelectionInfo.update(senderID);
   }
 
   setAutoViewBox() {

--- a/src/fontra/views/editor/sidebar-selection-info.js
+++ b/src/fontra/views/editor/sidebar-selection-info.js
@@ -218,7 +218,7 @@ export class SidebarSelectionInfo {
       selectionRects.push(component.controlBounds);
     }
     if (!selectionRects.length && glyphController?.controlBounds) {
-      selectionRects.push(glyphController.controlBounds);
+      selectionRects.push(glyphController.bounds);
     }
     if (selectionRects.length) {
       const selectionBounds = unionRect(...selectionRects);

--- a/src/fontra/views/editor/sidebar-selection-info.js
+++ b/src/fontra/views/editor/sidebar-selection-info.js
@@ -77,35 +77,9 @@ export class SidebarSelectionInfo {
       ]),
     ].sort((a, b) => a - b);
 
-    const selectionRects = [];
-    if (pointIndices) {
-      selectionRects.push(
-        rectFromPoints(pointIndices.map((i) => instance.path.getPoint(i)))
-      );
-    }
-    for (const componentIndex of componentIndices) {
-      const component = glyphController.components[componentIndex];
-      if (!component || !component.controlBounds) {
-        continue;
-      }
-      selectionRects.push(component.controlBounds);
-    }
-    if (!selectionRects.length && glyphController?.controlBounds) {
-      selectionRects.push(glyphController.controlBounds);
-    }
-    if (selectionRects.length) {
-      const selectionBounds = unionRect(...selectionRects);
-      let { width, height } = rectSize(selectionBounds);
-      width = Math.round(width * 10) / 10;
-      height = Math.round(height * 10) / 10;
-      formContents.push({ type: "divider" });
-      formContents.push({
-        key: "dimensions",
-        type: "text",
-        label: "Dimensions",
-        value: `↔ ${width} ↕ ${height}`,
-      });
-    }
+    formContents.push(
+      ...this._setupDimensionsInfo(glyphController, pointIndices, componentIndices)
+    );
 
     for (const index of componentIndices) {
       const component = instance.components[index];
@@ -187,6 +161,40 @@ export class SidebarSelectionInfo {
       this.infoForm.setFieldDescriptions(formContents);
       await this._setupSelectionInfoHandlers(glyphName);
     }
+  }
+
+  _setupDimensionsInfo(glyphController, pointIndices, componentIndices) {
+    const selectionRects = [];
+    if (pointIndices) {
+      selectionRects.push(
+        rectFromPoints(pointIndices.map((i) => instance.path.getPoint(i)))
+      );
+    }
+    for (const componentIndex of componentIndices) {
+      const component = glyphController.components[componentIndex];
+      if (!component || !component.controlBounds) {
+        continue;
+      }
+      selectionRects.push(component.controlBounds);
+    }
+    if (!selectionRects.length && glyphController?.controlBounds) {
+      selectionRects.push(glyphController.controlBounds);
+    }
+    const formContents = [];
+    if (selectionRects.length) {
+      const selectionBounds = unionRect(...selectionRects);
+      let { width, height } = rectSize(selectionBounds);
+      width = Math.round(width * 10) / 10;
+      height = Math.round(height * 10) / 10;
+      formContents.push({ type: "divider" });
+      formContents.push({
+        key: "dimensions",
+        type: "text",
+        label: "Dimensions",
+        value: `↔ ${width} ↕ ${height}`,
+      });
+    }
+    return formContents;
   }
 
   async _setupSelectionInfoHandlers(glyphName) {

--- a/src/fontra/views/editor/sidebar-selection-info.js
+++ b/src/fontra/views/editor/sidebar-selection-info.js
@@ -205,6 +205,7 @@ export class SidebarSelectionInfo {
   _getDimensionsString(glyphController, pointIndices, componentIndices) {
     const selectionRects = [];
     if (pointIndices.length) {
+      const instance = glyphController.instance;
       selectionRects.push(
         rectFromPoints(pointIndices.map((i) => instance.path.getPoint(i)))
       );

--- a/src/fontra/views/editor/sidebar-selection-info.js
+++ b/src/fontra/views/editor/sidebar-selection-info.js
@@ -215,7 +215,7 @@ export class SidebarSelectionInfo {
       if (!component || !component.controlBounds) {
         continue;
       }
-      selectionRects.push(component.controlBounds);
+      selectionRects.push(component.bounds);
     }
     if (!selectionRects.length && glyphController?.controlBounds) {
       selectionRects.push(glyphController.bounds);

--- a/test-js/test-rectangle.js
+++ b/test-js/test-rectangle.js
@@ -17,6 +17,7 @@ import {
   rectToArray,
   isEmptyRect,
   rectFromPoints,
+  updateRect,
 } from "../src/fontra/client/core/rectangle.js";
 import { parametrize } from "./test-support.js";
 
@@ -420,6 +421,94 @@ describe("rectFromPoints", () => {
     ([rectangle, acceptance, testDescription]) => {
       const result = rectFromPoints(rectangle);
       expect(result).deep.equals(acceptance, testDescription);
+    }
+  );
+});
+
+describe("updateRect", () => {
+  const testData = [
+    [
+      {
+        xMin: 0,
+        yMin: 0,
+        xMax: 10,
+        yMax: 10,
+      },
+      { x: 0, y: 0 },
+      {
+        xMin: 0,
+        yMin: 0,
+        xMax: 10,
+        yMax: 10,
+      },
+    ],
+    [
+      {
+        xMin: 0,
+        yMin: 0,
+        xMax: 10,
+        yMax: 10,
+      },
+      { x: 20, y: 0 },
+      {
+        xMin: 0,
+        yMin: 0,
+        xMax: 20,
+        yMax: 10,
+      },
+    ],
+    [
+      {
+        xMin: 0,
+        yMin: 0,
+        xMax: 10,
+        yMax: 10,
+      },
+      { x: 0, y: 20 },
+      {
+        xMin: 0,
+        yMin: 0,
+        xMax: 10,
+        yMax: 20,
+      },
+    ],
+    [
+      {
+        xMin: 0,
+        yMin: 0,
+        xMax: 10,
+        yMax: 10,
+      },
+      { x: -10, y: 0 },
+      {
+        xMin: -10,
+        yMin: 0,
+        xMax: 10,
+        yMax: 10,
+      },
+    ],
+    [
+      {
+        xMin: 0,
+        yMin: 0,
+        xMax: 10,
+        yMax: 10,
+      },
+      { x: 0, y: -10 },
+      {
+        xMin: 0,
+        yMin: -10,
+        xMax: 10,
+        yMax: 10,
+      },
+    ],
+  ];
+  parametrize(
+    "Update a rect with a point",
+    testData,
+    ([rectangle, point, acceptance]) => {
+      const result = updateRect(rectangle, point);
+      expect(result).deep.equals(acceptance);
     }
   );
 });

--- a/test-js/test-rectangle.js
+++ b/test-js/test-rectangle.js
@@ -44,6 +44,13 @@ describe("pointInRect", () => {
     [{ x: 220, y: 220 }, { xMin: 0, yMin: 0, xMax: 200, yMax: 200 }, false],
     [{ x: 220, y: -1 }, { xMin: 0, yMin: 0, xMax: 200, yMax: 200 }, false],
     [{ x: -1, y: 200 }, { xMin: 0, yMin: 0, xMax: 200, yMax: 200 }, false],
+    [{ x: 0, y: 0 }, { xMin: 0, yMin: 0, xMax: 200, yMax: 200 }, true],
+    [{ x: 0, y: 100 }, { xMin: 0, yMin: 0, xMax: 200, yMax: 200 }, true],
+    [{ x: 0, y: 200 }, { xMin: 0, yMin: 0, xMax: 200, yMax: 200 }, true],
+    [{ x: 0, y: 201 }, { xMin: 0, yMin: 0, xMax: 200, yMax: 200 }, false],
+    [{ x: 100, y: 200 }, { xMin: 0, yMin: 0, xMax: 200, yMax: 200 }, true],
+    [{ x: 200, y: 200 }, { xMin: 0, yMin: 0, xMax: 200, yMax: 200 }, true],
+    [{ x: 0, y: -1 }, { xMin: 0, yMin: 0, xMax: 200, yMax: 200 }, false],
   ];
   parametrize(
     "is point in rectangle",

--- a/test-js/test-var-path.js
+++ b/test-js/test-var-path.js
@@ -1,6 +1,8 @@
 import chai from "chai";
 const expect = chai.expect;
 
+import { parametrize } from "./test-support.js";
+
 import {
   POINT_TYPE_OFF_CURVE_CUBIC,
   POINT_TYPE_OFF_CURVE_QUAD,
@@ -702,6 +704,70 @@ describe("VarPackedPath Tests", () => {
       xMax: 10,
       yMax: 11,
     });
+  });
+
+  const getBoundsTestData = [
+    [(p) => {}, undefined],
+    [
+      (p) => {
+        p.moveTo(10, 20);
+      },
+      { xMin: 10, yMin: 20, xMax: 10, yMax: 20 },
+    ],
+    [
+      (p) => {
+        p.moveTo(10, 20);
+        p.lineTo(20, 30);
+      },
+      { xMin: 10, yMin: 20, xMax: 20, yMax: 30 },
+    ],
+    [
+      (p) => {
+        p.moveTo(0, 0);
+        p.cubicCurveTo(10, 0, 20, 10, 20, 20);
+      },
+      { xMin: 0, yMin: 0, xMax: 20, yMax: 20 },
+    ],
+    [
+      (p) => {
+        p.moveTo(0, 0);
+        p.cubicCurveTo(10, 20, 20, 20, 30, 0);
+      },
+      { xMin: 0, yMin: 0, xMax: 30, yMax: 15 },
+    ],
+    [
+      (p) => {
+        p.moveTo(0, 0);
+        p.cubicCurveTo(20, 10, 20, 20, 0, 30);
+      },
+      { xMin: 0, yMin: 0, xMax: 15, yMax: 30 },
+    ],
+    [
+      (p) => {
+        p.moveTo(0, 0);
+        p.quadraticCurveTo(10, 20, 20, 20, 30, 0);
+      },
+      { xMin: 0, yMin: 0, xMax: 30, yMax: 20 },
+    ],
+    [
+      (p) => {
+        p.moveTo(0, 0);
+        p.quadraticCurveTo(10, 20, 20, 0);
+      },
+      { xMin: 0, yMin: 0, xMax: 20, yMax: 10 },
+    ],
+    [
+      (p) => {
+        p.moveTo(0, 0);
+        p.quadraticCurveTo(20, 10, 0, 20);
+      },
+      { xMin: 0, yMin: 0, xMax: 10, yMax: 20 },
+    ],
+  ];
+  parametrize("test getBounds", getBoundsTestData, ([drawFunc, expectedBounds]) => {
+    const p = new VarPackedPath();
+    drawFunc(p);
+    expect(p.getBounds()).to.deep.equal(expectedBounds);
   });
 
   it("test firstOnCurve bug", () => {


### PR DESCRIPTION
This is a basic version of #345.

TODO:
- [x] dimensions are not updated when variable component sliders are pulled
- [x] use proper bounding box of components (and glyph) instead of control bounds
- ~[ ] Selected component bounds does not update if the base glyph gets edited in another window~

This PR also adds proper bounds computing ("tight bounds", as opposed to control bounds).