### PR TITLE
Set canvas language to someting 'neutral', so that user language settings have no influence here

### DIFF
--- a/src/fontra/views/editor/editor.html
+++ b/src/fontra/views/editor/editor.html
@@ -73,7 +73,7 @@
       </div>
 
       <div class="main-container">
-        <canvas id="edit-canvas" tabindex="1"></canvas>
+        <canvas id="edit-canvas" tabindex="1" lang="en"></canvas>
 
         <div id="mini-console"></div>
 


### PR DESCRIPTION
I would prefer to set the language when drawing text in the canvas, but I couldn't find a way. Setting the `lang` attr on the `<canvas>` element is at least effective.

This fixes #725.