### PR TITLE
Bump flake8 to 7.0.0: some of flake's dependencies may have broken f-string warnings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
         args: ["--profile", "black"]
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
+    rev: 7.0.0
     hooks:
       - id: flake8
 


### PR DESCRIPTION
We suddenly got flake8 warnings like:
```
icons/export-icons-as-svg.py:15:27: E231 missing whitespace after ':'
```
But the colon was embedded in an f-string, and this was a wrong warning. Upgrading to 7.0.0 fixes this.