### PR TITLE
support for searching the menu panel via typing item titles

### DIFF
--- a/src/fontra/client/web-components/menu-panel.js
+++ b/src/fontra/client/web-components/menu-panel.js
@@ -94,6 +94,8 @@ class MenuPanel extends SimpleElement {
     this.position = position;
     this.positionContainer = positionContainer;
     this.menuElement = html.div({ class: "menu-container", tabindex: 0 });
+    this.menuSearchTimer;
+    this.menuSearchText = "";
 
     // No context menu on our context menu please:
     this.menuElement.oncontextmenu = (event) => event.preventDefault();
@@ -178,6 +180,8 @@ class MenuPanel extends SimpleElement {
 
   handleKeyDown(event) {
     event.stopImmediatePropagation();
+
+    this.searchMenuItems(event.key);
     switch (event.key) {
       case "Escape":
         this.dismiss();
@@ -194,6 +198,36 @@ class MenuPanel extends SimpleElement {
           selectedItem.onclick(event);
         }
         break;
+    }
+  }
+
+  searchMenuItems(key) {
+    // Returns true only for letters, numbers & spaces
+    const isValidSearchInput = /^[a-zA-Z0-9 ]$/.test(key);
+    if (isValidSearchInput) {
+      let foundMatchingItem = false;
+      this.menuSearchText += key.toLowerCase();
+
+      for (const item of this.menuElement.children) {
+        if (item.classList.contains("enabled")) {
+          const itemText = item.textContent.toLowerCase();
+          if (itemText.startsWith(this.menuSearchText)) {
+            foundMatchingItem = true;
+            this.selectItem(item);
+            break;
+          }
+        }
+      }
+
+      // If an item matching the search text is not found, then allow the user to immediately start searching again
+      clearTimeout(this.menuSearchTimer);
+      if (foundMatchingItem) {
+        this.menuSearchTimer = setTimeout(() => {
+          this.menuSearchText = "";
+        }, 1000);
+      } else {
+        this.menuSearchText = "";
+      }
     }
   }
 


### PR DESCRIPTION
Made it so that items in the menu panel can be searched by typing a part (or the entirety) of one of the enabled menu options.

_(There seems to be some kind of error when pressing "Enter" to confirm a selected option, but that was the case in the main branch, too. I will create an issue for it and post more info there.)_