### PR TITLE
[ui-list] Improve scrollbars behaviour.

### DIFF
--- a/src/fontra/client/web-components/ui-list.js
+++ b/src/fontra/client/web-components/ui-list.js
@@ -26,8 +26,7 @@ export class UIList extends UnlitElement {
     }
 
     .container {
-      overflow-x: hidden;
-      overflow-y: auto;
+      overflow: auto;
       height: 100%;
       width: 100%;
       box-sizing: border-box;
@@ -51,8 +50,7 @@ export class UIList extends UnlitElement {
     }
 
     .header-container {
-      overflow-x: hidden;
-      overflow-y: auto;
+      overflow: auto;
       height: 100%;
       width: 100%;
       box-sizing: border-box;

--- a/src/fontra/client/web-components/ui-list.js
+++ b/src/fontra/client/web-components/ui-list.js
@@ -26,7 +26,8 @@ export class UIList extends UnlitElement {
     }
 
     .container {
-      overflow: scroll;
+      overflow-x: hidden;
+      overflow-y: auto;
       height: 100%;
       width: 100%;
       box-sizing: border-box;
@@ -50,7 +51,8 @@ export class UIList extends UnlitElement {
     }
 
     .header-container {
-      overflow: scroll;
+      overflow-x: hidden;
+      overflow-y: auto;
       height: 100%;
       width: 100%;
       box-sizing: border-box;


### PR DESCRIPTION
This fixes part of #293.

We can assume that the ui-list is always a vertically scrollable list, but it doesn't need always to be scrolled, so these are the changes:

- Horizontal scrollbars are always hidden.
- Vertical scrollbars are visible only if necessary.