### PR TITLE
Make normalizeLocation() not fail on invalid axes

### DIFF
--- a/src/fontra/client/core/var-model.js
+++ b/src/fontra/client/core/var-model.js
@@ -2,7 +2,7 @@
 
 import { VariationError } from "./errors.js";
 import { isSuperset } from "./set-ops.js";
-import { reversedEnumerate } from "./utils.js";
+import { clamp, reversedEnumerate } from "./utils.js";
 import { addItemwise, mulScalar, subItemwise } from "./var-funcs.js";
 
 export class VariationModel {
@@ -316,7 +316,12 @@ export function normalizeLocation(location, axisList) {
     if (v === undefined) {
       v = axis.defaultValue;
     }
-    out[axis.name] = normalizeValue(v, axis.minValue, axis.defaultValue, axis.maxValue);
+    out[axis.name] = normalizeValue(
+      v,
+      axis.minValue,
+      clamp(axis.defaultValue, axis.minValue, axis.maxValue),
+      clamp(axis.maxValue, axis.minValue, axis.maxValue)
+    );
   }
   return out;
 }

--- a/test-js/test-var-model.js
+++ b/test-js/test-var-model.js
@@ -163,6 +163,27 @@ describe("var-model tests", () => {
       expect(normalizeLocation({ wght: 1000 }, axes)).to.deep.equal({ wght: 0.0 });
       expect(normalizeLocation({ wght: 1001 }, axes)).to.deep.equal({ wght: 0.0 });
     });
+
+    it("buggy axis low default", () => {
+      const axes = [{ name: "wght", minValue: 500, defaultValue: 0, maxValue: 1000 }];
+      expect(normalizeLocation({ wght: 0 }, axes)).to.deep.equal({ wght: 0.0 });
+      expect(normalizeLocation({ wght: 500 }, axes)).to.deep.equal({ wght: 0.0 });
+      expect(normalizeLocation({ wght: 600 }, axes)).to.deep.equal({ wght: 0.2 });
+      expect(normalizeLocation({ wght: 1000 }, axes)).to.deep.equal({ wght: 1.0 });
+    });
+
+    it("buggy axis high default", () => {
+      const axes = [{ name: "wght", minValue: 0, defaultValue: 1000, maxValue: 500 }];
+      expect(normalizeLocation({ wght: 0 }, axes)).to.deep.equal({ wght: -1.0 });
+      expect(normalizeLocation({ wght: 400 }, axes)).to.deep.equal({ wght: -0.2 });
+      expect(normalizeLocation({ wght: 500 }, axes)).to.deep.equal({ wght: 0.0 });
+      expect(normalizeLocation({ wght: 1000 }, axes)).to.deep.equal({ wght: 0.0 });
+    });
+
+    it("buggy axis min/max", () => {
+      const axes = [{ name: "wght", minValue: 0, defaultValue: 0, maxValue: -500 }];
+      expect(normalizeLocation({ wght: 0 }, axes)).to.deep.equal({ wght: 0 });
+    });
   });
 
   describe("supportScalar tests", () => {


### PR DESCRIPTION
This fixes #1045.