### PR TITLE
Tidy up the menu bar

### DIFF
--- a/src/fontra/client/web-components/menu-bar.js
+++ b/src/fontra/client/web-components/menu-bar.js
@@ -5,11 +5,11 @@ import { MenuPanel } from "./menu-panel.js";
 export class MenuBar extends SimpleElement {
   static styles = `
   .menu-bar {
-    padding: 0.2rem 0.5rem;
+    display: flex;
     align-items: center;
-    position: absolute;
     font-size: 1rem;
     width: 100%;
+    height:100%;
   }
 
   .menu-item {

--- a/src/fontra/client/web-components/menu-bar.js
+++ b/src/fontra/client/web-components/menu-bar.js
@@ -8,8 +8,8 @@ export class MenuBar extends SimpleElement {
     display: flex;
     align-items: center;
     font-size: 1rem;
-    width: 100%;
     height:100%;
+    padding: 0 0.5rem;
   }
 
   .menu-item {

--- a/src/fontra/client/web-components/menu-bar.js
+++ b/src/fontra/client/web-components/menu-bar.js
@@ -14,7 +14,6 @@ export class MenuBar extends SimpleElement {
 
   .menu-item {
     padding: 0.4rem 0.6rem;
-    display: inline-block;
     cursor: default;
     user-select: none;
   }

--- a/src/fontra/views/editor/editor.css
+++ b/src/fontra/views/editor/editor.css
@@ -129,7 +129,6 @@ body {
 .top-bar-container {
   grid-column: 1 / 4;
   grid-row: 1;
-  padding: 0 0.5rem;
   z-index: 200;
   height: var(--editor-top-bar-height);
   background: var(--editor-top-bar-background-color);

--- a/src/fontra/views/editor/editor.css
+++ b/src/fontra/views/editor/editor.css
@@ -127,10 +127,9 @@ body {
 }
 
 .top-bar-container {
-  grid-row-start: 1;
-  grid-row-end: 2;
-  grid-column-start: 1;
-  grid-column-end: 4;
+  grid-column: 1 / 4;
+  grid-row: 1;
+  padding: 0 0.5rem;
   z-index: 200;
   height: var(--editor-top-bar-height);
   background: var(--editor-top-bar-background-color);


### PR DESCRIPTION
Now, menu bar height matches with container and the width doesn't overflow.
fix #1177 