### PR TITLE
Paste layers in selected glyph & paste in selected non-existant glyph

### DIFF
--- a/src/fontra/client/core/font-controller.js
+++ b/src/fontra/client/core/font-controller.js
@@ -204,7 +204,7 @@ export class FontController {
     }
   }
 
-  async newGlyph(glyphName, codePoint, varGlyph, undoLabel) {
+  async newGlyph(glyphName, codePoint, varGlyph, undoLabel = null) {
     if (this.glyphMap[glyphName]) {
       throw new Error(`assert -- glyph "${glyphName}" already exists`);
     }

--- a/src/fontra/client/core/font-controller.js
+++ b/src/fontra/client/core/font-controller.js
@@ -216,6 +216,7 @@ export class FontController {
     const sourceName = "<default>"; // TODO: get from backend (via namedLocations?)
 
     const glyph = VariableGlyph.fromObject(varGlyph);
+    glyph.name = glyphName;
     const glyphController = this.makeVariableGlyphController(glyph);
     this._glyphsPromiseCache.put(glyphName, Promise.resolve(glyphController));
 

--- a/src/fontra/client/core/font-controller.js
+++ b/src/fontra/client/core/font-controller.js
@@ -204,7 +204,7 @@ export class FontController {
     }
   }
 
-  async newGlyph(glyphName, codePoint, templateInstance) {
+  async newGlyph(glyphName, codePoint, varGlyph) {
     if (this.glyphMap[glyphName]) {
       throw new Error(`assert -- glyph "${glyphName}" already exists`);
     }
@@ -215,11 +215,7 @@ export class FontController {
     }
     const sourceName = "<default>"; // TODO: get from backend (via namedLocations?)
 
-    const glyph = VariableGlyph.fromObject({
-      name: glyphName,
-      sources: [{ name: sourceName, location: {}, layerName: sourceName }],
-      layers: { [sourceName]: { glyph: structuredClone(templateInstance) } },
-    });
+    const glyph = VariableGlyph.fromObject(varGlyph);
     const glyphController = this.makeVariableGlyphController(glyph);
     this._glyphsPromiseCache.put(glyphName, Promise.resolve(glyphController));
 

--- a/src/fontra/client/core/font-controller.js
+++ b/src/fontra/client/core/font-controller.js
@@ -204,7 +204,7 @@ export class FontController {
     }
   }
 
-  async newGlyph(glyphName, codePoint, varGlyph) {
+  async newGlyph(glyphName, codePoint, varGlyph, undoLabel) {
     if (this.glyphMap[glyphName]) {
       throw new Error(`assert -- glyph "${glyphName}" already exists`);
     }
@@ -238,7 +238,7 @@ export class FontController {
       ],
     };
 
-    const undoInfo = { label: `new glyph "${glyphName}"` };
+    const undoInfo = { label: undoLabel || `new glyph "${glyphName}"` };
     const error = await this.editFinal(change, rollbackChange, undoInfo.label, true);
     // TODO handle error
     this.notifyEditListeners("editFinal", this);

--- a/src/fontra/views/editor/edit-tools-pointer.js
+++ b/src/fontra/views/editor/edit-tools-pointer.js
@@ -10,12 +10,14 @@ import {
   parseSelection,
   range,
 } from "../core/utils.js";
+import { VariableGlyph } from "../core/var-glyph.js";
 import { VarPackedPath } from "../core/var-path.js";
 import * as vector from "../core/vector.js";
 import { EditBehaviorFactory } from "./edit-behavior.js";
 import { BaseTool, shouldInitiateDrag } from "./edit-tools-base.js";
 import { equalGlyphSelection } from "./scene-controller.js";
 import { dialog } from "/web-components/modal-dialog.js";
+VariableGlyph;
 
 export class PointerTool extends BaseTool {
   iconPath = "/images/pointer.svg";
@@ -148,6 +150,8 @@ export class PointerTool extends BaseTool {
         : undefined;
       const positionedGlyph = sceneController.sceneModel.getSelectedPositionedGlyph();
       if (positionedGlyph?.isUndefined) {
+        // Create a new glyph
+        // TODO: dispatch event and let editor.js handle it
         this.sceneSettings.selectedGlyph = {
           ...this.sceneSettings.selectedGlyph,
           isEditing: false,
@@ -169,10 +173,15 @@ export class PointerTool extends BaseTool {
           ]
         );
         if (result === "ok") {
+          const layerName = "<default>";
           await this.editor.newGlyph(
             positionedGlyph.glyphName,
             positionedGlyph.character?.codePointAt(0),
-            positionedGlyph.glyph.instance
+            VariableGlyph.fromObject({
+              name: positionedGlyph.glyphName,
+              sources: [{ name: layerName, location: {}, layerName: layerName }],
+              layers: { [layerName]: { glyph: positionedGlyph.glyph.instance } },
+            })
           );
           this.sceneSettings.selectedGlyph = {
             ...this.sceneSettings.selectedGlyph,

--- a/src/fontra/views/editor/edit-tools-pointer.js
+++ b/src/fontra/views/editor/edit-tools-pointer.js
@@ -17,7 +17,6 @@ import { EditBehaviorFactory } from "./edit-behavior.js";
 import { BaseTool, shouldInitiateDrag } from "./edit-tools-base.js";
 import { equalGlyphSelection } from "./scene-controller.js";
 import { dialog } from "/web-components/modal-dialog.js";
-VariableGlyph;
 
 export class PointerTool extends BaseTool {
   iconPath = "/images/pointer.svg";

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -1125,6 +1125,25 @@ export class EditorController {
         );
         pasteVarGlyph = null;
       }
+    } else if (!pasteVarGlyph && !this.sceneSettings.selectedGlyph.isEditing) {
+      // We're pasting layers onto a glyph in select mode. Build a VariableGlyph
+      // from the layers as good as we can.
+      const layers = {};
+      const sources = [];
+      if (pasteLayerGlyphs.length === 1) {
+        const layerName = "<default>";
+        layers[layerName] = { glyph: pasteLayerGlyphs[0].glyph };
+        sources.push({ name: layerName, layerName });
+      } else {
+        for (const { layerName, location, glyph } of pasteLayerGlyphs) {
+          if (layerName) {
+            layers[layerName] = { glyph };
+            sources.push({ name: layerName, layerName, location: location || {} });
+          }
+        }
+      }
+      pasteVarGlyph = VariableGlyph.fromObject({ layers, sources });
+      pasteLayerGlyphs = null;
     }
 
     if (pasteVarGlyph) {

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -1522,8 +1522,8 @@ export class EditorController {
     showMenu(menuItems, { x: x + 1, y: y - 1 }, event.target);
   }
 
-  async newGlyph(glyphName, codePoint, templateInstance) {
-    await this.fontController.newGlyph(glyphName, codePoint, templateInstance);
+  async newGlyph(glyphName, codePoint, varGlyph) {
+    await this.fontController.newGlyph(glyphName, codePoint, varGlyph);
   }
 
   async externalChange(change, isLiveChange) {

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -1147,7 +1147,16 @@ export class EditorController {
     }
 
     if (pasteVarGlyph) {
-      await this._pasteReplaceGlyph(pasteVarGlyph);
+      const positionedGlyph = this.sceneModel.getSelectedPositionedGlyph();
+      if (positionedGlyph.isUndefined) {
+        await this.newGlyph(
+          positionedGlyph.glyphName,
+          positionedGlyph.character?.codePointAt(0),
+          pasteVarGlyph
+        );
+      } else {
+        await this._pasteReplaceGlyph(pasteVarGlyph);
+      }
     } else {
       await this._pasteLayerGlyphs(pasteLayerGlyphs);
     }

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -1152,7 +1152,8 @@ export class EditorController {
         await this.newGlyph(
           positionedGlyph.glyphName,
           positionedGlyph.character?.codePointAt(0),
-          pasteVarGlyph
+          pasteVarGlyph,
+          `paste new glyph "${positionedGlyph.glyphName}"`
         );
       } else {
         await this._pasteReplaceGlyph(pasteVarGlyph);
@@ -1531,8 +1532,8 @@ export class EditorController {
     showMenu(menuItems, { x: x + 1, y: y - 1 }, event.target);
   }
 
-  async newGlyph(glyphName, codePoint, varGlyph) {
-    await this.fontController.newGlyph(glyphName, codePoint, varGlyph);
+  async newGlyph(glyphName, codePoint, varGlyph, undoLabel) {
+    await this.fontController.newGlyph(glyphName, codePoint, varGlyph, undoLabel);
   }
 
   async externalChange(change, isLiveChange) {

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -1532,7 +1532,7 @@ export class EditorController {
     showMenu(menuItems, { x: x + 1, y: y - 1 }, event.target);
   }
 
-  async newGlyph(glyphName, codePoint, varGlyph, undoLabel) {
+  async newGlyph(glyphName, codePoint, varGlyph, undoLabel = null) {
     await this.fontController.newGlyph(glyphName, codePoint, varGlyph, undoLabel);
   }
 


### PR DESCRIPTION
This PR implements two things:
- Copy (multiple) layers in edit mode, paste in selecte mode. This fixes #947.
- Paste in non-existant glyph: this will create the glyph. This fixes #946.