### PR TITLE
rename font-level lib to customData

### DIFF
--- a/src/fontra/backends/fontra.py
+++ b/src/fontra/backends/fontra.py
@@ -96,10 +96,10 @@ class FontraBackend:
         self._scheduler.schedule(self._writeFontData)
 
     async def getFontLib(self):
-        return deepcopy(self.fontData.lib)
+        return deepcopy(self.fontData.customData)
 
-    async def putFontLib(self, lib):
-        self.fontData.lib = deepcopy(lib)
+    async def putFontLib(self, customData):
+        self.fontData.customData = deepcopy(customData)
         self._scheduler.schedule(self._writeFontData)
 
     def _readGlyphInfo(self):

--- a/src/fontra/client/core/classes.json
+++ b/src/fontra/client/core/classes.json
@@ -11,6 +11,10 @@
       "type": "dict",
       "subtype": "list"
     },
+    "customData": {
+      "type": "dict",
+      "subtype": "Any"
+    },
     "axes": {
       "type": "list",
       "subtype": "GlobalAxis"

--- a/src/fontra/core/classes.py
+++ b/src/fontra/core/classes.py
@@ -129,7 +129,7 @@ class Font:
     unitsPerEm: int = 1000
     glyphs: GlyphSet = field(default_factory=GlyphSet)
     glyphMap: GlyphMap = field(default_factory=GlyphMap)
-    lib: dict = field(default_factory=dict)
+    customData: CustomData = field(default_factory=CustomData)
     axes: list[Union[GlobalAxis, GlobalDiscreteAxis]] = field(default_factory=list)
 
     def _trackAssignedAttributeNames(self):

--- a/test-common/fonts/MutatorSans.fontra/font-data.json
+++ b/test-common/fonts/MutatorSans.fontra/font-data.json
@@ -1,6 +1,6 @@
 {
 "unitsPerEm": 1000,
-"lib": {},
+"customData": {},
 "axes": [
 {
 "name": "width",


### PR DESCRIPTION
In the .fontra format, rename font.lib to font.customData, to be more in line with other customData fields.