### PR TITLE
Delete .menuSearchTimer

### DIFF
--- a/src/fontra/client/web-components/menu-panel.js
+++ b/src/fontra/client/web-components/menu-panel.js
@@ -94,7 +94,6 @@ class MenuPanel extends SimpleElement {
     this.position = position;
     this.positionContainer = positionContainer;
     this.menuElement = html.div({ class: "menu-container", tabindex: 0 });
-    this.menuSearchTimer;
     this.menuSearchText = "";
 
     // No context menu on our context menu please:


### PR DESCRIPTION
Looks like this line is forgotten. Initializing it with an empty value or deleting it will be better I think.