### PR TITLE
Make it harder to accidentally click-select a segment

### DIFF
--- a/src/fontra/client/core/path-hit-tester.js
+++ b/src/fontra/client/core/path-hit-tester.js
@@ -122,6 +122,9 @@ export class PathHitTester {
     segments.forEach((segment) => {
       segment.bezier = new Bezier(segment.points);
       segment.bounds = rectFromPoints(segment.points);
+      segment.parentPoints = segment.parentPointIndices.map((i) =>
+        this.path.getPoint(i)
+      );
     });
     contour.segments = segments;
   }

--- a/src/fontra/views/editor/scene-model.js
+++ b/src/fontra/views/editor/scene-model.js
@@ -477,20 +477,19 @@ export class SceneModel {
 
   segmentSelectionAtPoint(point, size) {
     const pathHit = this.pathHitAtPoint(point, size);
-    if (pathHit.contourIndex !== undefined) {
-      if (
-        pathHit.segment.parentPoints.every(
-          (point) => vector.distance(pathHit, point) > size
-        )
-      ) {
-        const selection = new Set(
-          [
-            pathHit.segment.parentPointIndices[0],
-            pathHit.segment.parentPointIndices.at(-1),
-          ].map((i) => `point/${i}`)
-        );
-        return { selection, pathHit };
-      }
+    if (
+      pathHit.contourIndex !== undefined &&
+      pathHit.segment.parentPoints.every(
+        (point) => vector.distance(pathHit, point) > size
+      )
+    ) {
+      const selection = new Set(
+        [
+          pathHit.segment.parentPointIndices[0],
+          pathHit.segment.parentPointIndices.at(-1),
+        ].map((i) => `point/${i}`)
+      );
+      return { selection, pathHit };
     }
     return { selection: new Set() };
   }

--- a/src/fontra/views/editor/scene-model.js
+++ b/src/fontra/views/editor/scene-model.js
@@ -478,9 +478,11 @@ export class SceneModel {
   segmentSelectionAtPoint(point, size) {
     const pathHit = this.pathHitAtPoint(point, size);
     if (pathHit.contourIndex !== undefined) {
-      const d1 = vector.distance(pathHit, pathHit.segment.parentPoints[0]);
-      const d2 = vector.distance(pathHit, pathHit.segment.parentPoints.at(-1));
-      if (d1 > size && d2 > size) {
+      if (
+        pathHit.segment.parentPoints.every(
+          (point) => vector.distance(pathHit, point) > size
+        )
+      ) {
         const selection = new Set(
           [
             pathHit.segment.parentPointIndices[0],

--- a/src/fontra/views/editor/scene-model.js
+++ b/src/fontra/views/editor/scene-model.js
@@ -478,8 +478,7 @@ export class SceneModel {
   segmentSelectionAtPoint(point, size) {
     const pathHit = this.pathHitAtPoint(point, size);
     if (
-      pathHit.contourIndex !== undefined &&
-      pathHit.segment.parentPoints.every(
+      pathHit.segment?.parentPoints.every(
         (point) => vector.distance(pathHit, point) > size
       )
     ) {

--- a/src/fontra/views/editor/scene-model.js
+++ b/src/fontra/views/editor/scene-model.js
@@ -11,6 +11,7 @@ import {
 } from "../core/rectangle.js";
 import { difference, isEqualSet, updateSet } from "../core/set-ops.js";
 import { consolidateCalls, enumerate, parseSelection } from "../core/utils.js";
+import * as vector from "../core/vector.js";
 
 export class SceneModel {
   constructor(fontController, sceneSettingsController, isPointInPath) {
@@ -477,13 +478,17 @@ export class SceneModel {
   segmentSelectionAtPoint(point, size) {
     const pathHit = this.pathHitAtPoint(point, size);
     if (pathHit.contourIndex !== undefined) {
-      const selection = new Set(
-        [
-          pathHit.segment.parentPointIndices[0],
-          pathHit.segment.parentPointIndices.at(-1),
-        ].map((i) => `point/${i}`)
-      );
-      return { selection, pathHit };
+      const d1 = vector.distance(pathHit, pathHit.segment.parentPoints[0]);
+      const d2 = vector.distance(pathHit, pathHit.segment.parentPoints.at(-1));
+      if (d1 > size && d2 > size) {
+        const selection = new Set(
+          [
+            pathHit.segment.parentPointIndices[0],
+            pathHit.segment.parentPointIndices.at(-1),
+          ].map((i) => `point/${i}`)
+        );
+        return { selection, pathHit };
+      }
     }
     return { selection: new Set() };
   }


### PR DESCRIPTION
It turned out that it was easy to accidentally select a segment when trying to click on a point. This PR adds a margin around the points of the segment to make this less likely to happen.