### PR TITLE
Write unittests for utils.js

### DIFF
--- a/src/fontra/client/core/utils.js
+++ b/src/fontra/client/core/utils.js
@@ -99,6 +99,7 @@ export function parseCookies(str) {
   }
   return str
     .split(";")
+    .filter((s) => s)
     .map((v) => v.split("="))
     .reduce((acc, v) => {
       acc[decodeURIComponent(v[0].trim())] = decodeURIComponent(v[1].trim());
@@ -344,7 +345,7 @@ export function rgbaToCSS(rgba) {
   if (channels[3] == 255) {
     channels.pop();
   }
-  return `rgb(${channels.join(",")})`;
+  return `${channels.length === 4 ? "rgba" : "rgb"}(${channels.join(",")})`;
 }
 
 export function clamp(number, min, max) {

--- a/test-js/test-utils.js
+++ b/test-js/test-utils.js
@@ -58,7 +58,7 @@ describe("objectsEquals", () => {
 });
 
 describe("consolidateCalls", () => {
-  it("returns the function that will be executed in the next cycle of event loop", () => {
+  it("returns a function that will be executed in the next cycle of event loop", () => {
     let itWorked = false;
     const fun = consolidateCalls(() => {
       itWorked = true;
@@ -69,7 +69,7 @@ describe("consolidateCalls", () => {
       expect(itWorked).to.be.true;
     });
   });
-  it("The callback executed once", () => {
+  it("the callback should be executed only once", () => {
     let workedTimes = 0;
     const fun = consolidateCalls(() => {
       workedTimes++;


### PR DESCRIPTION
- Continuation for #510.
- Fixed returning `rgb(` css function for rgba values
- Fixed error thrown when parsing cookie with trailing semicolon.
