### PR TITLE
[designspace backend] Ignore the source layer name if it is set, but equals the default layer name

### DIFF
--- a/src/fontra/backends/designspace.py
+++ b/src/fontra/backends/designspace.py
@@ -136,7 +136,13 @@ class DesignspaceBackend:
                 path=source.path, name=sourceLayerName
             )
             sourceStyleName = source.styleName or sourceLayer.fileName
-            sourceName = makeUniqueSourceName(source.layerName or sourceStyleName)
+            sourceName = (
+                sourceStyleName
+                if not source.layerName
+                or source.layerName == reader.getDefaultLayerName()
+                else source.layerName
+            )
+            sourceName = makeUniqueSourceName(sourceName)
 
             self.dsSources.append(
                 DSSource(

--- a/test-py/data/mutatorsans/MutatorSans.designspace
+++ b/test-py/data/mutatorsans/MutatorSans.designspace
@@ -23,7 +23,7 @@
     </rule>
   </rules>
   <sources>
-    <source filename="MutatorSansLightCondensed.ufo" familyname="MutatorMathTest" stylename="LightCondensed">
+    <source filename="MutatorSansLightCondensed.ufo" familyname="MutatorMathTest" stylename="LightCondensed" layer="foreground">
       <lib copy="1"/>
       <groups copy="1"/>
       <features copy="1"/>


### PR DESCRIPTION
Also ignore the source layer name if it is set, but equals the default layer name.

This fixes #702.