### PR TITLE
Cleanup canvas resize

### DIFF
--- a/src/fontra/client/core/canvas-controller.js
+++ b/src/fontra/client/core/canvas-controller.js
@@ -23,7 +23,6 @@ export class CanvasController {
     });
     resizeObserver.observe(this.canvas.parentElement);
 
-    window.addEventListener("resize", (event) => this.handleResize(event));
     canvas.addEventListener("wheel", (event) => this.handleWheel(event));
 
     // Safari pinch zoom:
@@ -85,6 +84,7 @@ export class CanvasController {
       this.origin.y += dy;
     }
     this.previousOffsets = { parentOffsetX, parentOffsetY };
+    this._dispatchEvent("viewBoxChanged", "canvas-size");
   }
 
   draw() {
@@ -102,12 +102,6 @@ export class CanvasController {
   }
 
   // Event handlers
-
-  handleResize(event) {
-    this.setupSize();
-    this.requestUpdate();
-    this._dispatchEvent("viewBoxChanged", "canvas-size");
-  }
 
   handleWheel(event) {
     event.preventDefault();

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -374,12 +374,12 @@ export class EditorController {
         this.setAutoViewBox();
       } else {
         this.autoViewBox = false;
-        this.sceneSettingsController.setItem(
-          "viewBox",
-          this.canvasController.getViewBox(),
-          { senderID: this }
-        );
       }
+      this.sceneSettingsController.setItem(
+        "viewBox",
+        this.canvasController.getViewBox(),
+        { senderID: this }
+      );
     });
   }
 


### PR DESCRIPTION
This removes some redundant event listening, and fixes the synchronisation between `sceneSettings.viewBox` and the actual view box.