### PR TITLE
Make reference font settings persistent

### DIFF
--- a/src/fontra/client/core/opfs-write-worker.js
+++ b/src/fontra/client/core/opfs-write-worker.js
@@ -38,9 +38,10 @@ async function writeFileToOPFS(path, file) {
 }
 
 async function bufferFromFile(file) {
-  const reader = new FileReader();
-  const arrayBuffer = await new Promise((resolve) => {
+  const arrayBuffer = await new Promise((resolve, reject) => {
+    const reader = new FileReader();
     reader.onload = (event) => resolve(reader.result);
+    reader.onerror = reject;
     reader.readAsArrayBuffer(file);
   });
   return new DataView(arrayBuffer, 0);

--- a/src/fontra/client/core/opfs-write-worker.js
+++ b/src/fontra/client/core/opfs-write-worker.js
@@ -1,0 +1,47 @@
+"use strict";
+
+// This Web Worker script is needed to write files to the Origin Private File System
+// (OPFS) in Safari. Safari (as of august 2023) does not support the createWritable()
+// API, but does support the synchronous createSyncAccessHandle() API, but it is only
+// available from Web Workers. So we use a Web Worker.
+
+onmessage = async (event) => {
+  const result = {};
+  try {
+    result.returnValue = await writeFileToOPFS(event.data.path, event.data.file);
+  } catch (error) {
+    console.error(error);
+    result.error = error.toString();
+  }
+  postMessage(result);
+};
+
+async function writeFileToOPFS(path, file) {
+  const fileName = path.at(-1);
+  if (!fileName) {
+    throw new Error("invalid path");
+  }
+  const root = await navigator.storage.getDirectory();
+  let dir = root;
+  for (const dirName of path.slice(0, -1)) {
+    dir = await dir.getDirectoryHandle(dirName, { create: true });
+  }
+
+  const buffer = await bufferFromFile(file);
+  const fileHandle = await dir.getFileHandle(fileName, { create: true });
+  const writable = await fileHandle.createSyncAccessHandle();
+  try {
+    writable.write(buffer, { at: 0 });
+  } finally {
+    writable.close();
+  }
+}
+
+async function bufferFromFile(file) {
+  const reader = new FileReader();
+  const arrayBuffer = await new Promise((resolve) => {
+    reader.onload = (event) => resolve(reader.result);
+    reader.readAsArrayBuffer(file);
+  });
+  return new DataView(arrayBuffer, 0);
+}

--- a/src/fontra/client/core/opfs-write-worker.js
+++ b/src/fontra/client/core/opfs-write-worker.js
@@ -30,11 +30,8 @@ async function writeFileToOPFS(path, file) {
   const buffer = await bufferFromFile(file);
   const fileHandle = await dir.getFileHandle(fileName, { create: true });
   const writable = await fileHandle.createSyncAccessHandle();
-  try {
-    writable.write(buffer, { at: 0 });
-  } finally {
-    writable.close();
-  }
+  writable.write(buffer, { at: 0 });
+  writable.close();
 }
 
 async function bufferFromFile(file) {

--- a/src/fontra/client/core/utils.js
+++ b/src/fontra/client/core/utils.js
@@ -321,15 +321,6 @@ function findNestedActiveElement(element) {
     : element;
 }
 
-export function fileNameBasename(name) {
-  const separator = ".";
-  const parts = name.split(separator);
-  parts.pop();
-  const basename = parts.join(separator);
-  // console.log(basename);
-  return basename;
-}
-
 export function fileNameExtension(name) {
   return name.split(".").pop();
 }

--- a/src/fontra/client/core/utils.js
+++ b/src/fontra/client/core/utils.js
@@ -321,6 +321,10 @@ function findNestedActiveElement(element) {
     : element;
 }
 
+export function fileNameBasename(name) {
+  return name.split(".").shift();
+}
+
 export function fileNameExtension(name) {
   return name.split(".").pop();
 }

--- a/src/fontra/client/core/utils.js
+++ b/src/fontra/client/core/utils.js
@@ -322,7 +322,12 @@ function findNestedActiveElement(element) {
 }
 
 export function fileNameBasename(name) {
-  return name.split(".").shift();
+  const separator = ".";
+  const parts = name.split(separator);
+  parts.pop();
+  const basename = parts.join(separator);
+  // console.log(basename);
+  return basename;
 }
 
 export function fileNameExtension(name) {

--- a/src/fontra/client/web-components/modal-dialog.js
+++ b/src/fontra/client/web-components/modal-dialog.js
@@ -61,6 +61,7 @@ export class ModalDialog extends SimpleElement {
 
     dialog .message {
       grid-column: 1 / -1;
+      white-space: normal;
     }
 
     dialog .button {

--- a/src/fontra/client/web-components/modal-dialog.js
+++ b/src/fontra/client/web-components/modal-dialog.js
@@ -29,6 +29,7 @@ export class ModalDialog extends SimpleElement {
     dialog {
       background-color: transparent;
       border: none;
+      white-space: normal;
     }
 
     dialog::backdrop {
@@ -61,7 +62,6 @@ export class ModalDialog extends SimpleElement {
 
     dialog .message {
       grid-column: 1 / -1;
-      white-space: normal;
     }
 
     dialog .button {

--- a/src/fontra/client/web-components/reference-font.js
+++ b/src/fontra/client/web-components/reference-font.js
@@ -344,8 +344,8 @@ function getWriteWorker() {
 }
 
 function writeFontFileToOPFSInWorker(fileName, file) {
-  const worker = getWriteWorker();
   return new Promise((resolve, reject) => {
+    const worker = getWriteWorker();
     worker.onmessage = (event) => {
       if (event.data.error) {
         reject(event.data.error);

--- a/src/fontra/client/web-components/reference-font.js
+++ b/src/fontra/client/web-components/reference-font.js
@@ -210,23 +210,14 @@ function readFileAsync(file) {
 }
 
 async function getOPFSInfo() {
-  try {
-    return navigator.storage.estimate().then((info) => {
-      return {
-        free: info.quota - info.usage,
-        usage: info.usage,
-        percent: Math.round((info.usage / info.quota) * 100),
-        quota: info.quota,
-      };
-    });
-  } catch (error) {
-    dialog(
-      "Unable to retrieve Origin Private File System informations.",
-      error.toString(),
-      [{ title: "OK" }],
-      5000
-    );
-  }
+  return navigator.storage.estimate().then((info) => {
+    return {
+      free: info.quota - info.usage,
+      usage: info.usage,
+      percent: Math.round((info.usage / info.quota) * 100),
+      quota: info.quota,
+    };
+  });
 }
 
 async function getOPFSFontsDir() {
@@ -260,23 +251,13 @@ async function loadAllFontsFromOPFS() {
 }
 
 async function loadFontFromOPFS(fontName) {
-  try {
-    const fontsDir = await getOPFSFontsDir();
-    const fontFileHandle = await fontsDir.getFileHandle(fontName);
-    const fontFileData = await fontFileHandle.getFile();
-    const fontFileBuffer = await fontFileData.arrayBuffer();
-    const fontFileBlob = new Blob([fontFileBuffer], { type: "font/ttf" });
-    const fontFile = new File([fontFileBlob], fontName, { type: "font/ttf" });
-    return fontFile;
-  } catch (error) {
-    dialog(
-      "Unable to load font from Origin Private File System.",
-      error.toString(),
-      [{ title: "OK" }],
-      5000
-    );
-    return null;
-  }
+  const fontsDir = await getOPFSFontsDir();
+  const fontFileHandle = await fontsDir.getFileHandle(fontName);
+  const fontFileData = await fontFileHandle.getFile();
+  const fontFileBuffer = await fontFileData.arrayBuffer();
+  const fontFileBlob = new Blob([fontFileBuffer], { type: "font/ttf" });
+  const fontFile = new File([fontFileBlob], fontName, { type: "font/ttf" });
+  return fontFile;
 }
 
 async function deleteFontFromOPFS(font) {
@@ -306,6 +287,7 @@ async function saveFontToOPFS(file) {
       [{ title: "OK" }],
       5000
     );
+    return;
   }
   const fontsDir = await getOPFSFontsDir();
   const fontFile = await fontsDir.getFileHandle(file.name, { create: true });

--- a/src/fontra/client/web-components/reference-font.js
+++ b/src/fontra/client/web-components/reference-font.js
@@ -345,7 +345,6 @@ function getWriteWorker() {
 
 function writeFontFileToOPFSInWorker(fileName, file) {
   const worker = getWriteWorker();
-  worker.postMessage({ path: ["reference-fonts", fileName], file });
   return new Promise((resolve, reject) => {
     worker.onmessage = (event) => {
       if (event.data.error) {
@@ -354,6 +353,7 @@ function writeFontFileToOPFSInWorker(fileName, file) {
         resolve(event.data.returnValue);
       }
     };
+    worker.postMessage({ path: ["reference-fonts", fileName], file });
   });
 }
 

--- a/src/fontra/client/web-components/reference-font.js
+++ b/src/fontra/client/web-components/reference-font.js
@@ -171,16 +171,7 @@ export class ReferenceFont extends UnlitElement {
           return `- ${file.name}`;
         })
         .join("\n");
-      dialog(
-        dialogTitle,
-        dialogMessage,
-        [
-          {
-            title: "OK",
-          },
-        ],
-        5000
-      );
+      dialog(dialogTitle, dialogMessage, [{ title: "Okay" }], 5000);
     }
 
     const newSelectedItemIndex = this.filesUIList.items.length;
@@ -188,9 +179,17 @@ export class ReferenceFont extends UnlitElement {
     this.filesUIList.setItems(newItems);
     this.filesUIList.setSelectedItemIndex(newSelectedItemIndex, true);
 
-    for (const fontItem of fontItems) {
-      await writeFontFileToOPFS(fontItem.fontIdentifier, fontItem.droppedFile);
-      delete fontItem.droppedFile;
+    const writtenFontItems = [];
+    try {
+      for (const fontItem of fontItems) {
+        await writeFontFileToOPFS(fontItem.fontIdentifier, fontItem.droppedFile);
+        delete fontItem.droppedFile;
+        writtenFontItems.push(fontItem);
+      }
+    } catch (error) {
+      dialog("Could not store some reference fonts", error.toString(), [
+        { title: "Okay" },
+      ]);
     }
 
     // Only notify the list controller *after* the files have been written,
@@ -343,11 +342,8 @@ async function writeFontFileToOPFSAsync(fileName, file) {
     return "OPFS does not support fileHandle.createWritable()";
   }
   const writable = await fileHandle.createWritable();
-  try {
-    await writable.write(file);
-  } finally {
-    await writable.close();
-  }
+  await writable.write(file);
+  await writable.close();
 }
 
 let worker;

--- a/src/fontra/client/web-components/reference-font.js
+++ b/src/fontra/client/web-components/reference-font.js
@@ -99,11 +99,8 @@ export class ReferenceFont extends UnlitElement {
       }
       fileItems.forEach(async (fileItem) => {
         await saveFontToOPFS(fileItem.file);
+        updateFontsUIList();
       });
-      filesUIList.setItems([...filesUIList.items, ...fileItems]);
-      if (filesUIList.getSelectedItemIndex() === undefined) {
-        filesUIList.setSelectedItemIndex(0, true);
-      }
     };
     filesUIList.addEventListener("listSelectionChanged", async () => {
       const fileItem = filesUIList.getSelectedItem();
@@ -131,18 +128,24 @@ export class ReferenceFont extends UnlitElement {
       document.fonts.delete(fileItem.fontFace);
       // update model to trigger canvas update (delete reference font from canvas)
       this.model.referenceFontName = undefined;
-      items.splice(index, 1);
-      filesUIList.setItems(items);
-      filesUIList.setSelectedItemIndex(undefined, true);
       await deleteFontFromOPFS(fileItem);
+      updateFontsUIList(true);
     });
-    loadAllFontsFromOPFS().then((persistentFileItems) => {
-      // console.log(persistentFileItems);
-      filesUIList.setItems([...filesUIList.items, ...persistentFileItems]);
-      if (filesUIList.getSelectedItemIndex() === undefined) {
-        filesUIList.setSelectedItemIndex(0, true);
-      }
-    });
+
+    const updateFontsUIList = function (deselect) {
+      loadAllFontsFromOPFS().then((items) => {
+        filesUIList.setItems([...items]);
+        if (deselect === true) {
+          filesUIList.setSelectedItemIndex(undefined, true);
+        } else {
+          if (filesUIList.getSelectedItemIndex() === undefined) {
+            filesUIList.setSelectedItemIndex(0, true);
+          }
+        }
+      });
+    };
+
+    updateFontsUIList();
 
     const content = [
       div({ class: "title" }, ["Reference font"]),

--- a/src/fontra/client/web-components/reference-font.js
+++ b/src/fontra/client/web-components/reference-font.js
@@ -186,6 +186,7 @@ export class ReferenceFont extends UnlitElement {
     const newSelectedItemIndex = this.filesUIList.items.length;
     const newItems = [...this.filesUIList.items, ...fontItems];
     this.filesUIList.setItems(newItems);
+    this.filesUIList.setSelectedItemIndex(newSelectedItemIndex, true);
 
     for (const fontItem of fontItems) {
       await writeFontFileToOPFS(fontItem.fontIdentifier, fontItem.droppedFile);
@@ -198,8 +199,6 @@ export class ReferenceFont extends UnlitElement {
     this.listController.setItem("fontList", cleanFontItems(newItems), {
       senderID: this,
     });
-
-    this.filesUIList.setSelectedItemIndex(newSelectedItemIndex, true);
   }
 
   async _listSelectionChangedHandler() {

--- a/src/fontra/client/web-components/reference-font.js
+++ b/src/fontra/client/web-components/reference-font.js
@@ -345,7 +345,6 @@ function getWriteWorker() {
 
 function writeFontFileToOPFSInWorker(fileName, file) {
   const worker = getWriteWorker();
-  const objectURL = URL.createObjectURL(file);
   worker.postMessage({ path: ["reference-fonts", fileName], file });
   return new Promise((resolve, reject) => {
     worker.onmessage = (event) => {

--- a/src/fontra/client/web-components/reference-font.js
+++ b/src/fontra/client/web-components/reference-font.js
@@ -111,11 +111,12 @@ export class ReferenceFont extends UnlitElement {
       const file = fileItem.file;
       const fileExtension = fileNameExtension(file.name);
       if (!fileItem.fontFace) {
+        const fontName = makeFontFaceName(fileItem.fontName);
         const fontURL = makeFontFaceURL(
           await asBase64Data(file),
           fontTypeMapping[fileExtension]
         );
-        fileItem.fontFace = new FontFace(fileItem.fontName, fontURL, {});
+        fileItem.fontFace = new FontFace(fontName, fontURL, {});
         document.fonts.add(fileItem.fontFace);
         await fileItem.fontFace.load();
       }
@@ -174,6 +175,15 @@ export class ReferenceFont extends UnlitElement {
     ];
     return content;
   }
+}
+
+function makeFontFaceName(fontName) {
+  let name = fontName;
+  // replace all non-alphanumeric characters with hyphen
+  name = name.replace(/[^a-zA-Z0-9]/g, "-");
+  // remove starting and trailing hyphens
+  name = name.replace(/^-+|-+$/g, "");
+  return name;
 }
 
 function makeFontFaceURL(fontData, fontType) {

--- a/src/fontra/client/web-components/reference-font.js
+++ b/src/fontra/client/web-components/reference-font.js
@@ -71,7 +71,7 @@ export class ReferenceFont extends UnlitElement {
     );
 
     this.filesUIList.addEventListener("deleteKey", () =>
-      this._deleteSelectedItemHAndler()
+      this._deleteSelectedItemHandler()
     );
 
     this.filesUIList.setItems([...this.listController.model.fontList]);
@@ -229,7 +229,7 @@ export class ReferenceFont extends UnlitElement {
     this.model.referenceFontName = fileItem.fontIdentifier;
   }
 
-  async _deleteSelectedItemHAndler() {
+  async _deleteSelectedItemHandler() {
     const index = this.filesUIList.getSelectedItemIndex();
     const fontItems = [...this.filesUIList.items];
     const fileItem = fontItems[index];

--- a/src/fontra/client/web-components/reference-font.js
+++ b/src/fontra/client/web-components/reference-font.js
@@ -49,7 +49,7 @@ export class ReferenceFont extends UnlitElement {
     return this.controller.model;
   }
 
-  async render() {
+  render() {
     const columnDescriptions = [
       {
         key: "fileName",
@@ -136,12 +136,14 @@ export class ReferenceFont extends UnlitElement {
       filesUIList.setSelectedItemIndex(undefined, true);
       await deleteFontFromOPFS(fileItem);
     });
-    const persistentFileItems = await loadAllFontsFromOPFS();
-    // console.log(persistentFileItems, typeof persistentFileItems);
-    filesUIList.setItems([...filesUIList.items, ...persistentFileItems]);
-    if (filesUIList.getSelectedItemIndex() === undefined) {
-      filesUIList.setSelectedItemIndex(0, true);
-    }
+    loadAllFontsFromOPFS().then((persistentFileItems) => {
+      // console.log(persistentFileItems);
+      filesUIList.setItems([...filesUIList.items, ...persistentFileItems]);
+      if (filesUIList.getSelectedItemIndex() === undefined) {
+        filesUIList.setSelectedItemIndex(0, true);
+      }
+    });
+
     const content = [
       div({ class: "title" }, ["Reference font"]),
       div({}, [

--- a/src/fontra/client/web-components/reference-font.js
+++ b/src/fontra/client/web-components/reference-font.js
@@ -179,7 +179,7 @@ export class ReferenceFont extends UnlitElement {
     this.filesUIList.setItems(newItems);
     this.filesUIList.setSelectedItemIndex(newSelectedItemIndex, true);
 
-    const writtenFontItems = [];
+    const writtenFontItems = [...this.listController.model.fontList];
     try {
       for (const fontItem of fontItems) {
         await writeFontFileToOPFS(fontItem.fontIdentifier, fontItem.droppedFile);
@@ -195,7 +195,7 @@ export class ReferenceFont extends UnlitElement {
     // Only notify the list controller *after* the files have been written,
     // or else other tabs will try to read the font data too soon and will
     // fail
-    this.listController.setItem("fontList", cleanFontItems(newItems), {
+    this.listController.setItem("fontList", cleanFontItems(writtenFontItems), {
       senderID: this,
     });
   }

--- a/src/fontra/client/web-components/reference-font.js
+++ b/src/fontra/client/web-components/reference-font.js
@@ -129,7 +129,8 @@ export class ReferenceFont extends UnlitElement {
       const items = [...filesUIList.items];
       const fileItem = items[index];
       document.fonts.delete(fileItem.fontFace);
-      // TODO: fix reference font not deleted from canvas (just canvas not updated?!)
+      // update model to trigger canvas update (delete reference font from canvas)
+      this.model.referenceFontName = undefined;
       items.splice(index, 1);
       filesUIList.setItems(items);
       filesUIList.setSelectedItemIndex(undefined, true);

--- a/src/fontra/client/web-components/reference-font.js
+++ b/src/fontra/client/web-components/reference-font.js
@@ -229,28 +229,9 @@ async function getOPFSInfo() {
   }
 }
 
-async function getOPFSRoot() {
-  let root = null;
-  try {
-    root = await navigator.storage.getDirectory();
-  } catch (error) {
-    dialog(
-      "Unable to open Origin Private File System.",
-      error.toString(),
-      [{ title: "OK" }],
-      5000
-    );
-  }
-  return root;
-}
-
 async function getOPFSFontsDir() {
-  let root = await getOPFSRoot();
-  if (!root) {
-    return null;
-  }
-  const fontsDir = await root.getDirectoryHandle("reference-fonts", { create: true });
-  return fontsDir;
+  let root = await navigator.storage.getDirectory();
+  return await root.getDirectoryHandle("reference-fonts", { create: true });
 }
 
 async function listFontsInOPFS() {

--- a/src/fontra/client/web-components/reference-font.js
+++ b/src/fontra/client/web-components/reference-font.js
@@ -200,8 +200,12 @@ async function getOPFSRoot() {
     root = await navigator.storage.getDirectory();
     // TODO: check space available
   } catch (error) {
-    // TODO: replace with dialog
-    alert("Unable to open OPFS. \n" + error);
+    dialog(
+      "Unable to open Origin Private File System.",
+      error.toString(),
+      [{ title: "OK" }],
+      5000
+    );
   }
   return root;
 }
@@ -250,8 +254,12 @@ async function loadFontFromOPFS(fontName) {
     const fontFile = new File([fontFileBlob], fontName, { type: "font/ttf" });
     return fontFile;
   } catch (error) {
-    // TODO: replace with dialog
-    alert("Unable to load font from OPFS. \n" + error);
+    dialog(
+      "Unable to load font from Origin Private File System.",
+      error.toString(),
+      [{ title: "OK" }],
+      5000
+    );
     return null;
   }
 }
@@ -265,8 +273,12 @@ async function deleteFontFromOPFS(font) {
     // when one of them gets deleted, the file stored in OPFS gets deleted too,
     // subsequent items deletion will throw this exception
     // because the file has already been deleted previously.
-    // TODO: replace with dialog
-    alert("Unable to delete font file from OPFS. \n" + error);
+    dialog(
+      "Unable to delete font file from Origin Private File System.",
+      error.toString(),
+      [{ title: "OK" }],
+      5000
+    );
   }
 }
 
@@ -281,8 +293,12 @@ async function saveFontToOPFS(file) {
   try {
     await fontFileIO.write(fontFileBinaryData);
   } catch (error) {
-    // TODO: replace with dialog
-    alert("Unable to save font file to OPFS. \n" + error);
+    dialog(
+      "Unable to save font file to Origin Private File System.",
+      error.toString(),
+      [{ title: "OK" }],
+      5000
+    );
   } finally {
     await fontFileIO.close();
   }

--- a/src/fontra/client/web-components/reference-font.js
+++ b/src/fontra/client/web-components/reference-font.js
@@ -143,13 +143,13 @@ export class ReferenceFont extends UnlitElement {
   }
 
   async _filesDropHandler(files) {
-    const fileItemsInvalid = [];
-    const fileItems = [...files]
+    const fontItemsInvalid = [];
+    const fontItems = [...files]
       .filter((file) => {
         const fileExtension = fileNameExtension(file.name).toLowerCase();
         const fileTypeSupported = fontFileExtensions.has(fileExtension);
         if (!fileTypeSupported) {
-          fileItemsInvalid.push(file);
+          fontItemsInvalid.push(file);
         }
         return fileTypeSupported;
       })
@@ -162,11 +162,11 @@ export class ReferenceFont extends UnlitElement {
         };
       });
 
-    if (fileItemsInvalid.length) {
+    if (fontItemsInvalid.length) {
       const dialogTitle = `The following item${
-        fileItemsInvalid.length > 1 ? "s" : ""
+        fontItemsInvalid.length > 1 ? "s" : ""
       } can't be used as a reference font:`;
-      const dialogMessage = fileItemsInvalid
+      const dialogMessage = fontItemsInvalid
         .map((file) => {
           return `- ${file.name}`;
         })
@@ -184,12 +184,12 @@ export class ReferenceFont extends UnlitElement {
     }
 
     const newSelectedItemIndex = this.filesUIList.items.length;
-    const newItems = [...this.filesUIList.items, ...fileItems];
+    const newItems = [...this.filesUIList.items, ...fontItems];
     this.filesUIList.setItems(newItems);
 
-    for (const fileItem of fileItems) {
-      await writeFontFileToOPFS(fileItem.fontIdentifier, fileItem.droppedFile);
-      delete fileItem.droppedFile;
+    for (const fontItem of fontItems) {
+      await writeFontFileToOPFS(fontItem.fontIdentifier, fontItem.droppedFile);
+      delete fontItem.droppedFile;
     }
 
     // Only notify the list controller *after* the files have been written,
@@ -203,8 +203,8 @@ export class ReferenceFont extends UnlitElement {
   }
 
   async _listSelectionChangedHandler() {
-    const fileItem = this.filesUIList.getSelectedItem();
-    if (!fileItem) {
+    const fontItem = this.filesUIList.getSelectedItem();
+    if (!fontItem) {
       this.model.referenceFontName = undefined;
       this.listController.model.selectedFontIndex = null;
       return;
@@ -213,21 +213,21 @@ export class ReferenceFont extends UnlitElement {
     this.listController.model.selectedFontIndex =
       this.filesUIList.getSelectedItemIndex();
 
-    if (!fileItem.fontFace) {
-      if (!fileItem.objectURL) {
-        fileItem.objectURL = URL.createObjectURL(
-          await readFontFileFromOPFS(fileItem.fontIdentifier)
+    if (!fontItem.fontFace) {
+      if (!fontItem.objectURL) {
+        fontItem.objectURL = URL.createObjectURL(
+          await readFontFileFromOPFS(fontItem.fontIdentifier)
         );
       }
-      fileItem.fontFace = new FontFace(
-        fileItem.fontIdentifier,
-        `url(${fileItem.objectURL})`,
+      fontItem.fontFace = new FontFace(
+        fontItem.fontIdentifier,
+        `url(${fontItem.objectURL})`,
         {}
       );
-      document.fonts.add(fileItem.fontFace);
-      await fileItem.fontFace.load();
+      document.fonts.add(fontItem.fontFace);
+      await fontItem.fontFace.load();
     }
-    this.model.referenceFontName = fileItem.fontIdentifier;
+    this.model.referenceFontName = fontItem.fontIdentifier;
   }
 
   async _deleteSelectedItemHandler() {

--- a/src/fontra/client/web-components/reference-font.js
+++ b/src/fontra/client/web-components/reference-font.js
@@ -64,7 +64,7 @@ export class ReferenceFont extends UnlitElement {
     this.filesUIList.columnDescriptions = columnDescriptions;
     this.filesUIList.minHeight = "6em";
 
-    this.filesUIList.onFilesDrop = (files) => this._filesDropHAndler(files);
+    this.filesUIList.onFilesDrop = (files) => this._filesDropHandler(files);
 
     this.filesUIList.addEventListener("listSelectionChanged", () =>
       this._listSelectionChangedHandler()
@@ -141,7 +141,7 @@ export class ReferenceFont extends UnlitElement {
     }
   }
 
-  async _filesDropHAndler(files) {
+  async _filesDropHandler(files) {
     const fileItemsInvalid = [];
     const fileItems = [...files]
       .filter((file) => {

--- a/src/fontra/client/web-components/reference-font.js
+++ b/src/fontra/client/web-components/reference-font.js
@@ -1,6 +1,6 @@
 import { ObservableController } from "/core/observable-object.js";
 import { UnlitElement, div, input, label, span } from "/core/unlit.js";
-import { fileNameExtension } from "/core/utils.js";
+import { fileNameBasename, fileNameExtension } from "/core/utils.js";
 import { themeColorCSS } from "./theme-support.js";
 import { UIList } from "./ui-list.js";
 import { dialog } from "/web-components/modal-dialog.js";
@@ -238,7 +238,7 @@ async function loadAllFontsFromOPFS() {
     let fontName = font["name"];
     font["file"] = await loadFontFromOPFS(fontName);
     font["fileName"] = fontName;
-    font["fontName"] = fontName.split(".")[0]; // TODO
+    font["fontName"] = fileNameBasename(fontName);
   }
   // console.log(fonts);
   return fonts;

--- a/src/fontra/client/web-components/reference-font.js
+++ b/src/fontra/client/web-components/reference-font.js
@@ -253,9 +253,18 @@ export class ReferenceFont extends UnlitElement {
     this.model.referenceFontName = undefined;
 
     this.filesUIList.setItems(newItems);
-    this.listController.setItem("fontList", cleanFontItems(newItems), {
-      senderID: this,
-    });
+
+    // Only share those fonts that we successfully stored before
+    const storedFontIDs = new Set(
+      this.listController.model.fontList.map((item) => item.fontIdentifier)
+    );
+    this.listController.setItem(
+      "fontList",
+      cleanFontItems(newItems.filter((item) => storedFontIDs.has(item.fontIdentifier))),
+      {
+        senderID: this,
+      }
+    );
 
     for (const fontItem of itemsToDelete) {
       garbageCollectFontItem(fontItem);

--- a/src/fontra/client/web-components/reference-font.js
+++ b/src/fontra/client/web-components/reference-font.js
@@ -1,6 +1,6 @@
 import { ObservableController } from "/core/observable-object.js";
 import { UnlitElement, div, input, label, span } from "/core/unlit.js";
-import { fileNameExtension } from "/core/utils.js";
+import { fileNameExtension, withTimeout } from "/core/utils.js";
 import { themeColorCSS } from "./theme-support.js";
 import { UIList } from "./ui-list.js";
 import { dialog } from "/web-components/modal-dialog.js";
@@ -343,18 +343,21 @@ function getWriteWorker() {
   return worker;
 }
 
-function writeFontFileToOPFSInWorker(fileName, file) {
-  return new Promise((resolve, reject) => {
-    const worker = getWriteWorker();
-    worker.onmessage = (event) => {
-      if (event.data.error) {
-        reject(event.data.error);
-      } else {
-        resolve(event.data.returnValue);
-      }
-    };
-    worker.postMessage({ path: ["reference-fonts", fileName], file });
-  });
+async function writeFontFileToOPFSInWorker(fileName, file) {
+  return await withTimeout(
+    new Promise((resolve, reject) => {
+      const worker = getWriteWorker();
+      worker.onmessage = (event) => {
+        if (event.data.error) {
+          reject(event.data.error);
+        } else {
+          resolve(event.data.returnValue);
+        }
+      };
+      worker.postMessage({ path: ["reference-fonts", fileName], file });
+    }),
+    5000
+  );
 }
 
 customElements.define("reference-font", ReferenceFont);

--- a/src/fontra/client/web-components/reference-font.js
+++ b/src/fontra/client/web-components/reference-font.js
@@ -62,6 +62,8 @@ export class ReferenceFont extends UnlitElement {
     this.filesUIList = new UIList();
 
     this.filesUIList.columnDescriptions = columnDescriptions;
+    this.filesUIList.itemEqualFunc = (a, b) => a.fontIdentifier == b.fontIdentifier;
+
     this.filesUIList.minHeight = "6em";
 
     this.filesUIList.onFilesDrop = (files) => this._filesDropHandler(files);
@@ -134,9 +136,7 @@ export class ReferenceFont extends UnlitElement {
       garbageCollectFontItem(leftoverItem);
     }
 
-    const selectedItem = this.filesUIList.getSelectedItem();
-    this.filesUIList.setItems(newItems);
-    this.filesUIList.setSelectedItem(selectedItem, true);
+    this.filesUIList.setItems(newItems, true);
     if (this.filesUIList.getSelectedItemIndex() === undefined) {
       this.model.referenceFontName = undefined;
     }

--- a/src/fontra/client/web-components/ui-list.js
+++ b/src/fontra/client/web-components/ui-list.js
@@ -172,13 +172,13 @@ export class UIList extends UnlitElement {
     this.requestUpdate();
   }
 
-  setItems(items) {
+  setItems(items, shouldDispatchEvent = false) {
     const selectedItem = this.getSelectedItem();
     this.contents.innerHTML = "";
     this.items = items;
     this._updateVisibility();
     this._itemsBackLog = Array.from(items);
-    this.setSelectedItem(selectedItem, false);
+    this.setSelectedItem(selectedItem, shouldDispatchEvent);
     this._addMoreItemsIfNeeded();
   }
 

--- a/src/fontra/client/web-components/ui-list.js
+++ b/src/fontra/client/web-components/ui-list.js
@@ -377,10 +377,14 @@ export class UIList extends UnlitElement {
     }
     if (
       (event.key === "Delete" || event.key === "Backspace") &&
-      this.selectedItemIndex !== undefined
+      (this.selectedItemIndex !== undefined || event.altKey)
     ) {
       event.stopImmediatePropagation();
-      this._dispatchEvent("deleteKey");
+      if (event.altKey) {
+        this._dispatchEvent("deleteKeyAlt");
+      } else {
+        this._dispatchEvent("deleteKey");
+      }
       return;
     }
     if (event.key !== "ArrowUp" && event.key !== "ArrowDown") {

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -236,6 +236,12 @@ export class EditorController {
     this.initTools();
     await this.initSidebarDesignspace();
 
+    const blankFont = new FontFace("AdobeBlank", `url("/fonts/AdobeBlank.woff2")`, {});
+    document.fonts.add(blankFont);
+    await blankFont.load();
+
+    // Delay a tiny amount to account for a delay in the sidebars being set up,
+    // which affects the available viewBox
     setTimeout(() => this.setupFromWindowLocation(), 20);
   }
 
@@ -573,10 +579,7 @@ export class EditorController {
     );
   }
 
-  async initSidebarReferenceFont() {
-    const blankFont = new FontFace("AdobeBlank", `url("/fonts/AdobeBlank.woff2")`, {});
-    document.fonts.add(blankFont);
-    await blankFont.load();
+  initSidebarReferenceFont() {
     const referenceFontElement = document.querySelector("#reference-font");
     referenceFontElement.controller.addKeyListener("referenceFontName", (event) => {
       if (event.newValue) {


### PR DESCRIPTION
Make reference font settings persistent by storing dropped font in the Origin Private File System (OPFS).

This PR fixes #519. Also fixes #686.