### PR TITLE
Fixed selected item "enter" key confirmation to use appropriate event

### DIFF
--- a/src/fontra/client/web-components/menu-panel.js
+++ b/src/fontra/client/web-components/menu-panel.js
@@ -191,7 +191,7 @@ class MenuPanel extends SimpleElement {
       case "Enter":
         const selectedItem = this.findSelectedItem();
         if (selectedItem) {
-          selectedItem.onclick(event);
+          selectedItem.onmouseup(event);
         }
         break;
     }


### PR DESCRIPTION
This fixes https://github.com/googlefonts/fontra/issues/1128.