### PR TITLE
Fix update problem with selection info

### DIFF
--- a/src/fontra/views/editor/panel-selection-info.js
+++ b/src/fontra/views/editor/panel-selection-info.js
@@ -124,16 +124,19 @@ export default class SelectionInfoPanel extends Panel {
       await this.sceneController.sceneModel.getGlyphInstance(glyphName);
     let unicodes = this.fontController.glyphMap?.[glyphName] || [];
 
-    const positionedGlyph =
-      this.sceneController.sceneModel.getSelectedPositionedGlyph();
-
-    const instance = positionedGlyph?.glyph.instance;
+    const instance = glyphController?.instance;
     this.haveInstance = !!instance;
 
-    if (positionedGlyph?.isUndefined && positionedGlyph.character && !unicodes.length) {
+    const selectedGlyphInfo = this.sceneController.sceneModel.getSelectedGlyphInfo();
+
+    if (
+      selectedGlyphInfo?.isUndefined &&
+      selectedGlyphInfo.character &&
+      !unicodes.length
+    ) {
       // Glyph does not yet exist in the font, but we can grab the unicode from
-      // positionedGlyph.character anyway
-      unicodes = [positionedGlyph.character.codePointAt(0)];
+      // selectedGlyphInfo.character anyway
+      unicodes = [selectedGlyphInfo.character.codePointAt(0)];
     }
 
     const unicodesStr = unicodes
@@ -144,7 +147,7 @@ export default class SelectionInfoPanel extends Panel {
       .join(" ");
 
     const formContents = [];
-    if (glyphName && instance) {
+    if (glyphName) {
       formContents.push({
         key: "glyphName",
         type: "text",
@@ -157,13 +160,15 @@ export default class SelectionInfoPanel extends Panel {
         label: "Unicode",
         value: unicodesStr,
       });
-      formContents.push({
-        type: "edit-number",
-        key: '["xAdvance"]',
-        label: "Advance width",
-        value: instance.xAdvance,
-        minValue: 0,
-      });
+      if (instance) {
+        formContents.push({
+          type: "edit-number",
+          key: '["xAdvance"]',
+          label: "Advance width",
+          value: instance.xAdvance,
+          minValue: 0,
+        });
+      }
     }
 
     const { pointIndices, componentIndices } = this._getSelection();

--- a/src/fontra/views/editor/scene-model.js
+++ b/src/fontra/views/editor/scene-model.js
@@ -93,6 +93,10 @@ export class SceneModel {
     ];
   }
 
+  getSelectedGlyphInfo() {
+    return getSelectedGlyphInfo(this.selectedGlyph, this.glyphLines);
+  }
+
   getSelectedGlyphName() {
     return getSelectedGlyphName(this.selectedGlyph, this.glyphLines);
   }
@@ -739,8 +743,12 @@ function makeGlyphNamesPattern(glyphNames) {
   return { glyphs: glyphsObj };
 }
 
-export function getSelectedGlyphName(selectedGlyph, glyphLines) {
+export function getSelectedGlyphInfo(selectedGlyph, glyphLines) {
   if (selectedGlyph) {
-    return glyphLines[selectedGlyph.lineIndex]?.[selectedGlyph.glyphIndex]?.glyphName;
+    return glyphLines[selectedGlyph.lineIndex]?.[selectedGlyph.glyphIndex];
   }
+}
+
+export function getSelectedGlyphName(selectedGlyph, glyphLines) {
+  return getSelectedGlyphInfo(selectedGlyph, glyphLines)?.glyphName;
 }


### PR DESCRIPTION
The selection info depended on the glyph from positioned lines, however, in the case of external changes, the "current glyph changed" event comes _before_ the scene has been updated, so the glyph from positioned lines was stale.

We already have the right glyph controller, we just need to take the "glyph does not yet exist" case into account.

This fixes #809.