### PR TITLE
Improve multi source paste

### DIFF
--- a/src/fontra/client/core/var-model.js
+++ b/src/fontra/client/core/var-model.js
@@ -489,3 +489,17 @@ export function piecewiseLinearMap(v, mapping) {
   const vb = mapping[b];
   return va + ((vb - va) * (v - a)) / (b - a);
 }
+
+export function makeSparseLocation(location, axisList) {
+  // Return a subset of `locations` that only contains values for axes
+  // defined in axisList, and that are not equal to the default value
+  // for the axis.
+  return Object.fromEntries(
+    axisList
+      .filter(
+        (axis) =>
+          location[axis.name] !== undefined && location[axis.name] !== axis.defaultValue
+      )
+      .map((axis) => [axis.name, location[axis.name]])
+  );
+}

--- a/src/fontra/client/core/var-model.js
+++ b/src/fontra/client/core/var-model.js
@@ -491,8 +491,8 @@ export function piecewiseLinearMap(v, mapping) {
 }
 
 export function makeSparseLocation(location, axisList) {
-  // Return a subset of `locations` that only contains values for axes
-  // defined in axisList, and that are not equal to the default value
+  // Return a subset of `location` that only contains values for axes
+  // defined in `axisList`, and that are not equal to the default value
   // for the axis.
   return Object.fromEntries(
     axisList

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -39,6 +39,7 @@ import {
 } from "../core/utils.js";
 import { addItemwise, mulScalar, subItemwise } from "../core/var-funcs.js";
 import { StaticGlyph, VariableGlyph, copyComponent } from "../core/var-glyph.js";
+import { locationToString, makeSparseLocation } from "../core/var-model.js";
 import { VarPackedPath, joinPaths } from "../core/var-path.js";
 import { CJKDesignFrame } from "./cjk-design-frame.js";
 import { HandTool } from "./edit-tools-hand.js";
@@ -977,6 +978,17 @@ export class EditorController {
     if (!varGlyph) {
       return;
     }
+
+    const layerLocations = {};
+    for (const source of varGlyph.sources) {
+      if (!(source.layerName in layerLocations)) {
+        layerLocations[source.layerName] = makeSparseLocation(
+          source.location,
+          varGlyph.combinedAxes
+        );
+      }
+    }
+
     const layerGlyphs = [];
     let flattenedPath;
     for (const [layerName, layerGlyph] of Object.entries(
@@ -989,7 +1001,11 @@ export class EditorController {
       if (!flattenedPath) {
         flattenedPath = copyResult.flattenedPath;
       }
-      layerGlyphs.push({ layerName, glyph: copyResult.instance });
+      layerGlyphs.push({
+        layerName,
+        location: layerLocations[layerName],
+        glyph: copyResult.instance,
+      });
     }
     if (!layerGlyphs.length && !doCut) {
       const { instance, flattenedPath: instancePath } = this._prepareCopyOrCut(

--- a/src/fontra/views/editor/panel-designspace-navigation.js
+++ b/src/fontra/views/editor/panel-designspace-navigation.js
@@ -17,6 +17,7 @@ import {
 import { Layer, Source } from "/core/var-glyph.js";
 import {
   locationToString,
+  makeSparseLocation,
   mapForward,
   normalizeLocation,
   piecewiseLinearMap,
@@ -1026,17 +1027,6 @@ function roundComponentOrigins(components) {
       component.transformation.translateY
     );
   });
-}
-
-function makeSparseLocation(location, axes) {
-  return Object.fromEntries(
-    axes
-      .filter(
-        (axis) =>
-          location[axis.name] !== undefined && location[axis.name] !== axis.defaultValue
-      )
-      .map((axis) => [axis.name, location[axis.name]])
-  );
 }
 
 function getAxisInfoFromGlyph(glyph) {


### PR DESCRIPTION
When doing multi-source paste, if a destination layer can't be found by name, try to look it up by source location.

This fixes #927.