### PR TITLE
dumpURLFragment() in Python: don't escape non-ascii

### DIFF
--- a/src/fontra/core/urlfragment.py
+++ b/src/fontra/core/urlfragment.py
@@ -4,7 +4,7 @@ import zlib
 
 
 def dumpURLFragment(obj):
-    text = json.dumps(obj, separators=(",", ":"))
+    text = json.dumps(obj, separators=(",", ":"), ensure_ascii=False)
     compressed = zlib.compress(text.encode("utf-8"))
     return "#" + base64.b64encode(compressed).decode("ascii")
 

--- a/test-common/url-fragment-test-data.json
+++ b/test-common/url-fragment-test-data.json
@@ -4,5 +4,9 @@
   {
     "object": { "a": { "b": 123, "c": 456 } },
     "fragment": "#eJyrVkpUsqpWSlKyMjQy1lFKVrIyMTWrrQUARnAF8g=="
+  },
+  {
+    "object": { "text": "Å" },
+    "fragment": "#eJyrVipJrShRslI63KpUCwAg+gTI"
   }
 ]


### PR DESCRIPTION
Don't escape non-ascii in the Python implementation of dumpURLFragment(): utf-8 is more compact, and this matches JSON.stringify().

Unfortunately we can't test non-BMP strings, as the Node fallback UTF-8 encoder in fflate doesn't support it properly. It works correctly in the browser, though.