### PR TITLE
[pen tool] Draw no quads for cubics

### DIFF
--- a/src/fontra/client/core/path-functions.js
+++ b/src/fontra/client/core/path-functions.js
@@ -616,7 +616,7 @@ function computeHandlesFromFragment(curveType, contour) {
   ];
 }
 
-function scalePoint(pinPoint, point, factor) {
+export function scalePoint(pinPoint, point, factor) {
   return vector.addVectors(
     pinPoint,
     vector.mulVectorScalar(vector.subVectors(point, pinPoint), factor)

--- a/src/fontra/client/core/var-path.js
+++ b/src/fontra/client/core/var-path.js
@@ -313,7 +313,6 @@ export class VarPackedPath {
   }
 
   getContourPoint(contourIndex, contourPointIndex) {
-    contourIndex = this._normalizeContourIndex(contourIndex);
     const pointIndex = this.getAbsolutePointIndex(
       contourIndex,
       contourPointIndex,
@@ -323,7 +322,6 @@ export class VarPackedPath {
   }
 
   setContourPoint(contourIndex, contourPointIndex, point) {
-    contourIndex = this._normalizeContourIndex(contourIndex);
     const pointIndex = this.getAbsolutePointIndex(
       contourIndex,
       contourPointIndex,
@@ -334,7 +332,7 @@ export class VarPackedPath {
 
   insertPoint(contourIndex, contourPointIndex, point) {
     contourIndex = this._normalizeContourIndex(contourIndex);
-    const pointIndex = this.getAbsolutePointIndex(
+    const pointIndex = this._getAbsolutePointIndex(
       contourIndex,
       contourPointIndex,
       true
@@ -350,7 +348,7 @@ export class VarPackedPath {
 
   deletePoint(contourIndex, contourPointIndex) {
     contourIndex = this._normalizeContourIndex(contourIndex);
-    const pointIndex = this.getAbsolutePointIndex(contourIndex, contourPointIndex);
+    const pointIndex = this._getAbsolutePointIndex(contourIndex, contourPointIndex);
     this.coordinates.splice(pointIndex * 2, 2);
     this.pointTypes.splice(pointIndex, 1);
     this._moveEndPoints(contourIndex, -1);
@@ -387,6 +385,12 @@ export class VarPackedPath {
   }
 
   getAbsolutePointIndex(contourIndex, contourPointIndex, forInsert = false) {
+    contourIndex = this._normalizeContourIndex(contourIndex);
+    return this._getAbsolutePointIndex(contourIndex, contourPointIndex, forInsert);
+  }
+
+  _getAbsolutePointIndex(contourIndex, contourPointIndex, forInsert = false) {
+    contourIndex = this._normalizeContourIndex(contourIndex);
     const startPoint = this._getContourStartPoint(contourIndex);
     const contour = this.contourInfo[contourIndex];
     const numPoints = contour.endPoint + 1 - startPoint;

--- a/src/fontra/views/editor/edit-tools-pen.js
+++ b/src/fontra/views/editor/edit-tools-pen.js
@@ -215,16 +215,14 @@ export class PenTool extends BaseTool {
           const deepDragChanges = thisPropagateChange(dragChanges.change);
           await sendIncrementalChange(deepDragChanges, true); // true: "may drop"
         }
-        const deepDragChanges = thisPropagateChange(dragChanges.change);
-        await sendIncrementalChange(deepDragChanges);
       } else {
         dragChanges = recordChanges(primaryLayerGlyph, (primaryLayerGlyph) => {
           behavior.noDrag(primaryLayerGlyph.path);
         });
         this.sceneController.selection = behavior.selection;
-        const deepDragChanges = thisPropagateChange(dragChanges.change);
-        await sendIncrementalChange(deepDragChanges);
       }
+      const deepDragChanges = thisPropagateChange(dragChanges.change);
+      await sendIncrementalChange(deepDragChanges);
 
       const finalChanges = initialChanges.concat(preDragChanges, dragChanges);
 

--- a/src/fontra/views/editor/edit-tools-pen.js
+++ b/src/fontra/views/editor/edit-tools-pen.js
@@ -547,6 +547,8 @@ function ensureCubicOffCurves(context, path) {
     return;
   }
 
+  // Compute handles for a cubic segment that will look the same as the
+  // one-off-curve quad segment we have.
   const [handle1, handle2] = [prevPrevPoint, thisPoint].map((point) => {
     return {
       ...vector.roundVector(scalePoint(point, prevPoint, 2 / 3)),

--- a/src/fontra/views/editor/edit-tools-pen.js
+++ b/src/fontra/views/editor/edit-tools-pen.js
@@ -530,7 +530,11 @@ function connectToContour(context, path, point, shiftConstrain) {
 }
 
 function ensureCubicOffCurves(context, path) {
-  if (context.curveType !== "cubic" || context.isOnCurve) {
+  if (
+    context.curveType !== "cubic" ||
+    context.isOnCurve ||
+    path.getNumPointsOfContour(context.contourIndex) < 3
+  ) {
     return;
   }
 

--- a/src/fontra/views/editor/edit-tools-pen.js
+++ b/src/fontra/views/editor/edit-tools-pen.js
@@ -1,8 +1,8 @@
 import { recordChanges } from "../core/change-recorder.js";
 import { ChangeCollector, applyChange, consolidateChanges } from "../core/changes.js";
-import { insertHandles, insertPoint } from "../core/path-functions.js";
+import { insertHandles, insertPoint, scalePoint } from "../core/path-functions.js";
 import { isEqualSet } from "../core/set-ops.js";
-import { parseSelection } from "../core/utils.js";
+import { modulo, parseSelection } from "../core/utils.js";
 import { VarPackedPath } from "../core/var-path.js";
 import * as vector from "../core/vector.js";
 import { constrainHorVerDiag } from "./edit-behavior.js";
@@ -217,6 +217,13 @@ export class PenTool extends BaseTool {
         }
         const deepDragChanges = thisPropagateChange(dragChanges.change);
         await sendIncrementalChange(deepDragChanges);
+      } else {
+        dragChanges = recordChanges(primaryLayerGlyph, (primaryLayerGlyph) => {
+          behavior.noDrag(primaryLayerGlyph.path);
+        });
+        this.sceneController.selection = behavior.selection;
+        const deepDragChanges = thisPropagateChange(dragChanges.change);
+        await sendIncrementalChange(deepDragChanges);
       }
 
       const finalChanges = initialChanges.concat(preDragChanges, dragChanges);
@@ -256,6 +263,7 @@ function getPenToolBehavior(sceneController, initialEvent, path, curveType) {
       setup: [setupAnchorPoint, insertAnchorPoint],
       setupDrag: appendInfo.isOnCurve ? insertHandleOut : insertHandleInOut,
       drag: dragHandle,
+      noDrag: ensureCubicOffCurves,
     };
 
     const selectedPoint = path.getContourPoint(
@@ -300,12 +308,12 @@ function getPenToolBehavior(sceneController, initialEvent, path, curveType) {
           );
           if (clickedContourIndex === appendInfo.contourIndex) {
             // Close the current contour
-            behaviorFuncs = { setup: [closeContour] };
+            behaviorFuncs = { setup: [closeContour], noDrag: ensureCubicOffCurves };
           } else {
             // Connect to other open contour
             appendInfo.targetContourIndex = clickedContourIndex;
             appendInfo.targetContourPointIndex = clickedContourPointIndex;
-            behaviorFuncs = { setup: [connectToContour] };
+            behaviorFuncs = { setup: [connectToContour], noDrag: ensureCubicOffCurves };
           }
           if (!clickedPoint.type && selectedPoint.type) {
             behaviorFuncs.setupDrag = insertHandleIn;
@@ -354,6 +362,10 @@ class PenToolBehavior {
   drag(path, event) {
     const point = this.getPointFromEvent(event);
     this.behaviorFuncs.drag?.(this.context, path, point, event.shiftKey);
+  }
+
+  noDrag(path) {
+    this.behaviorFuncs.noDrag?.(this.context, path);
   }
 }
 
@@ -512,6 +524,54 @@ function connectToContour(context, path, point, shiftConstrain) {
       ? sourceContourPoints.length
       : (context.anchorIndex = targetContourPoints.length - 1);
   context.anchorPoint = path.getContourPoint(context.contourIndex, context.anchorIndex);
+  context.selection = getPointSelection(
+    path,
+    context.contourIndex,
+    context.anchorIndex
+  );
+}
+
+function ensureCubicOffCurves(context, path) {
+  if (context.curveType !== "cubic" || context.isOnCurve) {
+    return;
+  }
+
+  const [prevPrevPoint, prevPoint] = [
+    context.anchorIndex - 2 * context.appendDirection,
+    context.anchorIndex - context.appendDirection,
+  ].map((i) => path.getContourPoint(context.contourIndex, i));
+  const thisPoint = context.anchorPoint;
+
+  if (prevPrevPoint.type || !prevPoint.type || thisPoint.type) {
+    // Sanity check: we expect on-curve/off-curve/on-curve
+    return;
+  }
+
+  const [handle1, handle2] = [prevPrevPoint, thisPoint].map((point) => {
+    return {
+      ...vector.roundVector(scalePoint(point, prevPoint, 2 / 3)),
+      type: "cubic",
+    };
+  });
+
+  path.setContourPoint(
+    context.contourIndex,
+    context.anchorIndex - context.appendDirection,
+    handle1
+  );
+  path.insertPoint(
+    context.contourIndex,
+    context.anchorIndex + context.prependBias,
+    handle2
+  );
+  context.selection = getPointSelection(
+    path,
+    context.contourIndex,
+    modulo(
+      context.anchorIndex + context.appendBias,
+      path.getNumPointsOfContour(context.contourIndex)
+    )
+  );
 }
 
 function getPointSelection(path, contourIndex, contourPointIndex) {


### PR DESCRIPTION
When drawing cubics, ensure that we don't build curves with a single off-curve point.