### PR TITLE
[selection info panel] Set default value on axis sliders

### DIFF
--- a/src/fontra/client/web-components/ui-form.js
+++ b/src/fontra/client/web-components/ui-form.js
@@ -156,8 +156,9 @@ export class Form extends SimpleElement {
 
   _addEditNumberSlider(valueElement, fieldItem) {
     const rangeElement = new RangeSlider();
-    rangeElement.minValue = fieldItem.minValue;
     rangeElement.value = fieldItem.value;
+    rangeElement.minValue = fieldItem.minValue;
+    rangeElement.defaultValue = fieldItem.defaultValue;
     rangeElement.maxValue = fieldItem.maxValue;
 
     {

--- a/src/fontra/views/editor/panel-selection-info.js
+++ b/src/fontra/views/editor/panel-selection-info.js
@@ -217,6 +217,7 @@ export default class SelectionInfoPanel extends Panel {
             label: axis.name,
             value: value,
             minValue: axis.minValue,
+            defaultValue: axis.defaultValue,
             maxValue: axis.maxValue,
             disabled: !canEdit,
           });


### PR DESCRIPTION
Set default value on axis sliders, so alt-click does the expected thing, and the thumb gets style correctly at the default pos

This fixes #830.