### PR TITLE
[info panel] Show "base" unicode for unencoded glyphs

### DIFF
--- a/src/fontra/client/core/glyph-lines.js
+++ b/src/fontra/client/core/glyph-lines.js
@@ -1,4 +1,5 @@
 import { getSuggestedGlyphName, getUnicodeFromGlyphName } from "./server-utils.js";
+import { splitGlyphNameExtension } from "./utils.js";
 
 export async function glyphLinesFromText(text, characterMap, glyphMap) {
   const glyphLines = [];
@@ -52,10 +53,7 @@ async function glyphNamesFromText(text, characterMap, glyphMap) {
             // happens to be a character that we know a glyph name for.
             // This allows us to write /Å.alt instead of /Aring.alt in the
             // text entry field.
-            const periodIndex = glyphName.indexOf(".");
-            const baseGlyphName =
-              periodIndex >= 1 ? glyphName.slice(0, periodIndex) : glyphName;
-            const extension = periodIndex >= 1 ? glyphName.slice(periodIndex) : "";
+            const [baseGlyphName, extension] = splitGlyphNameExtension(glyphName);
             const baseCharCode = baseGlyphName.codePointAt(0);
             const charString = String.fromCodePoint(baseCharCode);
             if (baseGlyphName === charString) {

--- a/src/fontra/client/core/utils.js
+++ b/src/fontra/client/core/utils.js
@@ -427,3 +427,10 @@ export function* iter(iterable) {
     yield item;
   }
 }
+
+export function splitGlyphNameExtension(glyphName) {
+  const periodIndex = glyphName.indexOf(".");
+  const baseGlyphName = periodIndex >= 1 ? glyphName.slice(0, periodIndex) : glyphName;
+  const extension = periodIndex >= 1 ? glyphName.slice(periodIndex) : "";
+  return [baseGlyphName, extension];
+}

--- a/src/fontra/views/editor/panel-selection-info.js
+++ b/src/fontra/views/editor/panel-selection-info.js
@@ -139,12 +139,7 @@ export default class SelectionInfoPanel extends Panel {
       unicodes = [selectedGlyphInfo.character.codePointAt(0)];
     }
 
-    const unicodesStr = unicodes
-      .map(
-        (code) =>
-          `${makeUPlusStringFromCodePoint(code)}\u00A0(${getCharFromUnicode(code)})`
-      )
-      .join(" ");
+    const unicodesStr = makeUnicodesString(unicodes);
 
     const formContents = [];
     if (glyphName) {
@@ -466,6 +461,15 @@ function maybeClampValue(value, min, max) {
     value = Math.min(value, max);
   }
   return value;
+}
+
+function makeUnicodesString(unicodes) {
+  return (unicodes || [])
+    .map(
+      (code) =>
+        `${makeUPlusStringFromCodePoint(code)}\u00A0(${getCharFromUnicode(code)})`
+    )
+    .join(" ");
 }
 
 customElements.define("panel-selection-info", SelectionInfoPanel);

--- a/src/fontra/views/editor/panel-selection-info.js
+++ b/src/fontra/views/editor/panel-selection-info.js
@@ -8,6 +8,7 @@ import {
   makeUPlusStringFromCodePoint,
   parseSelection,
   round,
+  splitGlyphNameExtension,
   throttleCalls,
 } from "/core/utils.js";
 import { Form } from "/web-components/ui-form.js";
@@ -140,6 +141,13 @@ export default class SelectionInfoPanel extends Panel {
     }
 
     const unicodesStr = makeUnicodesString(unicodes);
+    let baseUnicodesStr;
+    if (glyphName && !unicodes.length) {
+      const [baseGlyphName, _] = splitGlyphNameExtension(glyphName);
+      baseUnicodesStr = makeUnicodesString(
+        this.fontController.glyphMap?.[baseGlyphName]
+      );
+    }
 
     const formContents = [];
     if (glyphName) {
@@ -155,6 +163,14 @@ export default class SelectionInfoPanel extends Panel {
         label: "Unicode",
         value: unicodesStr,
       });
+      if (baseUnicodesStr) {
+        formContents.push({
+          key: "baseUnicodes",
+          type: "text",
+          label: "Base unicode",
+          value: baseUnicodesStr,
+        });
+      }
       if (instance) {
         formContents.push({
           type: "edit-number",

--- a/test-js/test-utils.js
+++ b/test-js/test-utils.js
@@ -23,6 +23,7 @@ import {
   rgbaToCSS,
   round,
   scheduleCalls,
+  splitGlyphNameExtension,
   throttleCalls,
   withTimeout,
 } from "../src/fontra/client/core/utils.js";
@@ -457,4 +458,23 @@ describe("withTimeout", () => {
     }
     expect(thrown).to.be.false;
   });
+});
+
+describe("splitGlyphNameExtension", () => {
+  parametrize(
+    "splitGlyphNameExtension tests",
+    [
+      ["", ["", ""]],
+      ["a", ["a", ""]],
+      [".notdef", [".notdef", ""]],
+      [".x", [".x", ""]],
+      ["a.alt", ["a", ".alt"]],
+      ["a.alt.etc", ["a", ".alt.etc"]],
+      ["aring.alt.etc", ["aring", ".alt.etc"]],
+    ],
+    (testData) => {
+      const [inputGlyphName, expectedResult] = testData;
+      expect(splitGlyphNameExtension(inputGlyphName)).to.deep.equal(expectedResult);
+    }
+  );
 });


### PR DESCRIPTION
This fixes #895.

For unencoded glyphs that have a glyph name extension, try to look up the unicode for the "base" glyph (by stripping the extension), and show that as "Base unicode" in the selection info panel.

<img width="284" alt="image" src="https://github.com/googlefonts/fontra/assets/4246121/c397f959-0ae7-486c-896a-d210acffb35e">
