### PR TITLE
1134 menu bar left right navigate

### DIFF
--- a/src/fontra/client/web-components/menu-bar.js
+++ b/src/fontra/client/web-components/menu-bar.js
@@ -154,6 +154,7 @@ export class MenuBar extends SimpleElement {
   }
 
   navigateMenuBar(arrowKey) {
+    this.unhoverMenuItems();
     const currentSelection = this.contentElement.querySelector(".current");
     const menuItemElements = this.contentElement.children;
     const currentSelectionIndex = Array.prototype.indexOf.call(

--- a/src/fontra/client/web-components/menu-bar.js
+++ b/src/fontra/client/web-components/menu-bar.js
@@ -36,6 +36,7 @@ export class MenuBar extends SimpleElement {
     window.addEventListener("blur", this.onBlur.bind(this));
     this.contentElement.addEventListener("mouseover", this.onMouseover.bind(this));
     this.contentElement.addEventListener("click", this.onClick.bind(this));
+    this.contentElement.addEventListener("keydown", this.handleKeyDown.bind(this));
     this.showMenuWhenHover = false;
   }
 
@@ -118,6 +119,38 @@ export class MenuBar extends SimpleElement {
       },
     });
     this.contentElement.appendChild(menuPanel);
+  }
+
+  handleKeyDown(event) {
+    event.stopImmediatePropagation();
+    switch (event.key) {
+      case "ArrowLeft":
+      case "ArrowRight":
+        this.navigateMenuBar(event.key);
+        break;
+    }
+  }
+
+  navigateMenuBar(arrowKey) {
+    const currentSelection = this.contentElement.querySelector(".current");
+    const menuItemElements = this.contentElement.children;
+    const currentSelectionIndex = Array.prototype.indexOf.call(
+      menuItemElements,
+      currentSelection
+    );
+    let newSelectionIndex;
+    arrowKey == "ArrowLeft"
+      ? (newSelectionIndex = currentSelectionIndex - 1)
+      : (newSelectionIndex = currentSelectionIndex + 1);
+
+    if (menuItemElements[newSelectionIndex]?.classList.contains("menu-item")) {
+      this.clearCurrentSelection();
+      this.showMenuWhenHover = true;
+      this.showMenu(
+        this.items[newSelectionIndex].getItems(),
+        menuItemElements[newSelectionIndex]
+      );
+    }
   }
 
   render() {

--- a/src/fontra/client/web-components/menu-bar.js
+++ b/src/fontra/client/web-components/menu-bar.js
@@ -19,7 +19,7 @@ export class MenuBar extends SimpleElement {
     user-select: none;
   }
 
-  .menu-item:hover,
+  .menu-item.hovered,
   .menu-item.current {
     background: var(--editor-top-bar-link-hover);
     border-radius: 5px;
@@ -35,6 +35,10 @@ export class MenuBar extends SimpleElement {
     window.addEventListener("mousedown", this.onBlur.bind(this));
     window.addEventListener("blur", this.onBlur.bind(this));
     this.contentElement.addEventListener("mouseover", this.onMouseover.bind(this));
+    this.contentElement.addEventListener(
+      "mouseleave",
+      this.unhoverMenuItems.bind(this)
+    );
     this.contentElement.addEventListener("click", this.onClick.bind(this));
     this.contentElement.addEventListener("keydown", this.handleKeyDown.bind(this));
     this.showMenuWhenHover = false;
@@ -61,10 +65,13 @@ export class MenuBar extends SimpleElement {
   }
 
   onMouseover(event) {
+    this.hoverMenuItem(event);
+
     const currentSelection = this.contentElement.querySelector(".current");
     if (!currentSelection && !this.showMenuWhenHover) {
       return;
     }
+
     if (event.target === this.contentElement) {
       this.clearCurrentSelection();
       this.showMenuWhenHover = true;
@@ -81,6 +88,21 @@ export class MenuBar extends SimpleElement {
           break;
         }
       }
+    }
+  }
+
+  hoverMenuItem(event) {
+    this.unhoverMenuItems();
+    const hoveredItem = event.target;
+    if (!hoveredItem.classList.contains("menu-item")) {
+      return;
+    }
+    hoveredItem.classList.add("hovered");
+  }
+
+  unhoverMenuItems() {
+    for (const item of this.contentElement.children) {
+      item.classList.remove("hovered");
     }
   }
 

--- a/src/fontra/client/web-components/menu-bar.js
+++ b/src/fontra/client/web-components/menu-bar.js
@@ -138,10 +138,8 @@ export class MenuBar extends SimpleElement {
       menuItemElements,
       currentSelection
     );
-    let newSelectionIndex;
-    arrowKey == "ArrowLeft"
-      ? (newSelectionIndex = currentSelectionIndex - 1)
-      : (newSelectionIndex = currentSelectionIndex + 1);
+    const newSelectionIndex =
+      currentSelectionIndex + (arrowKey == "ArrowLeft" ? -1 : +1);
 
     if (menuItemElements[newSelectionIndex]?.classList.contains("menu-item")) {
       this.clearCurrentSelection();

--- a/src/fontra/client/web-components/menu-panel.js
+++ b/src/fontra/client/web-components/menu-panel.js
@@ -266,8 +266,6 @@ export class MenuPanel extends SimpleElement {
   }
 
   handleKeyDown(event) {
-    event.stopImmediatePropagation();
-
     this.searchMenuItems(event.key);
     switch (event.key) {
       case "Escape":

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -312,16 +312,18 @@ export class EditorController {
               title: "Zoom to fit",
               enabled: () => {
                 let viewBox = this.sceneController.getSelectionBox();
-                if (viewBox) {
-                  const size = rectSize(viewBox);
-                  if (size.width < 4 && size.height < 4) {
-                    const center = rectCenter(viewBox);
-                    viewBox = centeredRect(center.x, center.y, 10, 10);
-                  } else {
-                    viewBox = rectAddMargin(viewBox, 0.1);
-                  }
-                  return !this.canvasController.isActualViewBox(viewBox);
+                if (!viewBox) {
+                  return false;
                 }
+
+                const size = rectSize(viewBox);
+                if (size.width < 4 && size.height < 4) {
+                  const center = rectCenter(viewBox);
+                  viewBox = centeredRect(center.x, center.y, 10, 10);
+                } else {
+                  viewBox = rectAddMargin(viewBox, 0.1);
+                }
+                return !this.canvasController.isActualViewBox(viewBox);
               },
               shortCut: { keysOrCodes: "0", metaKey: true, globalOverride: true },
               callback: () => {

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -312,14 +312,16 @@ export class EditorController {
               title: "Zoom to fit",
               enabled: () => {
                 let viewBox = this.sceneController.getSelectionBox();
-                const size = rectSize(viewBox);
-                if (size.width < 4 && size.height < 4) {
-                  const center = rectCenter(viewBox);
-                  viewBox = centeredRect(center.x, center.y, 10, 10);
-                } else {
-                  viewBox = rectAddMargin(viewBox, 0.1);
+                if (viewBox) {
+                  const size = rectSize(viewBox);
+                  if (size.width < 4 && size.height < 4) {
+                    const center = rectCenter(viewBox);
+                    viewBox = centeredRect(center.x, center.y, 10, 10);
+                  } else {
+                    viewBox = rectAddMargin(viewBox, 0.1);
+                  }
+                  return !this.canvasController.isActualViewBox(viewBox);
                 }
-                return !this.canvasController.isActualViewBox(viewBox);
               },
               shortCut: { keysOrCodes: "0", metaKey: true, globalOverride: true },
               callback: () => {


### PR DESCRIPTION
Had to remove `event.stopImmediatePropagation()` from the `menu-panel.js` due to it blocking events being fired from `menu-bar.js`.
Please, tell me if this is something that might be breaking something (from my testing it was fine).

Also, I did a tiny fix for the "View" menu item since it didn't work and threw an error if nothing was typed to be shown inside the viewbox.
![error1](https://github.com/googlefonts/fontra/assets/50188474/d027249a-9ab3-43cb-b845-47110fec7068)
![ok](https://github.com/googlefonts/fontra/assets/50188474/1fad9ec6-8879-45de-83d2-933110046771)


Any feedback is greatly appreciated!

This resolves https://github.com/googlefonts/fontra/issues/1134.

The "View" menu change fixes https://github.com/googlefonts/fontra/issues/1135.