### PR TITLE
Rect-select: handle empty component: its controlBounds will be null/undefined

### DIFF
--- a/src/fontra/client/core/glyph-controller.js
+++ b/src/fontra/client/core/glyph-controller.js
@@ -531,8 +531,10 @@ class ComponentController {
   }
 
   intersectsRect(rect) {
+    const controlBounds = this.controlBounds;
     return (
-      sectRect(rect, this.controlBounds) &&
+      controlBounds &&
+      sectRect(rect, controlBounds) &&
       (pointInConvexPolygon(rect.xMin, rect.yMin, this.convexHull) ||
         rectIntersectsPolygon(rect, this.convexHull)) &&
       this.unpackedContours.some(


### PR DESCRIPTION
This fixes #783.