### PR TITLE
[context-menu] Fix wrong items vertical margins and left padding.

### DIFF
--- a/src/fontra/client/web-components/menu-panel.js
+++ b/src/fontra/client/web-components/menu-panel.js
@@ -62,7 +62,7 @@ class MenuPanel extends SimpleElement {
       display: grid;
       grid-template-columns: 1em auto;
       gap: 0em;
-      padding: 0.05em 0.8em 0.05em 0.0em; /* top, right, bottom, left */
+      padding: 0.1em 0.8em 0.1em 0.0em; /* top, right, bottom, left */
       color: #8080a0;
     }
 

--- a/src/fontra/client/web-components/menu-panel.js
+++ b/src/fontra/client/web-components/menu-panel.js
@@ -62,7 +62,7 @@ class MenuPanel extends SimpleElement {
       display: grid;
       grid-template-columns: 1em auto;
       gap: 0em;
-      padding: 0.1em 0.8em 0.1em 0.0em; /* top, right, bottom, left */
+      padding: 0.05em 0.8em 0.05em 0.0em; /* top, right, bottom, left */
       color: #8080a0;
     }
 

--- a/src/fontra/client/web-components/menu-panel.js
+++ b/src/fontra/client/web-components/menu-panel.js
@@ -56,6 +56,7 @@ class MenuPanel extends SimpleElement {
       border: none;
       border-top: 1px solid #80808080;
       height: 1px;
+      margin: 0.4em 0 0.35em 0;
     }
 
     .context-menu-item {

--- a/src/fontra/client/web-components/menu-panel.js
+++ b/src/fontra/client/web-components/menu-panel.js
@@ -62,7 +62,7 @@ class MenuPanel extends SimpleElement {
       display: grid;
       grid-template-columns: 1em auto;
       gap: 0em;
-      padding: 0.1em 0.8em 0.1em 0.5em; /* top, right, bottom, left */
+      padding: 0.1em 0.8em 0.1em 0.0em; /* top, right, bottom, left */
       color: #8080a0;
     }
 

--- a/src/fontra/client/web-components/menu-panel.js
+++ b/src/fontra/client/web-components/menu-panel.js
@@ -52,27 +52,23 @@ class MenuPanel extends SimpleElement {
       cursor: default;
     }
 
+    .menu-container {
+      margin: 0.2em 0em 0.3em 0em; /* top, right, bottom, left */
+    }
+
     .menu-item-divider {
       border: none;
       border-top: 1px solid #80808080;
       height: 1px;
-      margin: 0.4em 0 0.35em 0;
+      margin: 0.3em 0 0.2em 0;
     }
 
     .context-menu-item {
       display: grid;
       grid-template-columns: 1em auto;
       gap: 0em;
-      padding: 0.1em 0.8em 0.1em 0.0em; /* top, right, bottom, left */
+      padding: 0.1em 0.8em 0.1em 0.5em; /* top, right, bottom, left */
       color: #8080a0;
-    }
-
-    .context-menu-item:first-of-type {
-        margin-top: 0.5em;
-    }
-
-    .context-menu-item:last-of-type {
-        margin-bottom: 0.5em;
     }
 
     .context-menu-item.enabled {
@@ -97,7 +93,7 @@ class MenuPanel extends SimpleElement {
     this.style = "display: none;";
     this.position = position;
     this.positionContainer = positionContainer;
-    this.menuElement = html.div({ tabindex: 0 });
+    this.menuElement = html.div({ class: "menu-container", tabindex: 0 });
 
     // No context menu on our context menu please:
     this.menuElement.oncontextmenu = (event) => event.preventDefault();

--- a/src/fontra/client/web-components/menu-panel.js
+++ b/src/fontra/client/web-components/menu-panel.js
@@ -66,6 +66,14 @@ class MenuPanel extends SimpleElement {
       color: #8080a0;
     }
 
+    .context-menu-item:first-of-type {
+        margin-top: 0.5em;
+    }
+
+    .context-menu-item:last-of-type {
+        margin-bottom: 0.5em;
+    }
+
     .context-menu-item.enabled {
       color: inherit;
     }


### PR DESCRIPTION
Fix #800 

Before

<img width="180" alt="Screenshot 2023-09-13 at 15 43 09" src="https://github.com/googlefonts/fontra/assets/1035294/e848edd4-c597-4f79-8947-87fb445d118c">

---

After

<img width="167" alt="Screenshot 2023-09-13 at 15 56 30" src="https://github.com/googlefonts/fontra/assets/1035294/790d8a62-571b-4c97-86bf-9c2e35441505">


