### PR TITLE
Add shortcut for Decompose Components

### DIFF
--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -797,7 +797,8 @@ export class EditorController {
         this.registerShortCut(
           menuItem.shortCut.keysOrCodes,
           menuItem.shortCut,
-          menuItem.callback
+          menuItem.callback,
+          menuItem.enabled
         );
       }
     }
@@ -826,7 +827,7 @@ export class EditorController {
     });
   }
 
-  registerShortCut(keysOrCodes, modifiers, callback) {
+  registerShortCut(keysOrCodes, modifiers, callback, enabled = null) {
     //
     // Register a shortcut handler
     //
@@ -841,9 +842,13 @@ export class EditorController {
     // `callback` is a callable that will be called with the event as its single
     // argument.
     //
+    // `enabled` is an optional callable that should return true if the action is
+    // enabled. If `enabled()` returns false, `callback` will not be called.
+    // If `enabled` is not given, `callback` will be called unconditionally.
+    //
 
     for (const keyOrCode of keysOrCodes) {
-      const handlerDef = { ...modifiers, callback };
+      const handlerDef = { ...modifiers, callback, enabled };
       if (!this.shortCutHandlers[keyOrCode]) {
         this.shortCutHandlers[keyOrCode] = [];
       }
@@ -852,11 +857,14 @@ export class EditorController {
   }
 
   async keyDownHandler(event) {
-    const callback = this._getShortCutCallback(event);
+    const { callback, enabled } = this._getShortCutCallback(event);
     if (callback !== undefined) {
+      this.sceneController.updateContextMenuState(null);
       event.preventDefault();
       event.stopImmediatePropagation();
-      await callback(event);
+      if (!enabled || enabled()) {
+        await callback(event);
+      }
     }
   }
 
@@ -866,7 +874,7 @@ export class EditorController {
       handlerDefs = this.shortCutHandlers[event.code];
     }
     if (!handlerDefs) {
-      return undefined;
+      return {};
     }
     for (const handlerDef of handlerDefs) {
       if (
@@ -884,9 +892,9 @@ export class EditorController {
       if (!matchEvent(handlerDef, event)) {
         continue;
       }
-      return handlerDef.callback;
+      return { callback: handlerDef.callback, enabled: handlerDef.enabled };
     }
-    return undefined;
+    return {};
   }
 
   getUndoRedoLabel(isRedo) {

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -790,6 +790,7 @@ export class EditorController {
 
     for (const menuItem of [
       ...this.basicContextMenuItems,
+      ...this.glyphEditContextMenuItems,
       ...this.glyphSelectedContextMenuItems,
     ]) {
       if (menuItem.shortCut) {

--- a/src/fontra/views/editor/scene-controller.js
+++ b/src/fontra/views/editor/scene-controller.js
@@ -546,6 +546,11 @@ export class SceneController {
           (this.contextMenuState.componentSelection?.length === 1 ? "" : "s"),
         enabled: () => this.contextMenuState.componentSelection?.length,
         callback: () => this.decomposeSelectedComponents(),
+        shortCut: {
+          keysOrCodes: "d",
+          metaKey: true,
+          shiftKey: true,
+        },
       },
     ];
     return contextMenuItems;

--- a/src/fontra/views/editor/scene-controller.js
+++ b/src/fontra/views/editor/scene-controller.js
@@ -546,11 +546,7 @@ export class SceneController {
           (this.contextMenuState.componentSelection?.length === 1 ? "" : "s"),
         enabled: () => this.contextMenuState.componentSelection?.length,
         callback: () => this.decomposeSelectedComponents(),
-        shortCut: {
-          keysOrCodes: "d",
-          metaKey: true,
-          shiftKey: true,
-        },
+        shortCut: { keysOrCodes: "d", metaKey: true, shiftKey: true },
       },
     ];
     return contextMenuItems;

--- a/src/fontra/views/editor/scene-controller.js
+++ b/src/fontra/views/editor/scene-controller.js
@@ -495,27 +495,31 @@ export class SceneController {
     this._eventElement.dispatchEvent(event);
   }
 
-  updateContextMenuState(event) {
+  updateContextMenuState(event = null) {
     this.contextMenuState = {};
     if (!this.sceneSettings.selectedGlyph?.isEditing) {
       return;
     }
-    const { selection: clickedSelection } = this.sceneModel.selectionAtPoint(
-      this.localPoint(event),
-      this.mouseClickMargin
-    );
     let relevantSelection;
-    if (!clickedSelection.size) {
-      // Clicked on nothing, ignore selection
-      relevantSelection = clickedSelection;
-    } else {
-      if (!isSuperset(this.selection, clickedSelection)) {
-        // Clicked on something that wasn't yet selected; select it
-        this.selection = clickedSelection;
-      } else {
-        // Use the existing selection as context
-      }
+    if (!event) {
       relevantSelection = this.selection;
+    } else {
+      const { selection: clickedSelection } = this.sceneModel.selectionAtPoint(
+        this.localPoint(event),
+        this.mouseClickMargin
+      );
+      if (!clickedSelection.size) {
+        // Clicked on nothing, ignore selection
+        relevantSelection = clickedSelection;
+      } else {
+        if (!isSuperset(this.selection, clickedSelection)) {
+          // Clicked on something that wasn't yet selected; select it
+          this.selection = clickedSelection;
+        } else {
+          // Use the existing selection as context
+        }
+        relevantSelection = this.selection;
+      }
     }
     const { point: pointSelection, component: componentSelection } =
       parseSelection(relevantSelection);
@@ -544,7 +548,7 @@ export class SceneController {
         title: () =>
           "Decompose Component" +
           (this.contextMenuState.componentSelection?.length === 1 ? "" : "s"),
-        enabled: () => this.contextMenuState.componentSelection?.length,
+        enabled: () => !!this.contextMenuState?.componentSelection?.length,
         callback: () => this.decomposeSelectedComponents(),
         shortCut: { keysOrCodes: "d", metaKey: true, shiftKey: true },
       },


### PR DESCRIPTION
This fixes #1073.

This adds a shortcut (command-shift-D) for the Decompose Components context menu.

Additionally, this fixes the shortcut infrastructure to also use and respect the `enabled()` callback when a menu item is activated via a shortcut.