### PR TITLE
Fixes menu bar color in dark theme

### DIFF
--- a/src/fontra/views/editor/editor.css
+++ b/src/fontra/views/editor/editor.css
@@ -61,6 +61,8 @@
   --editor-mini-console-foreground-color: var(
     --editor-mini-console-foreground-color-dark
   );
+  --editor-top-bar-background-color: var(--editor-top-bar-background-color-dark);
+  --editor-top-bar-border-color: var(--editor-top-bar-border-color-dark);
   --editor-top-bar-link-hover: var(--editor-top-bar-link-hover-dark);
 }
 


### PR DESCRIPTION
This is screenshot from chrome on windows
![image](https://github.com/googlefonts/fontra/assets/80741557/2a0d8b47-8ab0-4f0a-991e-b86a8ed16668)
