### PR TITLE
[filesystem] Drop fonthandler when the last connection using it goes away

### DIFF
--- a/src/fontra/core/server.py
+++ b/src/fontra/core/server.py
@@ -155,7 +155,7 @@ class FontraServer:
             await websocket.close()
         else:
             connection = RemoteObjectConnection(websocket, path, subject, True)
-            with subject.useConnection(connection):
+            async with subject.useConnection(connection):
                 await connection.handleConnection()
         finally:
             self._activeWebsockets.discard(websocket)

--- a/src/fontra/filesystem/projectmanager.py
+++ b/src/fontra/filesystem/projectmanager.py
@@ -87,7 +87,18 @@ class FileSystemProjectManager:
             if projectPath is None:
                 raise FileNotFoundError(projectPath)
             backend = getFileSystemBackend(projectPath)
-            fontHandler = FontHandler(backend, readOnly=self.readOnly)
+
+            async def closeFontHandler():
+                logger.info(f"closing FontHandler for '{path}'")
+                del self.fontHandlers[path]
+                await fontHandler.close()
+
+            logger.info(f"new FontHandler for '{path}'")
+            fontHandler = FontHandler(
+                backend,
+                readOnly=self.readOnly,
+                allConnectionsClosedCallback=closeFontHandler,
+            )
             await fontHandler.startTasks()
             self.fontHandlers[path] = fontHandler
         return fontHandler


### PR DESCRIPTION
FontHandler instances are cached per access path, but they were never cleaned up, so it was not possible to reload underlying data unless the backend specifically implemented it. This change makes cleans up the FontHandler instance after the last connection using it goes away. Reloading a (single) page will now recreate the FontHandler.