### PR TITLE
Improve which sources are marked as "incompatible"

### DIFF
--- a/src/fontra/client/core/glyph-controller.js
+++ b/src/fontra/client/core/glyph-controller.js
@@ -234,7 +234,7 @@ export class VariableGlyphController {
           layerGlyphs,
           errors
         );
-        if (countTrueValues(errors[referenceLayerName]) <= this.sources.length / 2) {
+        if (Object.keys(errors[referenceLayerName]).length <= this.sources.length / 2) {
           // good enough
           break;
         }
@@ -995,7 +995,6 @@ function checkInterpolationCompatibility(
     if (layerName === referenceLayerName) {
       continue;
     }
-    errors[layerName] = null;
     if (layerName in previousErrors) {
       const error = previousErrors[layerName][referenceLayerName];
       if (error) {
@@ -1010,14 +1009,4 @@ function checkInterpolationCompatibility(
     }
   }
   return errors;
-}
-
-function countTrueValues(obj) {
-  let count = 0;
-  for (const item of Object.values(obj)) {
-    if (item) {
-      count++;
-    }
-  }
-  return count;
 }


### PR DESCRIPTION
This attempts to find a more likely candidate for the reference source, based on the balance between compatible and incompatible sources. It's still a bi of a heuristic, but is deterministic, and should work well in most cases.

Example 1:
- The default source is incompatible with all other sources, but all other sources are compatible with themselves, we should mark the default source as incompatible, and not the rest (as noted in https://github.com/googlefonts/fontra/issues/704#issuecomment-1723002207)

Example 2: 
- If among 5 sources 3 sources are compatible with each other, but not with the remaining two, which are also compatible with another, this will mark the set of two as the buggy ones, and not the set of three, regardless of the order of the sources.

This fixes #818.