### PR TITLE
Use central structure/unstructure funcs, so we can use a custom cattrs converter object

### DIFF
--- a/src/fontra/backends/fontra.py
+++ b/src/fontra/backends/fontra.py
@@ -8,9 +8,7 @@ from copy import deepcopy
 from dataclasses import dataclass, field
 from typing import Callable
 
-import cattrs
-
-from fontra.core.classes import Font, VariableGlyph
+from fontra.core.classes import Font, VariableGlyph, structure, unstructure
 
 from .filenames import stringToFileName
 
@@ -122,12 +120,12 @@ class FontraBackend:
                 writer.writerow([glyphName, codePoints])
 
     def _readFontData(self):
-        self.fontData = cattrs.structure(
+        self.fontData = structure(
             json.loads(self.fontDataPath.read_text(encoding="utf-8")), Font
         )
 
     def _writeFontData(self):
-        fontData = cattrs.unstructure(self.fontData)
+        fontData = unstructure(self.fontData)
         fontData.pop("glyphs", None)
         fontData.pop("glyphMap", None)
         self.fontDataPath.write_text(serialize(fontData) + "\n", encoding="utf-8")
@@ -144,7 +142,7 @@ class FontraBackend:
 
 def serializeGlyph(glyph, glyphName=None):
     glyph = glyph.convertToPaths()
-    jsonGlyph = cattrs.unstructure(glyph)
+    jsonGlyph = unstructure(glyph)
     if glyphName is not None:
         jsonGlyph["name"] = glyphName
     return serialize(jsonGlyph) + "\n"
@@ -154,7 +152,7 @@ def deserializeGlyph(jsonSource, glyphName=None):
     jsonGlyph = json.loads(jsonSource)
     if glyphName is not None:
         jsonGlyph["name"] = glyphName
-    glyph = cattrs.structure(jsonGlyph, VariableGlyph)
+    glyph = structure(jsonGlyph, VariableGlyph)
     return glyph.convertToPackedPaths()
 
 

--- a/src/fontra/core/path.py
+++ b/src/fontra/core/path.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass, field, replace
 from enum import IntEnum
 from typing import TypedDict
 
-import cattrs
 from fontTools.misc.transform import DecomposedTransform
 
 logger = logging.getLogger(__name__)
@@ -38,7 +37,9 @@ class Path:
         return self
 
     def asPackedPath(self):
-        return PackedPath.fromUnpackedContours(cattrs.unstructure(self.contours))
+        from .classes import unstructure
+
+        return PackedPath.fromUnpackedContours(unstructure(self.contours))
 
     def isEmpty(self):
         return not self.contours
@@ -91,7 +92,9 @@ class PackedPath:
         )
 
     def asPath(self):
-        return Path(contours=cattrs.structure(self.unpackedContours(), list[Contour]))
+        from .classes import structure
+
+        return Path(contours=structure(self.unpackedContours(), list[Contour]))
 
     def asPackedPath(self):
         return self

--- a/src/fontra/core/remote.py
+++ b/src/fontra/core/remote.py
@@ -2,8 +2,9 @@ import asyncio
 import logging
 import traceback
 
-import cattrs
 from aiohttp import WSMsgType
+
+from .classes import unstructure
 
 logger = logging.getLogger(__name__)
 
@@ -91,7 +92,7 @@ class RemoteObjectConnection:
             methodHandler = getattr(subject, methodName, None)
             if getattr(methodHandler, "fontraRemoteMethod", False):
                 returnValue = await methodHandler(*arguments, connection=self)
-                returnValue = cattrs.unstructure(returnValue)
+                returnValue = unstructure(returnValue)
                 response = {"client-call-id": clientCallID, "return-value": returnValue}
             else:
                 response = {

--- a/src/fontra/core/serverutils.py
+++ b/src/fontra/core/serverutils.py
@@ -1,6 +1,5 @@
-import cattrs
-
 from . import clipboard, glyphnames
+from .classes import unstructure
 
 apiFunctions = {}
 
@@ -22,4 +21,4 @@ def getUnicodeFromGlyphName(glyphName):
 
 @api
 def parseClipboard(data):
-    return cattrs.unstructure(clipboard.parseClipboard(data))
+    return unstructure(clipboard.parseClipboard(data))

--- a/test-py/test_classes.py
+++ b/test-py/test_classes.py
@@ -1,8 +1,6 @@
 import json
 import pathlib
 
-import cattrs
-
 from fontra.backends.fontra import deserializeGlyph
 from fontra.core.classes import (
     Layer,
@@ -10,6 +8,7 @@ from fontra.core.classes import (
     VariableGlyph,
     classCastFuncs,
     serializableClassSchema,
+    unstructure,
 )
 
 repoRoot = pathlib.Path(__file__).resolve().parent.parent
@@ -35,17 +34,17 @@ def test_cast():
         / "B^1.json"
     )
     originalGlyph = deserializeGlyph(glyphPath.read_text(encoding="utf-8"))
-    unstructuredGlyph = cattrs.unstructure(originalGlyph)
+    unstructuredGlyph = unstructure(originalGlyph)
     # Ensure that the PointType enums get converted to ints
     unstructuredGlyph = json.loads(json.dumps(unstructuredGlyph))
     glyph = classCastFuncs[VariableGlyph](unstructuredGlyph)
     assert glyph == originalGlyph
     assert str(glyph) == str(originalGlyph)
 
-    sourcesList = cattrs.unstructure(glyph.sources)
+    sourcesList = unstructure(glyph.sources)
     sources = classCastFuncs[list[Source]](sourcesList)
     assert glyph.sources == sources
 
-    layersDict = cattrs.unstructure(glyph.layers)
+    layersDict = unstructure(glyph.layers)
     layers = classCastFuncs[dict[str, Layer]](layersDict)
     assert glyph.layers == layers

--- a/test-py/test_font.py
+++ b/test-py/test_font.py
@@ -2,11 +2,10 @@ import contextlib
 import pathlib
 from dataclasses import asdict
 
-import cattrs
 import pytest
 
 from fontra.backends import getFileSystemBackend
-from fontra.core.classes import GlobalAxis, GlobalDiscreteAxis, VariableGlyph
+from fontra.core.classes import GlobalAxis, GlobalDiscreteAxis, VariableGlyph, structure
 
 dataDir = pathlib.Path(__file__).resolve().parent / "data"
 
@@ -963,7 +962,7 @@ async def test_getGlyphMap(testFontName, numGlyphs, testMapping):
 @pytest.mark.asyncio
 @pytest.mark.parametrize("testFontName, expectedGlyph", getGlyphTestData)
 async def test_getGlyph(testFontName, expectedGlyph):
-    expectedGlyph = cattrs.structure(expectedGlyph, VariableGlyph)
+    expectedGlyph = structure(expectedGlyph, VariableGlyph)
     font = getTestFont(testFontName)
     with contextlib.closing(font):
         glyph = await font.getGlyph(expectedGlyph.name)

--- a/test-py/test_path.py
+++ b/test-py/test_path.py
@@ -1,8 +1,8 @@
 import operator
 
-import cattrs
 import pytest
 
+from fontra.core.classes import structure, unstructure
 from fontra.core.path import (
     Contour,
     InterpolationError,
@@ -127,26 +127,26 @@ pathTestData = [
 
 @pytest.mark.parametrize("path", pathTestData)
 def test_packedPathPointPenRoundTrip(path):
-    path = cattrs.structure(path, PackedPath)
+    path = structure(path, PackedPath)
     pen = PackedPathPointPen()
     path.drawPoints(pen)
     repackedPath = pen.getPath()
     assert path == repackedPath
-    assert cattrs.unstructure(path) == cattrs.unstructure(repackedPath)
+    assert unstructure(path) == unstructure(repackedPath)
 
 
 @pytest.mark.parametrize("path", pathTestData)
 def test_unpackPathRoundTrip(path):
-    path = cattrs.structure(path, PackedPath)
+    path = structure(path, PackedPath)
     unpackedPath = path.unpackedContours()
     repackedPath = PackedPath.fromUnpackedContours(unpackedPath)
     assert path == repackedPath
-    assert cattrs.unstructure(path) == cattrs.unstructure(repackedPath)
+    assert unstructure(path) == unstructure(repackedPath)
 
 
 @pytest.mark.parametrize("path", pathTestData)
 def test_pathConversion(path):
-    packedPath = cattrs.structure(path, PackedPath)
+    packedPath = structure(path, PackedPath)
     path = packedPath.asPath()
     packedPath2 = path.asPackedPath()
     assert packedPath == packedPath2
@@ -167,7 +167,7 @@ expectedPackedPathRepr = "PackedPath(coordinates=[232, -10, 338, -10, 403, 38, 4
 
 def test_packedPathRepr():
     path = pathTestData[1]
-    packedPath = cattrs.structure(path, PackedPath)
+    packedPath = structure(path, PackedPath)
     assert expectedPackedPathRepr == str(packedPath)
 
 
@@ -183,7 +183,7 @@ expectedPathRepr = "Path(contours=[Contour(points=[{'x': 232, 'y': -10, 'smooth'
 
 def test_pathRepr():
     path = pathTestData[1]
-    packedPath = cattrs.structure(path, PackedPath)
+    packedPath = structure(path, PackedPath)
     path = packedPath.asPath()
     assert expectedPathRepr == str(path)
 


### PR DESCRIPTION
This makes Fontra play nicer with other apps that may use cattrs: we won't leak our hooks into other uses of cattrs.