### PR TITLE
close dialog via backdrop click

### DIFF
--- a/src/fontra/client/web-components/modal-dialog.js
+++ b/src/fontra/client/web-components/modal-dialog.js
@@ -134,7 +134,9 @@ export class ModalDialog extends SimpleElement {
     });
     this.dialogElement = document.createElement("dialog");
     this.dialogElement.addEventListener("click", (event) => {
-      event.target.nodeName == "DIALOG" ? this._dialogDone(null) : null;
+      if (event.target.nodeName == "DIALOG") {
+        this._dialogDone(null);
+      }
     });
     this.dialogElement.appendChild(this.dialogBox);
     this.shadowRoot.append(this.dialogElement);

--- a/src/fontra/client/web-components/modal-dialog.js
+++ b/src/fontra/client/web-components/modal-dialog.js
@@ -133,6 +133,9 @@ export class ModalDialog extends SimpleElement {
       onkeydown: (event) => this._handleKeyDown(event),
     });
     this.dialogElement = document.createElement("dialog");
+    this.dialogElement.addEventListener("click", (event) => {
+      event.target.nodeName == "DIALOG" ? this._dialogDone(null) : null;
+    });
     this.dialogElement.appendChild(this.dialogBox);
     this.shadowRoot.append(this.dialogElement);
   }


### PR DESCRIPTION
No good way to close dialog elements via the backdrop, but it works nicely.

All other solutions found are doing calculations with getBoundingClientRect().

This fixes #1122.