### PR TITLE
Make rect select not respond to live modifier changes

### DIFF
--- a/src/fontra/views/editor/edit-tools-pointer.js
+++ b/src/fontra/views/editor/edit-tools-pointer.js
@@ -220,6 +220,10 @@ export class PointerTool extends BaseTool {
     const sceneController = this.sceneController;
     const initialPoint = sceneController.localPoint(initialEvent);
     for await (const event of eventStream) {
+      const modifierEvent = sceneController.experimentalFeatures
+        .rectSelectLiveModifierKeys
+        ? event
+        : initialEvent;
       const currentPoint = sceneController.localPoint(event);
       const selRect = normalizeRect({
         xMin: initialPoint.x,
@@ -229,7 +233,7 @@ export class PointerTool extends BaseTool {
       });
       const selection = this.sceneModel.selectionAtRect(
         selRect,
-        event.altKey ? (point) => !!point.type : (point) => !point.type
+        modifierEvent.altKey ? (point) => !!point.type : (point) => !point.type
       );
       const positionedGlyph = this.sceneModel.getSelectedPositionedGlyph();
       sceneController.selectionRect = offsetRect(
@@ -238,7 +242,7 @@ export class PointerTool extends BaseTool {
         -positionedGlyph.y
       );
 
-      const modeFunc = getSelectModeFunction(event);
+      const modeFunc = getSelectModeFunction(modifierEvent);
       sceneController.selection = modeFunc(initialSelection, selection);
     }
     sceneController.selectionRect = undefined;

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -103,6 +103,7 @@ export class EditorController {
     this.experimentalFeaturesController = new ObservableController({
       scalingEditBehavior: false,
       quadPenTool: false,
+      rectSelectLiveModifiers: false,
     });
     this.experimentalFeaturesController.synchronizeWithLocalStorage(
       "fontra-editor-experimental-features."

--- a/src/fontra/views/editor/panel-user-settings.js
+++ b/src/fontra/views/editor/panel-user-settings.js
@@ -82,6 +82,11 @@ export default class UserSettingsPanel extends Panel {
           displayName: "Pen tool draws quadratics",
           ui: "checkbox",
         },
+        {
+          key: "rectSelectLiveModifierKeys",
+          displayName: "Rect-select live modifier keys",
+          ui: "checkbox",
+        },
       ],
     });
 


### PR DESCRIPTION
Make rect select not respond to live modifier changes by default; opt-in for the old behavior