### PR TITLE
Improve multi-source paste in edit mode

### DIFF
--- a/src/fontra/client/core/font-controller.js
+++ b/src/fontra/client/core/font-controller.js
@@ -171,11 +171,14 @@ export class FontController {
   async _getGlyph(glyphName) {
     let glyph = await this.font.getGlyph(glyphName);
     if (glyph !== null) {
-      glyph = VariableGlyph.fromObject(glyph);
-      glyph = new VariableGlyphController(glyph, this.globalAxes);
+      glyph = this.makeVariableGlyphController(VariableGlyph.fromObject(glyph));
       this.updateGlyphDependencies(glyph);
     }
     return glyph;
+  }
+
+  makeVariableGlyphController(glyph) {
+    return new VariableGlyphController(glyph, this.globalAxes);
   }
 
   updateGlyphDependencies(glyph) {
@@ -212,7 +215,7 @@ export class FontController {
       sources: [{ name: sourceName, location: {}, layerName: sourceName }],
       layers: { [sourceName]: { glyph: structuredClone(templateInstance) } },
     });
-    const glyphController = new VariableGlyphController(glyph, this.globalAxes);
+    const glyphController = this.makeVariableGlyphController(glyph);
     this._glyphsPromiseCache.put(glyphName, Promise.resolve(glyphController));
 
     const codePoints = typeof codePoint == "number" ? [codePoint] : [];

--- a/src/fontra/client/core/utils.js
+++ b/src/fontra/client/core/utils.js
@@ -434,3 +434,11 @@ export function splitGlyphNameExtension(glyphName) {
   const extension = periodIndex >= 1 ? glyphName.slice(periodIndex) : "";
   return [baseGlyphName, extension];
 }
+
+export function isObjectEmpty(obj) {
+  // Return true if `obj` has no properties
+  for (const _ in obj) {
+    return false;
+  }
+  return true;
+}

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -1856,6 +1856,7 @@ async function runDialogWholeGlyphPaste() {
 
   const radioGroup = [
     html.div({}, "What would you like to do with the glyph on the clipboard?"),
+    html.br(),
   ];
   for (const [label, value] of [
     ["Replace the current glyph", PASTE_BEHAVIOR_REPLACE],
@@ -1874,6 +1875,7 @@ async function runDialogWholeGlyphPaste() {
       html.br()
     );
   }
+  radioGroup.push(html.br());
 
   dialog.setContent(html.div({}, radioGroup));
   const result = await dialog.run();

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -1094,7 +1094,7 @@ export class EditorController {
       if (!result) {
         return;
       }
-      if (result !== PASTE_BEHAVIOR_REPLACE) {
+      if (result === PASTE_BEHAVIOR_ADD) {
         // We will paste an entire variable glyph onto the existing layers.
         // Build pasteLayerGlyphs from the glyph's sources.
         const varGlyphController =

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -1095,8 +1095,8 @@ export class EditorController {
         return;
       }
       if (result !== PASTE_BEHAVIOR_REPLACE) {
-        // We will paste the whole glyph onto the existing layers.
-        // Build pasteLayerGlyphs, based on the whole glyph's sources.
+        // We will paste an entire variable glyph onto the existing layers.
+        // Build pasteLayerGlyphs from the glyph's sources.
         const varGlyphController =
           this.fontController.makeVariableGlyphController(pasteVarGlyph);
         const combinedAxes = varGlyphController.combinedAxes;

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -30,6 +30,7 @@ import {
   getCharFromUnicode,
   hyphenatedToCamelCase,
   isActiveElementTypeable,
+  isObjectEmpty,
   parseSelection,
   range,
   readFromClipboard,
@@ -1099,17 +1100,21 @@ export class EditorController {
       }
       replaceGlyph = result === PASTE_BEHAVIOR_REPLACE;
       if (!replaceGlyph) {
+        // We'll paste the whole glyph onto the existing layers. Build new
         const varGlyphController =
           this.fontController.makeVariableGlyphController(pasteVarGlyph);
         const combinedAxes = varGlyphController.combinedAxes;
-        pasteLayerGlyphs = [pasteLayerGlyphs[0]];
-        for (const source of pasteVarGlyph.sources) {
-          pasteLayerGlyphs.push({
+        pasteLayerGlyphs = pasteVarGlyph.sources.map((source) => {
+          return {
             layerName: source.layerName,
             location: makeSparseLocation(source.location, combinedAxes),
             glyph: pasteVarGlyph.layers[source.layerName].glyph,
-          });
-        }
+          };
+        });
+        // Sort so the default source comes first, as it is used as a fallback
+        pasteLayerGlyphs.sort((a, b) =>
+          !isObjectEmpty(a.location) && isObjectEmpty(b.location) ? 1 : -1
+        );
       }
     }
 

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -1085,7 +1085,7 @@ export class EditorController {
   }
 
   async doPaste() {
-    const { pasteVarGlyph, pasteLayerGlyphs } = await this._unpackClipboard();
+    let { pasteVarGlyph, pasteLayerGlyphs } = await this._unpackClipboard();
     if (!pasteLayerGlyphs?.length) {
       return;
     }
@@ -1098,6 +1098,19 @@ export class EditorController {
         return;
       }
       replaceGlyph = result === PASTE_BEHAVIOR_REPLACE;
+      if (!replaceGlyph) {
+        const varGlyphController =
+          this.fontController.makeVariableGlyphController(pasteVarGlyph);
+        const combinedAxes = varGlyphController.combinedAxes;
+        pasteLayerGlyphs = [pasteLayerGlyphs[0]];
+        for (const source of pasteVarGlyph.sources) {
+          pasteLayerGlyphs.push({
+            layerName: source.layerName,
+            location: makeSparseLocation(source.location, combinedAxes),
+            glyph: pasteVarGlyph.layers[source.layerName].glyph,
+          });
+        }
+      }
     }
 
     if (replaceGlyph && pasteVarGlyph) {

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -1854,10 +1854,12 @@ async function runDialogWholeGlyphPaste() {
     { title: "Okay", resultValue: "ok", isDefaultButton: true },
   ]);
 
-  const radioGroup = [html.div({}, "What would you like to do with the copied glyph?")];
+  const radioGroup = [
+    html.div({}, "What would you like to do with the glyph on the clipboard?"),
+  ];
   for (const [label, value] of [
-    ["Replace glyph", PASTE_BEHAVIOR_REPLACE],
-    ["Add to glyph", PASTE_BEHAVIOR_ADD],
+    ["Replace the current glyph", PASTE_BEHAVIOR_REPLACE],
+    ["Add to the current glyph (match layers)", PASTE_BEHAVIOR_ADD],
   ]) {
     radioGroup.push(
       html.input({

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -1100,7 +1100,8 @@ export class EditorController {
       }
       replaceGlyph = result === PASTE_BEHAVIOR_REPLACE;
       if (!replaceGlyph) {
-        // We'll paste the whole glyph onto the existing layers. Build new
+        // We will paste the whole glyph onto the existing layers.
+        // Build pasteLayerGlyphs, based on the whole glyph's sources.
         const varGlyphController =
           this.fontController.makeVariableGlyphController(pasteVarGlyph);
         const combinedAxes = varGlyphController.combinedAxes;

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -1849,7 +1849,7 @@ async function runDialogWholeGlyphPaste() {
     controller.model.behavior = PASTE_BEHAVIOR_REPLACE;
   }
 
-  const dialog = await dialogSetup("Pasting an entire glyph", null, [
+  const dialog = await dialogSetup("You are about to paste an entire glyph", null, [
     { title: "Cancel", resultValue: "cancel", isCancelButton: true },
     { title: "Okay", resultValue: "ok", isDefaultButton: true },
   ]);
@@ -1858,6 +1858,7 @@ async function runDialogWholeGlyphPaste() {
     html.div({}, "What would you like to do with the glyph on the clipboard?"),
     html.br(),
   ];
+
   for (const [label, value] of [
     ["Replace the current glyph", PASTE_BEHAVIOR_REPLACE],
     ["Add to the current glyph (match layers)", PASTE_BEHAVIOR_ADD],


### PR DESCRIPTION
In edit mode, when pasting a whole glyph, ask the user whether they want to replace the glyph, or add to it.