### PR TITLE
Restore focus after setSelectionRange() call, to work around Safari oddity.

### DIFF
--- a/src/fontra/client/core/utils.js
+++ b/src/fontra/client/core/utils.js
@@ -314,9 +314,12 @@ export function isActiveElementTypeable() {
   return false;
 }
 
-function findNestedActiveElement(element) {
+export function findNestedActiveElement(element) {
   // If the element element is part of a Web Component's Shadow DOM, take
   // *its* active element, recursively.
+  if (!element) {
+    element = document.activeElement;
+  }
   return element.shadowRoot && element.shadowRoot.activeElement
     ? findNestedActiveElement(element.shadowRoot.activeElement)
     : element;

--- a/src/fontra/views/editor/panel-text-entry.js
+++ b/src/fontra/views/editor/panel-text-entry.js
@@ -1,4 +1,5 @@
 import * as html from "/core/unlit.js";
+import { findNestedActiveElement } from "/core/utils.js";
 import { css } from "../third-party/lit.js";
 import Panel from "./panel.js";
 
@@ -130,7 +131,13 @@ export default class TextEntryPanel extends Panel {
         return;
       }
       this.textEntryElement.value = event.newValue;
+
+      // https://github.com/googlefonts/fontra/issues/754
+      // In Safari, setSelectionRange() changes the focus. We don't want that,
+      // so we make sure to restore the focus to whatever it was.
+      const savedActiveElement = findNestedActiveElement();
       this.textEntryElement.setSelectionRange(0, 0);
+      savedActiveElement?.focus();
     };
 
     this.textSettingsController.addKeyListener(


### PR DESCRIPTION
Restore focus after setSelectionRange() call, to work around Safari oddity.

This fixes #754.