### PR TITLE
Fix regression caused by default field optimization: ensure all compo transformation fields are filled

### DIFF
--- a/src/fontra/client/core/var-glyph.js
+++ b/src/fontra/client/core/var-glyph.js
@@ -63,10 +63,22 @@ export class StaticGlyph {
   }
 }
 
+const identityTransformation = {
+  translateX: 0,
+  translateY: 0,
+  rotation: 0,
+  scaleX: 1,
+  scaleY: 1,
+  skewX: 0,
+  skewY: 0,
+  tCenterX: 0,
+  tCenterY: 0,
+};
+
 export function copyComponent(component) {
   return {
     name: component.name,
-    transformation: { ...component.transformation },
+    transformation: { ...identityTransformation, ...component.transformation },
     location: { ...component.location },
   };
 }

--- a/test-js/test-var-glyph.js
+++ b/test-js/test-var-glyph.js
@@ -25,7 +25,21 @@ function makeTestGlyphObject() {
           verticalOrigin: 800,
           path: { contourInfo: [], coordinates: [], pointTypes: [] },
           components: [
-            { name: "test", location: { a: 0.5 }, transformation: { translateX: 0 } },
+            {
+              name: "test",
+              location: { a: 0.5 },
+              transformation: {
+                translateX: 0,
+                translateY: 0,
+                rotation: 0,
+                scaleX: 1,
+                scaleY: 1,
+                skewX: 0,
+                skewY: 0,
+                tCenterX: 0,
+                tCenterY: 0,
+              },
+            },
           ],
         },
         customData: {},
@@ -40,6 +54,46 @@ describe("var-glyph Tests", () => {
     const vgObj = makeTestGlyphObject();
     const vg = VariableGlyph.fromObject(vgObj);
     expect(vg).to.deep.equal(vgObj);
+  });
+
+  it("new densify StaticGlyph", () => {
+    const sparseObject = {
+      xAdvance: 500,
+      components: [
+        {
+          name: "test",
+        },
+      ],
+    };
+    const denseObject = {
+      components: [
+        {
+          name: "test",
+          transformation: {
+            rotation: 0,
+            scaleX: 1,
+            scaleY: 1,
+            skewX: 0,
+            skewY: 0,
+            tCenterX: 0,
+            tCenterY: 0,
+            translateX: 0,
+            translateY: 0,
+          },
+          location: {},
+        },
+      ],
+      path: {
+        contourInfo: [],
+        coordinates: [],
+        pointTypes: [],
+      },
+      verticalOrigin: undefined,
+      xAdvance: 500,
+      yAdvance: undefined,
+    };
+    const glyph = StaticGlyph.fromObject(sparseObject);
+    expect(glyph).to.deep.equal(denseObject);
   });
 
   const modifierFuncs = [


### PR DESCRIPTION
This was caused by #983.