### PR TITLE
Multi-source editing

### DIFF
--- a/src/fontra/client/core/changes.js
+++ b/src/fontra/client/core/changes.js
@@ -104,6 +104,13 @@ export class ChangeCollector {
     }
     return ChangeCollector.fromChanges(forwardChanges, rollbackChanges);
   }
+
+  prefixed(pathPrefix) {
+    return ChangeCollector.fromChanges(
+      consolidateChanges(this.change, pathPrefix),
+      consolidateChanges(this.rollbackChange, pathPrefix)
+    );
+  }
 }
 
 export function consolidateChanges(changes, prefixPath) {

--- a/src/fontra/client/core/glyph-controller.js
+++ b/src/fontra/client/core/glyph-controller.js
@@ -354,12 +354,20 @@ export class VariableGlyphController {
   }
 
   async instantiateController(location, layerName, getGlyphFunc) {
-    const sourceIndex = this.getSourceIndex(location);
+    let sourceIndex = this.getSourceIndex(location);
     location = this.mapLocationGlobalToLocal(location);
 
     if (!layerName || !(layerName in this.layers)) {
       if (sourceIndex !== undefined) {
         layerName = this.sources[sourceIndex].layerName;
+      }
+    }
+    if (layerName && sourceIndex === undefined) {
+      for (const [i, source] of enumerate(this.sources)) {
+        if (source.layerName === layerName) {
+          sourceIndex = i;
+          break;
+        }
       }
     }
 

--- a/src/fontra/client/core/path-functions.js
+++ b/src/fontra/client/core/path-functions.js
@@ -1,3 +1,4 @@
+import { Bezier } from "../third-party/bezier-js.js";
 import { arrayExtend, range, reversed } from "./utils.js";
 import { VarPackedPath } from "./var-path.js";
 import * as vector from "./vector.js";
@@ -26,8 +27,11 @@ export function insertPoint(path, intersection) {
     selectedPointIndex = insertIndex;
   } else {
     // insert point in curve
+    const segments = [...path.iterContourDecomposedSegments(contourIndex)];
+    const segment = segments[intersection.segmentIndex];
+    const bezier = new Bezier(...segment.points);
     const firstOffCurve = path.getPoint(segment.parentPointIndices[1]);
-    const { left, right } = segment.bezier.split(intersection.t);
+    const { left, right } = bezier.split(intersection.t);
     if (firstOffCurve.type === "cubic") {
       const points = [...left.points.slice(1), ...right.points.slice(1, 3)].map(
         roundVector

--- a/src/fontra/client/core/path-functions.js
+++ b/src/fontra/client/core/path-functions.js
@@ -22,7 +22,7 @@ export function insertPoint(path, intersection) {
     path.insertPoint(
       contourIndex,
       insertIndex,
-      interpolatePoints(...points, intersection.t)
+      vector.interpolateVectors(...points, intersection.t)
     );
     selectedPointIndex = insertIndex;
   } else {
@@ -423,9 +423,4 @@ function* rangesToContours(path, startPoint, ranges) {
     delete points.at(-1).smooth;
     yield { points: points, isClosed: false };
   }
-}
-
-function interpolatePoints(pt1, pt2, t) {
-  const d = vector.subVectors(pt2, pt1);
-  return vector.addVectors(pt1, vector.mulVectorScalar(d, t));
 }

--- a/src/fontra/client/core/path-functions.js
+++ b/src/fontra/client/core/path-functions.js
@@ -103,14 +103,17 @@ function impliedPoint(pointA, pointB) {
   };
 }
 
-export function insertHandles(path, handlePoints, insertIndex, type = "cubic") {
+export function insertHandles(path, segmentPoints, insertIndex, type = "cubic") {
   let [contourIndex, contourPointIndex] = path.getContourAndPointIndex(insertIndex);
   if (!contourPointIndex) {
     contourPointIndex = path.getNumPointsOfContour(contourIndex);
   }
   insertIndex = path.getAbsolutePointIndex(contourIndex, contourPointIndex, true);
-  handlePoints = handlePoints.map((pt) => {
-    return { x: pt.x, y: pt.y, type: type };
+  const handlePoints = [
+    vector.interpolateVectors(...segmentPoints, 1 / 3),
+    vector.interpolateVectors(...segmentPoints, 2 / 3),
+  ].map((pt) => {
+    return { ...pt, type: type };
   });
   path.insertPoint(contourIndex, contourPointIndex, handlePoints[1]);
   path.insertPoint(contourIndex, contourPointIndex, handlePoints[0]);

--- a/src/fontra/client/core/utils.js
+++ b/src/fontra/client/core/utils.js
@@ -418,3 +418,23 @@ export function escapeHTMLCharacters(dangerousString) {
   );
   return safeCharacters.join("");
 }
+
+export function* zip(...args) {
+  const iterators = args.map((arg) => iter(arg));
+  while (true) {
+    const results = iterators.map((it) => it.next());
+    if (results.some((r) => r.done)) {
+      if (!results.every((r) => r.done)) {
+        throw new Error("zip: input arguments have different lengths");
+      }
+      break;
+    }
+    yield results.map((r) => r.value);
+  }
+}
+
+export function* iter(iterable) {
+  for (const item of iterable) {
+    yield item;
+  }
+}

--- a/src/fontra/client/core/vector.js
+++ b/src/fontra/client/core/vector.js
@@ -69,3 +69,8 @@ export function distance(pt1, pt2) {
 export function dotVector(vectorA, vectorB) {
   return vectorA.x * vectorB.x + vectorA.y * vectorB.y;
 }
+
+export function interpolateVectors(vectorA, vectorB, t) {
+  const d = subVectors(vectorB, vectorA);
+  return addVectors(vectorA, mulVectorScalar(d, t));
+}

--- a/src/fontra/views/editor/edit-tools-pen.js
+++ b/src/fontra/views/editor/edit-tools-pen.js
@@ -137,6 +137,9 @@ export class PenTool extends BaseTool {
         let selection;
         for (const layerName of this.sceneController.editingLayerNames) {
           const instance = glyph.layers[layerName]?.glyph;
+          if (!instance) {
+            continue;
+          }
           const path = instance.path;
           selection = insertHandles(
             path,

--- a/src/fontra/views/editor/edit-tools-pen.js
+++ b/src/fontra/views/editor/edit-tools-pen.js
@@ -133,14 +133,18 @@ export class PenTool extends BaseTool {
     } else if (this.sceneModel.pathInsertHandles) {
       const segmentPointIndices =
         this.sceneModel.pathInsertHandles.hit.segment.pointIndices;
-      await this.sceneController.editInstanceAndRecordChanges((instance) => {
-        const path = instance.path;
-        const selection = insertHandles(
-          path,
-          segmentPointIndices.map((i) => path.getPoint(i)),
-          segmentPointIndices[1],
-          this.curveType
-        );
+      await this.sceneController.editGlyphAndRecordChanges((glyph) => {
+        let selection;
+        for (const layerName of this.sceneController.editingLayerNames) {
+          const instance = glyph.layers[layerName]?.glyph;
+          const path = instance.path;
+          selection = insertHandles(
+            path,
+            segmentPointIndices.map((i) => path.getPoint(i)),
+            segmentPointIndices[1],
+            this.curveType
+          );
+        }
         delete this.sceneModel.pathInsertHandles;
         this.sceneController.selection = selection;
         return "Insert Handles";

--- a/src/fontra/views/editor/edit-tools-pen.js
+++ b/src/fontra/views/editor/edit-tools-pen.js
@@ -115,7 +115,7 @@ export class PenTool extends BaseTool {
     if (this.sceneModel.pathConnectTargetPoint?.segment) {
       await this.sceneController.editLayersAndRecordChanges((layerGlyphs) => {
         let selection;
-        for (const layerGlyph of layerGlyphs) {
+        for (const layerGlyph of Object.values(layerGlyphs)) {
           selection = insertPoint(
             layerGlyph.path,
             this.sceneModel.pathConnectTargetPoint
@@ -131,7 +131,7 @@ export class PenTool extends BaseTool {
         this.sceneModel.pathInsertHandles.hit.segment.pointIndices;
       await this.sceneController.editLayersAndRecordChanges((layerGlyphs) => {
         let selection;
-        for (const layerGlyph of layerGlyphs) {
+        for (const layerGlyph of Object.values(layerGlyphs)) {
           const path = layerGlyph.path;
           selection = insertHandles(
             path,

--- a/src/fontra/views/editor/edit-tools-pen.js
+++ b/src/fontra/views/editor/edit-tools-pen.js
@@ -113,15 +113,11 @@ export class PenTool extends BaseTool {
     }
 
     if (this.sceneModel.pathConnectTargetPoint?.segment) {
-      await this.sceneController.editGlyphAndRecordChanges((glyph) => {
+      await this.sceneController.editLayersAndRecordChanges((layerGlyphs) => {
         let selection;
-        for (const layerName of this.sceneController.editingLayerNames) {
-          const instance = glyph.layers[layerName]?.glyph;
-          if (!instance) {
-            continue;
-          }
+        for (const layerGlyph of layerGlyphs) {
           selection = insertPoint(
-            instance.path,
+            layerGlyph.path,
             this.sceneModel.pathConnectTargetPoint
           );
         }
@@ -133,14 +129,10 @@ export class PenTool extends BaseTool {
     } else if (this.sceneModel.pathInsertHandles) {
       const segmentPointIndices =
         this.sceneModel.pathInsertHandles.hit.segment.pointIndices;
-      await this.sceneController.editGlyphAndRecordChanges((glyph) => {
+      await this.sceneController.editLayersAndRecordChanges((layerGlyphs) => {
         let selection;
-        for (const layerName of this.sceneController.editingLayerNames) {
-          const instance = glyph.layers[layerName]?.glyph;
-          if (!instance) {
-            continue;
-          }
-          const path = instance.path;
+        for (const layerGlyph of layerGlyphs) {
+          const path = layerGlyph.path;
           selection = insertHandles(
             path,
             segmentPointIndices.map((i) => path.getPoint(i)),

--- a/src/fontra/views/editor/edit-tools-pen.js
+++ b/src/fontra/views/editor/edit-tools-pen.js
@@ -73,9 +73,8 @@ export class PenTool extends BaseTool {
       if (event.altKey && hit.segment?.points?.length === 2) {
         const pt1 = hit.segment.points[0];
         const pt2 = hit.segment.points[1];
-        const d = vector.subVectors(pt2, pt1);
-        const handle1 = vector.addVectors(pt1, vector.mulVectorScalar(d, 1 / 3));
-        const handle2 = vector.addVectors(pt1, vector.mulVectorScalar(d, 2 / 3));
+        const handle1 = vector.interpolateVectors(pt1, pt2, 1 / 3);
+        const handle2 = vector.interpolateVectors(pt1, pt2, 2 / 3);
         return { insertHandles: { points: [handle1, handle2], hit: hit } };
       } else {
         return { targetPoint: hit };

--- a/src/fontra/views/editor/edit-tools-pen.js
+++ b/src/fontra/views/editor/edit-tools-pen.js
@@ -131,12 +131,14 @@ export class PenTool extends BaseTool {
       });
       return;
     } else if (this.sceneModel.pathInsertHandles) {
+      const segmentPointIndices =
+        this.sceneModel.pathInsertHandles.hit.segment.pointIndices;
       await this.sceneController.editInstanceAndRecordChanges((instance) => {
-        const handles = this.sceneModel.pathInsertHandles;
+        const path = instance.path;
         const selection = insertHandles(
-          instance.path,
-          handles.points,
-          handles.hit.segment.pointIndices[1],
+          path,
+          segmentPointIndices.map((i) => path.getPoint(i)),
+          segmentPointIndices[1],
           this.curveType
         );
         delete this.sceneModel.pathInsertHandles;

--- a/src/fontra/views/editor/edit-tools-pen.js
+++ b/src/fontra/views/editor/edit-tools-pen.js
@@ -113,40 +113,50 @@ export class PenTool extends BaseTool {
     }
 
     if (this.sceneModel.pathConnectTargetPoint?.segment) {
-      await this.sceneController.editLayersAndRecordChanges((layerGlyphs) => {
-        let selection;
-        for (const layerGlyph of Object.values(layerGlyphs)) {
-          selection = insertPoint(
-            layerGlyph.path,
-            this.sceneModel.pathConnectTargetPoint
-          );
-        }
-        delete this.sceneModel.pathConnectTargetPoint;
-        this.sceneController.selection = selection;
-        return "Insert Point";
-      });
-      return;
+      await this._handleInsertPoint();
     } else if (this.sceneModel.pathInsertHandles) {
-      const segmentPointIndices =
-        this.sceneModel.pathInsertHandles.hit.segment.pointIndices;
-      await this.sceneController.editLayersAndRecordChanges((layerGlyphs) => {
-        let selection;
-        for (const layerGlyph of Object.values(layerGlyphs)) {
-          const path = layerGlyph.path;
-          selection = insertHandles(
-            path,
-            segmentPointIndices.map((i) => path.getPoint(i)),
-            segmentPointIndices[1],
-            this.curveType
-          );
-        }
-        delete this.sceneModel.pathInsertHandles;
-        this.sceneController.selection = selection;
-        return "Insert Handles";
-      });
-      return;
+      await this._handleInsertHandles();
+    } else {
+      await this._handleAddPoints(eventStream, initialEvent);
     }
+  }
 
+  async _handleInsertPoint() {
+    await this.sceneController.editLayersAndRecordChanges((layerGlyphs) => {
+      let selection;
+      for (const layerGlyph of Object.values(layerGlyphs)) {
+        selection = insertPoint(
+          layerGlyph.path,
+          this.sceneModel.pathConnectTargetPoint
+        );
+      }
+      delete this.sceneModel.pathConnectTargetPoint;
+      this.sceneController.selection = selection;
+      return "Insert Point";
+    });
+  }
+
+  async _handleInsertHandles() {
+    const segmentPointIndices =
+      this.sceneModel.pathInsertHandles.hit.segment.pointIndices;
+    await this.sceneController.editLayersAndRecordChanges((layerGlyphs) => {
+      let selection;
+      for (const layerGlyph of Object.values(layerGlyphs)) {
+        const path = layerGlyph.path;
+        selection = insertHandles(
+          path,
+          segmentPointIndices.map((i) => path.getPoint(i)),
+          segmentPointIndices[1],
+          this.curveType
+        );
+      }
+      delete this.sceneModel.pathInsertHandles;
+      this.sceneController.selection = selection;
+      return "Insert Handles";
+    });
+  }
+
+  async _handleAddPoints(eventStream, initialEvent) {
     await this.sceneController.editInstance(async (sendIncrementalChange, instance) => {
       const behavior = getPenToolBehavior(
         this.sceneController,

--- a/src/fontra/views/editor/edit-tools-pointer.js
+++ b/src/fontra/views/editor/edit-tools-pointer.js
@@ -208,9 +208,9 @@ export class PointerTool extends BaseTool {
 
   async handlePointsDoubleClick(pointIndices) {
     let newPointType;
-    await this.sceneController.editLayersAndRecordChanges((instances) => {
-      for (const instance of instances) {
-        newPointType = toggleSmooth(instance.path, pointIndices, newPointType);
+    await this.sceneController.editLayersAndRecordChanges((layerGlyphs) => {
+      for (const layerGlyph of layerGlyphs) {
+        newPointType = toggleSmooth(layerGlyph.path, pointIndices, newPointType);
       }
       return "Toggle Smooth";
     });

--- a/src/fontra/views/editor/edit-tools-pointer.js
+++ b/src/fontra/views/editor/edit-tools-pointer.js
@@ -209,7 +209,7 @@ export class PointerTool extends BaseTool {
   async handlePointsDoubleClick(pointIndices) {
     let newPointType;
     await this.sceneController.editLayersAndRecordChanges((layerGlyphs) => {
-      for (const layerGlyph of layerGlyphs) {
+      for (const layerGlyph of Object.values(layerGlyphs)) {
         newPointType = toggleSmooth(layerGlyph.path, pointIndices, newPointType);
       }
       return "Toggle Smooth";

--- a/src/fontra/views/editor/edit-tools-pointer.js
+++ b/src/fontra/views/editor/edit-tools-pointer.js
@@ -208,13 +208,8 @@ export class PointerTool extends BaseTool {
 
   async handlePointsDoubleClick(pointIndices) {
     let newPointType;
-    await this.sceneController.editGlyphAndRecordChanges((glyph) => {
-      const layers = glyph.layers;
-      for (const layerName of this.sceneController.editingLayerNames) {
-        const instance = layers[layerName]?.glyph;
-        if (!instance) {
-          continue;
-        }
+    await this.sceneController.editLayersAndRecordChanges((instances) => {
+      for (const instance of instances) {
         newPointType = toggleSmooth(instance.path, pointIndices, newPointType);
       }
       return "Toggle Smooth";

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -856,14 +856,14 @@ export class EditorController {
     await this._writeInstanceToClipboard(layerGlyphs, flattenedPath, event);
   }
 
-  async _writeInstanceToClipboard(layerGlyphs, path, event) {
-    const bounds = path?.getControlBounds();
+  async _writeInstanceToClipboard(layerGlyphs, flattenedPath, event) {
+    const bounds = flattenedPath?.getControlBounds();
     if (!bounds || !layerGlyphs?.length) {
       // nothing to do
       return;
     }
 
-    const svgString = pathToSVG(path, bounds);
+    const svgString = pathToSVG(flattenedPath, bounds);
     const glyphName = this.sceneSettings.selectedGlyphName;
     const unicodes = this.fontController.glyphMap[glyphName] || [];
     const glifString = staticGlyphToGLIF(glyphName, layerGlyphs[0].glyph, unicodes);

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -1035,7 +1035,7 @@ export class EditorController {
       this.sceneController.selection
     );
     await this.sceneController.editLayersAndRecordChanges((layerGlyphs) => {
-      for (const layerGlyph of layerGlyphs) {
+      for (const layerGlyph of Object.values(layerGlyphs)) {
         if (event.altKey) {
           // Behave like "cut", but don't put anything on the clipboard
           this._prepareCopyOrCut(layerGlyph, true);

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -1031,20 +1031,22 @@ export class EditorController {
   }
 
   async doDelete(event) {
-    await this.sceneController.editInstanceAndRecordChanges((instance) => {
-      if (event.altKey) {
-        // Behave like "cut", but don't put anything on the clipboard
-        this._prepareCopyOrCut(instance, true);
-      } else {
-        const { point: pointSelection, component: componentSelection } = parseSelection(
-          this.sceneController.selection
-        );
-        if (pointSelection) {
-          deleteSelectedPoints(instance.path, pointSelection);
-        }
-        if (componentSelection) {
-          for (const componentIndex of reversed(componentSelection)) {
-            instance.components.splice(componentIndex, 1);
+    const { point: pointSelection, component: componentSelection } = parseSelection(
+      this.sceneController.selection
+    );
+    await this.sceneController.editLayersAndRecordChanges((layerGlyphs) => {
+      for (const layerGlyph of layerGlyphs) {
+        if (event.altKey) {
+          // Behave like "cut", but don't put anything on the clipboard
+          this._prepareCopyOrCut(layerGlyph, true);
+        } else {
+          if (pointSelection) {
+            deleteSelectedPoints(layerGlyph.path, pointSelection);
+          }
+          if (componentSelection) {
+            for (const componentIndex of reversed(componentSelection)) {
+              layerGlyph.components.splice(componentIndex, 1);
+            }
           }
         }
       }

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -828,22 +828,21 @@ export class EditorController {
       // We *have* to do this first, as it won't work after any
       // await (Safari insists on that). So we have to do a bit
       // of redundant work by calling _prepareCopyOrCut twice.
-      const { instance, flattenedPath } = this._prepareCopyOrCut(
+      const { layerGlyphs, flattenedPath } = this._prepareCopyOrCutLayers(
         undefined,
-        false,
-        true
+        false
       );
-      await this._writeInstanceToClipboard(instance, flattenedPath, event);
+      await this._writeLayersToClipboard(layerGlyphs, flattenedPath, event);
     }
     let copyResult;
-    await this.sceneController.editInstanceAndRecordChanges((instance) => {
-      copyResult = this._prepareCopyOrCut(instance, true, true);
+    await this.sceneController.editGlyphAndRecordChanges((glyph) => {
+      copyResult = this._prepareCopyOrCutLayers(glyph, true);
       this.sceneController.selection = new Set();
       return "Cut Selection";
     });
     if (copyResult && !event) {
-      const { instance, flattenedPath } = copyResult;
-      await this._writeInstanceToClipboard(instance, flattenedPath);
+      const { layerGlyphs, flattenedPath } = copyResult;
+      await this._writeLayersToClipboard(layerGlyphs, flattenedPath);
     }
   }
 
@@ -853,10 +852,10 @@ export class EditorController {
 
   async doCopy(event) {
     const { layerGlyphs, flattenedPath } = this._prepareCopyOrCutLayers(false);
-    await this._writeInstanceToClipboard(layerGlyphs, flattenedPath, event);
+    await this._writeLayersToClipboard(layerGlyphs, flattenedPath, event);
   }
 
-  async _writeInstanceToClipboard(layerGlyphs, flattenedPath, event) {
+  async _writeLayersToClipboard(layerGlyphs, flattenedPath, event) {
     const bounds = flattenedPath?.getControlBounds();
     if (!bounds || !layerGlyphs?.length) {
       // nothing to do

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -1073,11 +1073,7 @@ export class EditorController {
           const pasteGlyph =
             pasteLayerGlyphsByLayerName[layerName] || defaultPasteGlyph;
           layerGlyph.path.appendPath(pasteGlyph.path);
-          layerGlyph.components.splice(
-            layerGlyph.components.length,
-            0,
-            ...pasteGlyph.components
-          );
+          layerGlyph.components.push(...pasteGlyph.components);
         }
         this.sceneController.selection = selection;
         return "Paste";

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -828,8 +828,12 @@ export class EditorController {
       // We *have* to do this first, as it won't work after any
       // await (Safari insists on that). So we have to do a bit
       // of redundant work by calling _prepareCopyOrCut twice.
-      const { instance, path } = this._prepareCopyOrCut(undefined, false, true);
-      await this._writeInstanceToClipboard(instance, path, event);
+      const { instance, flattenedPath } = this._prepareCopyOrCut(
+        undefined,
+        false,
+        true
+      );
+      await this._writeInstanceToClipboard(instance, flattenedPath, event);
     }
     let copyResult;
     await this.sceneController.editInstanceAndRecordChanges((instance) => {
@@ -838,8 +842,8 @@ export class EditorController {
       return "Cut Selection";
     });
     if (copyResult && !event) {
-      const { instance, path } = copyResult;
-      await this._writeInstanceToClipboard(instance, path);
+      const { instance, flattenedPath } = copyResult;
+      await this._writeInstanceToClipboard(instance, flattenedPath);
     }
   }
 
@@ -848,11 +852,11 @@ export class EditorController {
   }
 
   async doCopy(event) {
-    const { instance, path } = this._prepareCopyOrCut(undefined, false, true);
+    const { instance, flattenedPath } = this._prepareCopyOrCut(undefined, false, true);
     if (!instance) {
       return;
     }
-    await this._writeInstanceToClipboard(instance, path, event);
+    await this._writeInstanceToClipboard(instance, flattenedPath, event);
   }
 
   async _writeInstanceToClipboard(instance, path, event) {
@@ -910,7 +914,9 @@ export class EditorController {
         ? {}
         : {
             instance: editInstance,
-            path: wantFlattenedPath ? glyphController.flattenedPath : undefined,
+            flattenedPath: wantFlattenedPath
+              ? glyphController.flattenedPath
+              : undefined,
           };
     }
 
@@ -942,7 +948,7 @@ export class EditorController {
     });
     return {
       instance: instance,
-      path: wantFlattenedPath ? joinPaths(flattenedPathList) : undefined,
+      flattenedPath: wantFlattenedPath ? joinPaths(flattenedPathList) : undefined,
     };
   }
 

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -835,11 +835,15 @@ export class EditorController {
       await this._writeLayersToClipboard(layerGlyphs, flattenedPath, event);
     }
     let copyResult;
-    await this.sceneController.editGlyphAndRecordChanges((glyph) => {
-      copyResult = this._prepareCopyOrCutLayers(glyph, true);
-      this.sceneController.selection = new Set();
-      return "Cut Selection";
-    });
+    await this.sceneController.editGlyphAndRecordChanges(
+      (glyph) => {
+        copyResult = this._prepareCopyOrCutLayers(glyph, true);
+        this.sceneController.selection = new Set();
+        return "Cut Selection";
+      },
+      undefined,
+      true
+    );
     if (copyResult && !event) {
       const { layerGlyphs, flattenedPath } = copyResult;
       await this._writeLayersToClipboard(layerGlyphs, flattenedPath);

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -909,7 +909,7 @@ export class EditorController {
       return doCut
         ? {}
         : {
-            instance: glyphController.instance,
+            instance: editInstance,
             path: glyphController.flattenedPath,
           };
     }
@@ -926,7 +926,7 @@ export class EditorController {
     }
     if (componentIndices) {
       paths.push(...componentIndices.map((i) => glyphController.components[i].path));
-      components = componentIndices.map((i) => glyphController.instance.components[i]);
+      components = componentIndices.map((i) => editInstance.components[i]);
       if (doCut) {
         for (const componentIndex of reversed(componentIndices)) {
           editInstance.components.splice(componentIndex, 1);
@@ -934,7 +934,7 @@ export class EditorController {
       }
     }
     const instance = StaticGlyph.fromObject({
-      ...glyphController.instance,
+      ...editInstance,
       path: path,
       components: components,
     });

--- a/src/fontra/views/editor/panel-designspace-navigation.js
+++ b/src/fontra/views/editor/panel-designspace-navigation.js
@@ -362,7 +362,7 @@ export default class DesignspaceNavigationPanel extends Panel {
     const selectedItem = this.sourcesList.getSelectedItem();
     const onOff = selectedItem?.interpolationStatus?.error
       ? false
-      : !items.every((item) => item.editing);
+      : selectedItem && !items.every((item) => item.editing);
     for (const item of items) {
       item.editing = onOff || item === selectedItem;
     }

--- a/src/fontra/views/editor/panel-designspace-navigation.js
+++ b/src/fontra/views/editor/panel-designspace-navigation.js
@@ -223,13 +223,13 @@ export default class DesignspaceNavigationPanel extends Panel {
           false,
           (item, key) => {
             const selectedItem = this.sourcesList.getSelectedItem();
-            if (
+            const newValue =
+              !selectedItem ||
               item?.interpolationStatus?.error ||
               (selectedItem?.interpolationStatus?.error && selectedItem !== item)
-            ) {
-              return false;
-            }
-            return !item[key] || item === selectedItem;
+                ? false
+                : !item[key] || item === selectedItem;
+            return { newValue, propagateEvent: !selectedItem };
           }
         ),
         width: "1.2em",
@@ -1036,12 +1036,14 @@ function makeIconCellFactory(
         event.stopImmediatePropagation();
       },
       [clickSymbol]: (event) => {
-        const newValue = switchValue
+        const { newValue, propagateEvent } = switchValue
           ? switchValue(item, colDesc.key)
-          : !item[colDesc.key];
+          : { newValue: !item[colDesc.key] };
         item[colDesc.key] = newValue;
         iconElement.src = iconPaths[boolInt(newValue)];
-        event.stopImmediatePropagation();
+        if (!propagateEvent) {
+          event.stopImmediatePropagation();
+        }
       },
     });
     item[controllerKey].addKeyListener(colDesc.key, (event) => {

--- a/src/fontra/views/editor/panel-designspace-navigation.js
+++ b/src/fontra/views/editor/panel-designspace-navigation.js
@@ -229,7 +229,7 @@ export default class DesignspaceNavigationPanel extends Panel {
               (selectedItem?.interpolationStatus?.error && selectedItem !== item)
                 ? false
                 : !item[key] || item === selectedItem;
-            return { newValue, propagateEvent: !selectedItem };
+            return { newValue, selectItem: !selectedItem };
           }
         ),
         width: "1.2em",
@@ -1036,12 +1036,12 @@ function makeIconCellFactory(
         event.stopImmediatePropagation();
       },
       [clickSymbol]: (event) => {
-        const { newValue, propagateEvent } = switchValue
+        const { newValue, selectItem } = switchValue
           ? switchValue(item, colDesc.key)
           : { newValue: !item[colDesc.key] };
         item[colDesc.key] = newValue;
         iconElement.src = iconPaths[boolInt(newValue)];
-        if (!propagateEvent) {
+        if (!selectItem) {
           event.stopImmediatePropagation();
         }
       },

--- a/src/fontra/views/editor/panel-designspace-navigation.js
+++ b/src/fontra/views/editor/panel-designspace-navigation.js
@@ -456,8 +456,15 @@ export default class DesignspaceNavigationPanel extends Panel {
       });
       sourceController.addKeyListener("status", async (event) => {
         await this.sceneController.editGlyphAndRecordChanges((glyph) => {
-          glyph.sources[index].customData[FONTRA_STATUS_KEY] = event.newValue;
-          return `set status ${source.name}`;
+          const editingLayerNames = new Set(this.sceneController.editingLayerNames);
+          let count = 0;
+          for (const [i, source] of enumerate(glyph.sources)) {
+            if (editingLayerNames.has(source.layerName)) {
+              source.customData[FONTRA_STATUS_KEY] = event.newValue;
+              count++;
+            }
+          }
+          return `set status ${count > 1 ? "(multiple)" : source.name}`;
         });
       });
       sourceItems.push(sourceController.model);

--- a/src/fontra/views/editor/panel-designspace-navigation.js
+++ b/src/fontra/views/editor/panel-designspace-navigation.js
@@ -479,7 +479,7 @@ export default class DesignspaceNavigationPanel extends Panel {
 
   _updateEditingStatus() {
     const selectedItem = this.sourcesList.getSelectedItem();
-    if (!selectedItem?.editing) {
+    if (!selectedItem?.editing || selectedItem.interpolationStatus?.error) {
       this.sourcesList.items.forEach((item) => {
         item.editing = item === selectedItem;
       });

--- a/src/fontra/views/editor/panel-selection-info.js
+++ b/src/fontra/views/editor/panel-selection-info.js
@@ -339,30 +339,12 @@ export default class SelectionInfoPanel extends Panel {
                 deleteNestedValue(layerGlyph, changePath);
               }
             }
-            const primaryOrgValue = layerInfo[0].orgValue;
-            const delta =
-              typeof primaryOrgValue === "number" ? value - primaryOrgValue : null;
-            changes = recordChanges(glyph, (glyph) => {
-              const layers = glyph.layers;
-              for (const { layerName, orgValue } of layerInfo) {
-                const newValue = delta === null ? value : orgValue + delta;
-                setNestedValue(layers[layerName].glyph, changePath, newValue);
-              }
-            });
+            changes = applyNewValue(glyph, layerInfo, changePath, value);
             await sendIncrementalChange(changes.change, true); // true: "may drop"
           }
         } else {
           // Simple, atomic change
-          const primaryOrgValue = layerInfo[0].orgValue;
-          const delta =
-            typeof primaryOrgValue === "number" ? value - primaryOrgValue : null;
-          changes = recordChanges(glyph, (glyph) => {
-            const layers = glyph.layers;
-            for (const { layerName, orgValue } of layerInfo) {
-              const newValue = delta === null ? value : orgValue + delta;
-              setNestedValue(layers[layerName].glyph, changePath, newValue);
-            }
-          });
+          changes = applyNewValue(glyph, layerInfo, changePath, value);
         }
 
         const undoLabel =
@@ -401,6 +383,18 @@ function deleteNestedValue(subject, path) {
   path = path.slice(0, -1);
   subject = getNestedValue(subject, path);
   delete subject[key];
+}
+
+function applyNewValue(glyph, layerInfo, changePath, value) {
+  const primaryOrgValue = layerInfo[0].orgValue;
+  const delta = typeof primaryOrgValue === "number" ? value - primaryOrgValue : null;
+  return recordChanges(glyph, (glyph) => {
+    const layers = glyph.layers;
+    for (const { layerName, orgValue } of layerInfo) {
+      const newValue = delta === null ? value : orgValue + delta;
+      setNestedValue(layers[layerName].glyph, changePath, newValue);
+    }
+  });
 }
 
 customElements.define("panel-selection-info", SelectionInfoPanel);

--- a/src/fontra/views/editor/panel-selection-info.js
+++ b/src/fontra/views/editor/panel-selection-info.js
@@ -49,12 +49,12 @@ export default class SelectionInfoPanel extends Panel {
     this.fontController = this.editorController.fontController;
     this.sceneController = this.editorController.sceneController;
 
-    this.editorController.sceneController.sceneSettingsController.addKeyListener(
+    this.sceneController.sceneSettingsController.addKeyListener(
       ["selectedGlyphName", "selection", "location"],
       (event) => this.throttledUpdate()
     );
 
-    this.editorController.sceneController.sceneSettingsController.addKeyListener(
+    this.sceneController.sceneSettingsController.addKeyListener(
       "positionedLines",
       (event) => {
         if (!this.haveInstance) {
@@ -63,7 +63,7 @@ export default class SelectionInfoPanel extends Panel {
       }
     );
 
-    this.editorController.sceneController.addCurrentGlyphChangeListener((event) => {
+    this.sceneController.addCurrentGlyphChangeListener((event) => {
       this.throttledUpdate(event.senderID);
     });
 

--- a/src/fontra/views/editor/panel-selection-info.js
+++ b/src/fontra/views/editor/panel-selection-info.js
@@ -340,7 +340,7 @@ export default class SelectionInfoPanel extends Panel {
             }
             const primaryOrgValue = layerInfo[0].orgValue;
             const delta =
-              primaryOrgValue !== undefined ? value - primaryOrgValue : null;
+              typeof primaryOrgValue === "number" ? value - primaryOrgValue : null;
             changes = recordChanges(glyph, (glyph) => {
               const layers = glyph.layers;
               for (const { layerName, orgValue } of layerInfo) {
@@ -353,7 +353,8 @@ export default class SelectionInfoPanel extends Panel {
         } else {
           // Simple, atomic change
           const primaryOrgValue = layerInfo[0].orgValue;
-          const delta = primaryOrgValue !== undefined ? value - primaryOrgValue : null;
+          const delta =
+            typeof primaryOrgValue === "number" ? value - primaryOrgValue : null;
           changes = recordChanges(glyph, (glyph) => {
             const layers = glyph.layers;
             for (const { layerName, orgValue } of layerInfo) {

--- a/src/fontra/views/editor/panel-selection-info.js
+++ b/src/fontra/views/editor/panel-selection-info.js
@@ -317,7 +317,6 @@ export default class SelectionInfoPanel extends Panel {
     this.infoForm.onFieldChange = async (fieldKey, value, valueStream) => {
       const changePath = JSON.parse(fieldKey);
       await this.sceneController.editGlyph(async (sendIncrementalChange, glyph) => {
-        let changes;
         const layerInfo = Object.entries(
           this.sceneController.getEditingLayerFromGlyphLayers(glyph.layers)
         ).map(([layerName, layerGlyph]) => {
@@ -327,6 +326,8 @@ export default class SelectionInfoPanel extends Panel {
             orgValue: getNestedValue(layerGlyph, changePath),
           };
         });
+
+        let changes;
 
         if (valueStream) {
           // Continuous changes (eg. slider drag)

--- a/src/fontra/views/editor/panel-selection-info.js
+++ b/src/fontra/views/editor/panel-selection-info.js
@@ -341,11 +341,10 @@ export default class SelectionInfoPanel extends Panel {
             });
           }
 
-          const plen = changePath.length;
           const undoLabel =
-            plen == 1
-              ? `${changePath[plen - 1]}`
-              : `${changePath[plen - 2]}.${changePath[plen - 1]}`;
+            changePath.length == 1
+              ? `${changePath.at(-1)}`
+              : `${changePath.at(-2)}.${changePath.at(-1)}`;
           return {
             changes: changes,
             undoLabel: undoLabel,

--- a/src/fontra/views/editor/panel-selection-info.js
+++ b/src/fontra/views/editor/panel-selection-info.js
@@ -66,6 +66,10 @@ export default class SelectionInfoPanel extends Panel {
     this.editorController.sceneController.addCurrentGlyphChangeListener((event) => {
       this.throttledUpdate(event.senderID);
     });
+
+    this.sceneController.addEventListener("glyphEditLocationNotAtSource", async () => {
+      this.update();
+    });
   }
 
   async update(senderID) {
@@ -105,8 +109,6 @@ export default class SelectionInfoPanel extends Panel {
       )
       .join(" ");
 
-    const canEdit = glyphController?.canEdit;
-
     const formContents = [];
     if (glyphName && instance) {
       formContents.push({
@@ -127,7 +129,6 @@ export default class SelectionInfoPanel extends Panel {
         label: "Advance width",
         value: instance.xAdvance,
         minValue: 0,
-        disabled: !canEdit,
       });
     }
 
@@ -177,7 +178,6 @@ export default class SelectionInfoPanel extends Panel {
           key: componentKey("transformation", key),
           label: key,
           value: value,
-          disabled: !canEdit,
         });
       }
       const baseGlyph = await this.fontController.getGlyph(component.name);
@@ -219,7 +219,6 @@ export default class SelectionInfoPanel extends Panel {
             minValue: axis.minValue,
             defaultValue: axis.defaultValue,
             maxValue: axis.maxValue,
-            disabled: !canEdit,
           });
         }
         if (locationItems.length) {

--- a/src/fontra/views/editor/scene-controller.js
+++ b/src/fontra/views/editor/scene-controller.js
@@ -723,10 +723,6 @@ export class SceneController {
   }
 
   async editGlyph(editFunc, senderID) {
-    return await this._editGlyphOrInstance(editFunc, senderID, false);
-  }
-
-  async editGlyphAtLayer(editFunc, senderID) {
     return await this._editGlyphOrInstance(editFunc, senderID, false, true);
   }
 

--- a/src/fontra/views/editor/scene-controller.js
+++ b/src/fontra/views/editor/scene-controller.js
@@ -681,8 +681,13 @@ export class SceneController {
     return this._glyphEditingDonePromise;
   }
 
-  async editGlyphAndRecordChanges(editFunc, senderID) {
-    return await this._editGlyphOrInstanceAndRecordChanges(editFunc, senderID, false);
+  async editGlyphAndRecordChanges(editFunc, senderID, requireSelectedLayer) {
+    return await this._editGlyphOrInstanceAndRecordChanges(
+      editFunc,
+      senderID,
+      false,
+      requireSelectedLayer
+    );
   }
 
   async editInstanceAndRecordChanges(editFunc, senderID) {

--- a/src/fontra/views/editor/scene-controller.js
+++ b/src/fontra/views/editor/scene-controller.js
@@ -609,7 +609,18 @@ export class SceneController {
   }
 
   get editingLayerNames() {
-    return Object.keys(this.editingLayers);
+    const primaryLayerName =
+      this.sceneModel.getSelectedPositionedGlyph()?.glyph?.layerName;
+    const layerNames = Object.keys(this.editingLayers);
+    if (primaryLayerName) {
+      // Ensure the primary editing layer name is first in the list
+      const i = layerNames.indexOf(primaryLayerName);
+      if (i > 0) {
+        layerNames.splice(i, 1);
+        layerNames.unshift(primaryLayerName);
+      }
+    }
+    return layerNames;
   }
 
   getGlobalLocation() {

--- a/src/fontra/views/editor/scene-controller.js
+++ b/src/fontra/views/editor/scene-controller.js
@@ -433,19 +433,28 @@ export class SceneController {
         consolidateChanges(rollbackChanges)
       );
 
-      const connectDetector = this.getPathConnectDetector();
-      // if (connectDetector.shouldConnect()) {
-      //   const connectChanges = recordChanges(instance, (instance) => {
-      //     this.selection = connectContours(
-      //       instance.path,
-      //       connectDetector.connectSourcePointIndex,
-      //       connectDetector.connectTargetPointIndex
-      //     );
-      //   });
-      //   if (connectChanges.hasChange) {
-      //     changes = changes.concat(connectChanges);
-      //   }
-      // }
+      let newSelection;
+      for (const { layerGlyph, changePath } of layerInfo) {
+        const connectDetector = this.getPathConnectDetector(layerGlyph.path);
+        if (connectDetector.shouldConnect()) {
+          const connectChanges = recordChanges(layerGlyph, (layerGlyph) => {
+            const thisSelection = connectContours(
+              layerGlyph.path,
+              connectDetector.connectSourcePointIndex,
+              connectDetector.connectTargetPointIndex
+            );
+            if (newSelection === undefined) {
+              newSelection = thisSelection;
+            }
+          });
+          if (connectChanges.hasChange) {
+            changes = changes.concat(connectChanges.prefixed(changePath));
+          }
+        }
+      }
+      if (newSelection) {
+        this.selection = newSelection;
+      }
 
       return {
         changes: changes,

--- a/src/fontra/views/editor/scene-controller.js
+++ b/src/fontra/views/editor/scene-controller.js
@@ -654,6 +654,16 @@ export class SceneController {
     return await this._editGlyphOrInstanceAndRecordChanges(editFunc, senderID, true);
   }
 
+  async editLayersAndRecordChanges(editFunc, senderID) {
+    return await this.editGlyphAndRecordChanges((glyph) => {
+      const layers = glyph.layers;
+      const layerGlyphs = this.editingLayerNames
+        .map((layerName) => layers[layerName]?.glyph)
+        .filter((layerGlyph) => layerGlyph);
+      return editFunc(layerGlyphs);
+    }, senderID);
+  }
+
   async _editGlyphOrInstanceAndRecordChanges(editFunc, senderID, doInstance) {
     await this._editGlyphOrInstance(
       (sendIncrementalChange, subject) => {

--- a/src/fontra/views/editor/scene-controller.js
+++ b/src/fontra/views/editor/scene-controller.js
@@ -658,14 +658,17 @@ export class SceneController {
 
   async editLayersAndRecordChanges(editFunc, senderID) {
     return await this.editGlyphAndRecordChanges((glyph) => {
-      const layers = glyph.layers;
-      const layerGlyphs = Object.fromEntries(
-        this.editingLayerNames
-          .map((layerName) => [layerName, layers[layerName]?.glyph])
-          .filter((layer) => layer[1])
-      );
+      const layerGlyphs = this._getEditingLayerGlyphs(glyph.layers);
       return editFunc(layerGlyphs);
     }, senderID);
+  }
+
+  _getEditingLayerGlyphs(layers) {
+    return Object.fromEntries(
+      this.editingLayerNames
+        .map((layerName) => [layerName, layers[layerName]?.glyph])
+        .filter((layer) => layer[1])
+    );
   }
 
   async _editGlyphOrInstanceAndRecordChanges(editFunc, senderID, doInstance) {

--- a/src/fontra/views/editor/scene-controller.js
+++ b/src/fontra/views/editor/scene-controller.js
@@ -419,14 +419,14 @@ export class SceneController {
 
       const editChanges = [];
       const rollbackChanges = [];
-      layerInfo.forEach(({ layerGlyph, changePath, editBehavior }) => {
+      for (const { layerGlyph, changePath, editBehavior } of layerInfo) {
         const editChange = editBehavior.makeChangeForDelta(delta);
         applyChange(layerGlyph, editChange);
         editChanges.push(consolidateChanges(editChange, changePath));
         rollbackChanges.push(
           consolidateChanges(editBehavior.rollbackChange, changePath)
         );
-      });
+      }
 
       let changes = ChangeCollector.fromChanges(
         consolidateChanges(editChanges),

--- a/src/fontra/views/editor/scene-controller.js
+++ b/src/fontra/views/editor/scene-controller.js
@@ -658,12 +658,12 @@ export class SceneController {
 
   async editLayersAndRecordChanges(editFunc, senderID) {
     return await this.editGlyphAndRecordChanges((glyph) => {
-      const layerGlyphs = this._getEditingLayerGlyphs(glyph.layers);
+      const layerGlyphs = this.getEditingLayerFromGlyphLayers(glyph.layers);
       return editFunc(layerGlyphs);
     }, senderID);
   }
 
-  _getEditingLayerGlyphs(layers) {
+  getEditingLayerFromGlyphLayers(layers) {
     return Object.fromEntries(
       this.editingLayerNames
         .map((layerName) => [layerName, layers[layerName]?.glyph])

--- a/src/fontra/views/editor/scene-controller.js
+++ b/src/fontra/views/editor/scene-controller.js
@@ -634,7 +634,7 @@ export class SceneController {
   }
 
   get editingLayers() {
-    return this.sceneModel.editingLayers || [];
+    return this.sceneModel.editingLayers || {};
   }
 
   set editingLayers(layerNames) {

--- a/src/fontra/views/editor/scene-controller.js
+++ b/src/fontra/views/editor/scene-controller.js
@@ -890,10 +890,12 @@ export class SceneController {
   }
 
   async breakContour() {
-    await this.editInstanceAndRecordChanges((instance) => {
+    const { point: pointIndices } = parseSelection(this.selection);
+    await this.editLayersAndRecordChanges((layerGlyphs) => {
       let numSplits;
-      const { point: pointIndices } = parseSelection(this.selection);
-      numSplits = splitPathAtPointIndices(instance.path, pointIndices);
+      for (const layerGlyph of layerGlyphs) {
+        numSplits = splitPathAtPointIndices(layerGlyph.path, pointIndices);
+      }
       this.selection = new Set();
       return "Break Contour" + (numSplits > 1 ? "s" : "");
     });

--- a/src/fontra/views/editor/scene-controller.js
+++ b/src/fontra/views/editor/scene-controller.js
@@ -690,10 +690,6 @@ export class SceneController {
     );
   }
 
-  async editInstanceAndRecordChanges(editFunc, senderID) {
-    return await this._editGlyphOrInstanceAndRecordChanges(editFunc, senderID, true);
-  }
-
   async editLayersAndRecordChanges(editFunc, senderID) {
     return await this._editGlyphOrInstanceAndRecordChanges(
       (glyph) => {

--- a/src/fontra/views/editor/scene-controller.js
+++ b/src/fontra/views/editor/scene-controller.js
@@ -781,7 +781,7 @@ export class SceneController {
 
     let glyphController;
     if (doInstance || requireSelectedLayer) {
-      const glyphController = this.sceneModel.getSelectedPositionedGlyph().glyph;
+      glyphController = this.sceneModel.getSelectedPositionedGlyph().glyph;
       if (!glyphController.canEdit) {
         this._dispatchEvent("glyphEditLocationNotAtSource");
         return;

--- a/src/fontra/views/editor/scene-controller.js
+++ b/src/fontra/views/editor/scene-controller.js
@@ -821,6 +821,7 @@ export class SceneController {
     if (undoInfo !== undefined) {
       this.selection = undoInfo.undoSelection;
       if (undoInfo.location) {
+        this.scrollAdjustBehavior = "pin-glyph-center";
         this.sceneSettings.location = undoInfo.location;
       }
       await this.sceneModel.updateScene();

--- a/src/fontra/views/editor/scene-controller.js
+++ b/src/fontra/views/editor/scene-controller.js
@@ -690,10 +690,15 @@ export class SceneController {
   }
 
   async editLayersAndRecordChanges(editFunc, senderID) {
-    return await this.editGlyphAndRecordChanges((glyph) => {
-      const layerGlyphs = this.getEditingLayerFromGlyphLayers(glyph.layers);
-      return editFunc(layerGlyphs);
-    }, senderID);
+    return await this._editGlyphOrInstanceAndRecordChanges(
+      (glyph) => {
+        const layerGlyphs = this.getEditingLayerFromGlyphLayers(glyph.layers);
+        return editFunc(layerGlyphs);
+      },
+      senderID,
+      false,
+      true
+    );
   }
 
   getEditingLayerFromGlyphLayers(layers) {
@@ -704,7 +709,12 @@ export class SceneController {
     );
   }
 
-  async _editGlyphOrInstanceAndRecordChanges(editFunc, senderID, doInstance) {
+  async _editGlyphOrInstanceAndRecordChanges(
+    editFunc,
+    senderID,
+    doInstance,
+    requireSelectedLayer
+  ) {
     await this._editGlyphOrInstance(
       (sendIncrementalChange, subject) => {
         let undoLabel;
@@ -718,16 +728,13 @@ export class SceneController {
         };
       },
       senderID,
-      doInstance
+      doInstance,
+      requireSelectedLayer
     );
   }
 
   async editGlyph(editFunc, senderID) {
     return await this._editGlyphOrInstance(editFunc, senderID, false, true);
-  }
-
-  async editInstance(editFunc, senderID) {
-    return await this._editGlyphOrInstance(editFunc, senderID, true);
   }
 
   async _editGlyphOrInstance(editFunc, senderID, doInstance, requireSelectedLayer) {

--- a/src/fontra/views/editor/scene-controller.js
+++ b/src/fontra/views/editor/scene-controller.js
@@ -924,27 +924,23 @@ export class SceneController {
     const { component: componentSelection } = parseSelection(this.selection);
     componentSelection.sort((a, b) => (a > b) - (a < b));
     const getGlyphFunc = (glyphName) => this.fontController.getGlyph(glyphName);
-    const decomposed = [];
+    const decomposed = {};
     for (const layerName of this.editingLayerNames) {
       const layerGlyph = varGlyph.layers[layerName]?.glyph;
       if (!layerGlyph) {
         continue;
       }
-      decomposed.push(
-        await decomposeComponents(
-          layerGlyph.components,
-          componentSelection,
-          layerLocations[layerName],
-          getGlyphFunc
-        )
+      decomposed[layerName] = await decomposeComponents(
+        layerGlyph.components,
+        componentSelection,
+        layerLocations[layerName],
+        getGlyphFunc
       );
     }
 
     await this.editLayersAndRecordChanges((layerGlyphs) => {
-      for (const [layerGlyph, decomposeInfo] of zip(
-        Object.values(layerGlyphs),
-        decomposed
-      )) {
+      for (const [layerName, layerGlyph] of Object.entries(layerGlyphs)) {
+        const decomposeInfo = decomposed[layerName];
         const path = layerGlyph.path;
         const components = layerGlyph.components;
 

--- a/src/fontra/views/editor/scene-controller.js
+++ b/src/fontra/views/editor/scene-controller.js
@@ -989,16 +989,19 @@ export class SceneController {
     });
   }
 
-  getPathConnectDetector() {
-    return new PathConnectDetector(this);
+  getPathConnectDetector(path) {
+    if (!path) {
+      const positionedGlyph = this.sceneModel.getSelectedPositionedGlyph();
+      path = positionedGlyph.glyph.path;
+    }
+    return new PathConnectDetector(this, path);
   }
 }
 
 class PathConnectDetector {
-  constructor(sceneController) {
+  constructor(sceneController, path) {
     this.sceneController = sceneController;
-    const positionedGlyph = sceneController.sceneModel.getSelectedPositionedGlyph();
-    this.path = positionedGlyph.glyph.path;
+    this.path = path;
     const selection = sceneController.selection;
     if (selection.size !== 1) {
       return;

--- a/src/fontra/views/editor/scene-controller.js
+++ b/src/fontra/views/editor/scene-controller.js
@@ -1041,12 +1041,14 @@ class PathConnectDetector {
       connectTargetPointIndex !== undefined &&
       connectTargetPointIndex !== this.connectSourcePointIndex &&
       !!this.path.isStartOrEndPoint(connectTargetPointIndex);
-    if (showConnectIndicator && shouldConnect) {
-      sceneController.sceneModel.pathConnectTargetPoint = this.path.getPoint(
-        connectTargetPointIndex
-      );
-    } else {
-      delete sceneController.sceneModel.pathConnectTargetPoint;
+    if (showConnectIndicator) {
+      if (shouldConnect) {
+        sceneController.sceneModel.pathConnectTargetPoint = this.path.getPoint(
+          connectTargetPointIndex
+        );
+      } else {
+        delete sceneController.sceneModel.pathConnectTargetPoint;
+      }
     }
     this.connectTargetPointIndex = connectTargetPointIndex;
     return shouldConnect;

--- a/src/fontra/views/editor/scene-model.js
+++ b/src/fontra/views/editor/scene-model.js
@@ -346,6 +346,7 @@ export class SceneModel {
             ? editLayerName
             : undefined;
 
+        const varGlyph = await this.fontController.getGlyph(glyphInfo.glyphName);
         let glyphInstance = await this.getGlyphInstance(
           glyphInfo.glyphName,
           thisGlyphEditLayerName
@@ -360,6 +361,7 @@ export class SceneModel {
           x: x,
           y: y,
           glyph: glyphInstance,
+          varGlyph: varGlyph,
           glyphName: glyphInfo.glyphName,
           character: glyphInfo.character,
           isUndefined: isUndefined,

--- a/src/fontra/views/editor/scene-model.js
+++ b/src/fontra/views/editor/scene-model.js
@@ -239,6 +239,9 @@ export class SceneModel {
       return;
     }
     const varGlyph = await this.fontController.getGlyph(glyphName);
+    if (!varGlyph) {
+      return;
+    }
     this.backgroundLayerGlyphs = await this._setupBackgroundGlyphs(
       glyphName,
       varGlyph,

--- a/src/fontra/views/editor/visualization-layer-definitions.js
+++ b/src/fontra/views/editor/visualization-layer-definitions.js
@@ -731,8 +731,8 @@ registerVisualizationLayerDefinition({
   screenParameters: {
     strokeWidth: 1,
   },
-  colors: { color: "#BBB" },
-  colorsDarkMode: { color: "#666" },
+  colors: { color: "#AAA8" },
+  colorsDarkMode: { color: "#8888" },
   draw: (context, positionedGlyph, parameters, model, controller) => {
     context.lineJoin = "round";
     context.lineWidth = parameters.strokeWidth;
@@ -752,7 +752,7 @@ registerVisualizationLayerDefinition({
     strokeWidth: 1,
   },
   colors: { color: "#66FA" },
-  colorsDarkMode: { color: "#66FA" },
+  colorsDarkMode: { color: "#88FA" },
   draw: (context, positionedGlyph, parameters, model, controller) => {
     const primaryEditingInstance = positionedGlyph.glyph;
     context.lineJoin = "round";


### PR DESCRIPTION
This implements various "multi-source editing" features.

- [x] Delete items
- [x] Break contour
- [x] Set start point
- [x] Reverse contour direction
- [x] Double-click on point to toggle smooth on/off
- [x] Decompose component
- [x] Insert point
- [x] Insert handles
- [x] Drawing points
- [x] Add component
- [x] Dragging points and components
- [x] Arrow key nudge points and components
- [x] Changing variable component values (transform + axes, base glyph name)
- [x] Cut/Copy/Paste
- [x] Change source development status

This fixes #851, which includes:
- Fixes #75
- Fixes #493
- Fixes #643 
- Fixes #743
- Fixes #803 
- Fixes #844 
