### PR TITLE
Simplify external change mechanism for backends

### DIFF
--- a/src/fontra/core/fonthandler.py
+++ b/src/fontra/core/fonthandler.py
@@ -76,8 +76,7 @@ class FontHandler:
             await self.finishWriting()  # shield for cancel?
             self._processWritesTask.cancel()
 
-    async def processExternalChanges(self, change, reloadPattern) -> None:
-        assert change is None
+    async def processExternalChanges(self, reloadPattern) -> None:
         if "glyphMap" in reloadPattern:
             del reloadPattern["glyphMap"]
             glyphMapChange = computeGlyphMapChange(


### PR DESCRIPTION
Remove the possibility for backends to communicate external changes in the form of a change object, and only keep the "reload pattern" mechanism. This makes life easier for backends, and removes their dependency on the "change" infrastructure.

This is a step towards breaking out the backend library code from the fontra app.