### PR TITLE
changed sidebar z-index to match topbar's z-index

### DIFF
--- a/src/fontra/views/editor/editor.css
+++ b/src/fontra/views/editor/editor.css
@@ -131,7 +131,6 @@ body {
   grid-row-end: 2;
   grid-column-start: 1;
   grid-column-end: 4;
-  z-index: 200;
   height: var(--editor-top-bar-height);
   background: var(--editor-top-bar-background-color);
   border-bottom: 1px solid var(--editor-top-bar-border-color);

--- a/src/fontra/views/editor/editor.css
+++ b/src/fontra/views/editor/editor.css
@@ -222,7 +222,7 @@ body {
   position: absolute;
   display: none;
 
-  box-shadow: 0px 0px 8px #0006;
+  box-shadow: 0px 8px 8px #0006;
   top: 0;
   width: 50px; /* arbitrary > blur radius */
   height: 100%;

--- a/src/fontra/views/editor/editor.css
+++ b/src/fontra/views/editor/editor.css
@@ -144,7 +144,7 @@ body {
 }
 
 .sidebar-container {
-  z-index: 100;
+  z-index: 200;
   background-color: var(--ui-element-background-color);
   height: 100%;
   width: 0;


### PR DESCRIPTION
Looks like this is happening because the `sidebar-container` class had a z-index of 100, while the `top-bar-container` class had a 
z-index of 200.

Changing the `sidebar-container` z-index to 200 seems to fix it pretty nicely without breaking anything else.

This fixes https://github.com/googlefonts/fontra/issues/1141.