### PR TITLE
[designspace] Only write classic components if _all_ components in _all_ layers are classic

### DIFF
--- a/src/fontra/backends/designspace.py
+++ b/src/fontra/backends/designspace.py
@@ -282,13 +282,11 @@ class DesignspaceBackend:
         revLayerNameMapping = reverseSparseDict(layerNameMapping)
 
         haveVariableComponents = any(
-            any(
-                compo.location
-                or compo.transformation.tCenterX
-                or compo.transformation.tCenterY
-                for compo in layer.glyph.components
-            )
+            compo.location
+            or compo.transformation.tCenterX
+            or compo.transformation.tCenterY
             for layer in glyph.layers.values()
+            for compo in layer.glyph.components
         )
 
         modTimes = set()

--- a/src/fontra/backends/designspace.py
+++ b/src/fontra/backends/designspace.py
@@ -762,13 +762,13 @@ def populateUFOLayerGlyph(
     variableComponents = []
     for component in staticGlyph.components:
         if component.location or forceVariableComponents:
-            # It's a variable component
+            # Store as a variable component
             varCoDict = {"base": component.name, "location": component.location}
             if component.transformation != DecomposedTransform():
                 varCoDict["transformation"] = asdict(component.transformation)
             variableComponents.append(varCoDict)
         else:
-            # It's a regular component
+            # Store as a regular component
             pen.addComponent(
                 component.name,
                 cleanupTransform(component.transformation.toTransform()),


### PR DESCRIPTION
Previously, it was decided on a per layer / per component basis whether it would be stored as a classic component or as a variable component.

This could mess up the component order if a component was considered variable in one source and not in another, even though that can be a perfectly compatible situation.

Additionally, if a component would use tCenterX/Y but no location, it would be stored as a classic component, thereby losing the tCenterX/Y information.

To avoid that, only write classic components if _all_ components in _all_ layers are classic (non-variable).

This fixes #585.