### PR TITLE
Fix zoom / scroll with scroll wheel on Windows, second attempt

### DIFF
--- a/src/fontra/client/core/canvas-controller.js
+++ b/src/fontra/client/core/canvas-controller.js
@@ -116,8 +116,8 @@ export class CanvasController {
     const clunkyScrollWheel =
       Math.abs(deltaY) > 50 && Math.abs(wheelDeltaY / deltaY) < 2;
     if (event.ctrlKey || event.altKey) {
-      // Note: with event.ctrlKey is *also* how zoom gestures on trackpads are received,
-      // on both Windows and macOS.
+      // Note: wheel events with ctrlKey down is *also* how zoom gestures on trackpads
+      // are received, on both Windows and macOS.
       const scaleDown = clunkyScrollWheel ? 500 : event.ctrlKey ? 100 : 300;
       this._doPinchMagnify(event, 1 - deltaY / scaleDown);
     } else {

--- a/src/fontra/client/core/canvas-controller.js
+++ b/src/fontra/client/core/canvas-controller.js
@@ -118,14 +118,14 @@ export class CanvasController {
     if (event.ctrlKey || event.altKey) {
       // Note: with event.ctrlKey is *also* how zoom gestures on trackpads are received,
       // on both Windows and macOS.
-      const scale = clunkyScrollWheel ? 500 : event.ctrlKey ? 100 : 300;
-      this._doPinchMagnify(event, 1 - deltaY / scale);
+      const scaleDown = clunkyScrollWheel ? 500 : event.ctrlKey ? 100 : 300;
+      this._doPinchMagnify(event, 1 - deltaY / scaleDown);
     } else {
-      const scale = clunkyScrollWheel ? 3 : 1;
+      const scaleDown = clunkyScrollWheel ? 3 : 1;
       if (Math.abs(deltaX) > Math.abs(deltaY)) {
-        this.origin.x -= deltaX / scale;
+        this.origin.x -= deltaX / scaleDown;
       } else {
-        this.origin[event.shiftKey ? "x" : "y"] -= deltaY / scale;
+        this.origin[event.shiftKey ? "x" : "y"] -= deltaY / scaleDown;
       }
       this.requestUpdate();
       this._dispatchEvent("viewBoxChanged", "origin");


### PR DESCRIPTION
Alternative to #925. 

Fixes #890:
Use some heuristics to detect a 'clunky' scroll wheel, and scale down deltaY to get more reasonable zoom and scroll behavior.

Fixes #891:
Implement shift scrollwheel to mean horizontal scroll.