### PR TITLE
Use `pre-commit` GitHub action.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,8 +43,7 @@ jobs:
       #     npm install
 
       - name: Run pre-commit
-        run: |
-          pre-commit run --all-files --verbose --show-diff-on-failure
+        uses: pre-commit/action@v3.0.0
 
       - name: Run Python tests with pytest
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,8 @@ jobs:
 
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.0
+        with:
+          extra_args: --all-files --verbose --show-diff-on-failure
 
       - name: Run Python tests with pytest
         run: |


### PR DESCRIPTION
Fix issue #834 by using the `pre-commit` GH action *(it caches installed hooks)*.

Running `pre-commit` is now much faster, before it took ~30s, now just ~10s.