### PR TITLE
[pen tool] Improve hover visualization at end point

### DIFF
--- a/src/fontra/client/core/changes.js
+++ b/src/fontra/client/core/changes.js
@@ -8,10 +8,10 @@ export class ChangeCollector {
 
   static fromChanges(forwardChanges, rollbackChanges) {
     if (!Array.isArray(forwardChanges)) {
-      forwardChanges = [forwardChanges];
+      forwardChanges = hasChange(forwardChanges) ? [forwardChanges] : [];
     }
     if (!Array.isArray(rollbackChanges)) {
-      rollbackChanges = [rollbackChanges];
+      rollbackChanges = hasChange(rollbackChanges) ? [rollbackChanges] : [];
     }
     const collector = new ChangeCollector();
     collector._forwardChanges = forwardChanges;

--- a/src/fontra/views/editor/edit-tools-pen.js
+++ b/src/fontra/views/editor/edit-tools-pen.js
@@ -307,6 +307,7 @@ function getPenToolBehavior(sceneController, initialEvent, path, curveType) {
           setup: [setupExistingAnchorPoint],
           setupDrag: insertHandleOut,
           drag: dragHandle,
+          noDrag: clickOnCurveNoDragSetSelection,
         };
       }
     } else if (clickedSelection.size === 1) {
@@ -595,6 +596,14 @@ function ensureCubicOffCurves(context, path) {
       context.anchorIndex + context.appendBias,
       path.getNumPointsOfContour(context.contourIndex)
     )
+  );
+}
+
+function clickOnCurveNoDragSetSelection(context, path) {
+  context.selection = getPointSelection(
+    path,
+    context.contourIndex,
+    context.anchorIndex
   );
 }
 

--- a/src/fontra/views/editor/edit-tools-pen.js
+++ b/src/fontra/views/editor/edit-tools-pen.js
@@ -18,16 +18,23 @@ export class PenTool extends BaseTool {
       return;
     }
     this.setCursor();
-    const { insertHandles, targetPoint } = this._getPathConnectTargetPoint(event);
+    const { insertHandles, targetPoint, danglingOffCurve, canDragOffCurve } =
+      this._getPathConnectTargetPoint(event);
     const prevInsertHandles = this.sceneModel.pathInsertHandles;
     const prevTargetPoint = this.sceneModel.pathConnectTargetPoint;
+    const prevDanglingOffCurve = this.sceneModel.pathDanglingOffCurve;
+    const prevCanDragOffCurve = this.sceneModel.pathCanDragOffCurve;
 
     if (
       !handlesEqual(insertHandles, prevInsertHandles) ||
-      !pointsEqual(targetPoint, prevTargetPoint)
+      !pointsEqual(targetPoint, prevTargetPoint) ||
+      !pointsEqual(danglingOffCurve, prevDanglingOffCurve) ||
+      !pointsEqual(canDragOffCurve, prevCanDragOffCurve)
     ) {
       this.sceneModel.pathInsertHandles = insertHandles;
       this.sceneModel.pathConnectTargetPoint = targetPoint;
+      this.sceneModel.pathDanglingOffCurve = danglingOffCurve;
+      this.sceneModel.pathCanDragOffCurve = canDragOffCurve;
       this.canvasController.requestUpdate();
     }
   }
@@ -37,9 +44,15 @@ export class PenTool extends BaseTool {
   }
 
   deactivate() {
+    this._resetHover();
+    this.canvasController.requestUpdate();
+  }
+
+  _resetHover() {
     delete this.sceneModel.pathInsertHandles;
     delete this.sceneModel.pathConnectTargetPoint;
-    this.canvasController.requestUpdate();
+    delete this.sceneModel.pathDanglingOffCurve;
+    delete this.sceneModel.pathCanDragOffCurve;
   }
 
   setCursor() {
@@ -95,7 +108,12 @@ export class PenTool extends BaseTool {
       appendInfo.contourPointIndex == contourPointIndex
     ) {
       // We're hovering over the source point
-      return {};
+      const point = path.getPoint(hoveredPointIndex);
+      if (!appendInfo.isOnCurve) {
+        return { danglingOffCurve: point };
+      } else {
+        return { canDragOffCurve: point };
+      }
     }
 
     if (
@@ -118,6 +136,7 @@ export class PenTool extends BaseTool {
     } else if (this.sceneModel.pathInsertHandles) {
       await this._handleInsertHandles();
     } else {
+      this._resetHover();
       await this._handleAddPoints(eventStream, initialEvent);
     }
   }

--- a/src/fontra/views/editor/visualization-layer-definitions.js
+++ b/src/fontra/views/editor/visualization-layer-definitions.js
@@ -702,16 +702,26 @@ registerVisualizationLayerDefinition({
   screenParameters: {
     connectRadius: 11,
     insertHandlesRadius: 5,
+    deleteOffCurveIndicatorLength: 7,
+    canDragOffCurveIndicatorRadius: 9,
+    strokeWidth: 2,
   },
   colors: { color: "#3080FF80" },
   colorsDarkMode: { color: "#50A0FF80" },
   draw: (context, positionedGlyph, parameters, model, controller) => {
     const targetPoint = model.pathConnectTargetPoint;
     const insertHandles = model.pathInsertHandles;
-    if (!targetPoint && !insertHandles) {
+    const danglingOffCurve = model.pathDanglingOffCurve;
+    const canDragOffCurve = model.pathCanDragOffCurve;
+    if (!targetPoint && !insertHandles && !danglingOffCurve && !canDragOffCurve) {
       return;
     }
+
     context.fillStyle = parameters.color;
+    context.strokeStyle = parameters.color;
+    context.lineWidth = parameters.strokeWidth;
+    context.lineCap = "round";
+
     if (targetPoint) {
       const radius = parameters.connectRadius;
       fillRoundNode(context, targetPoint, 2 * radius);
@@ -719,6 +729,26 @@ registerVisualizationLayerDefinition({
     for (const point of insertHandles?.points || []) {
       const radius = parameters.insertHandlesRadius;
       fillRoundNode(context, point, 2 * radius);
+    }
+    if (danglingOffCurve) {
+      const d = parameters.deleteOffCurveIndicatorLength;
+      const { x, y } = danglingOffCurve;
+      let dx = d;
+      let dy = d;
+      const inner = 0.666;
+      for (let i = 0; i < 4; i++) {
+        [dx, dy] = [-dy, dx];
+        strokeLine(context, x + inner * dx, y + inner * dy, x + dx, y + dy);
+      }
+    }
+    if (canDragOffCurve) {
+      const dashLength = (parameters.canDragOffCurveIndicatorRadius * Math.PI) / 6;
+      context.setLineDash([dashLength]);
+      strokeRoundNode(
+        context,
+        canDragOffCurve,
+        2 * parameters.canDragOffCurveIndicatorRadius
+      );
     }
   },
 });


### PR DESCRIPTION
This fixes #308.

- When hovering over the final point, show an indicator:
  - on-curve: dashed circle, "can drag off-curve from this point"
  - off-curve: "cross": will delete off-curve when clicked

This also fixes a redundant undo record, when clicking bot not dragging a final on-curve point.