### PR TITLE
Respond to external changes to .designspace files

### DIFF
--- a/src/fontra/backends/designspace.py
+++ b/src/fontra/backends/designspace.py
@@ -602,10 +602,10 @@ class DesignspaceBackend:
     ) -> None:
         if self.fileWatcher is None:
             self.fileWatcher = FileWatcher(self._fileWatcherCallback)
-            self.fileWatcher.setPaths(self._getFilesToWatch())
+            self.fileWatcher.setPaths(self._getPathsToWatch())
         self.fileWatcherCallbacks.append(callback)
 
-    def _getFilesToWatch(self):
+    def _getPathsToWatch(self):
         paths = sorted(set(self.ufoLayers.iterAttrs("path")))
         if self.dsDoc.path:
             paths.append(self.dsDoc.path)

--- a/src/fontra/backends/designspace.py
+++ b/src/fontra/backends/designspace.py
@@ -86,8 +86,10 @@ class DesignspaceBackend:
 
     def __init__(self, dsDoc: DesignSpaceDocument) -> None:
         self._initialize(dsDoc)
+        self.fileWatcher: FileWatcher | None = None
+        self.fileWatcherCallbacks: list[Callable[[Any], Awaitable[None]]] = []
 
-    def _initialize(self, dsDoc: DesignSpaceDocument, initFileWatcher=True) -> None:
+    def _initialize(self, dsDoc: DesignSpaceDocument) -> None:
         self.dsDoc = dsDoc
         self.ufoManager = UFOManager()
         self.updateAxisInfo()
@@ -95,12 +97,9 @@ class DesignspaceBackend:
         self.buildGlyphFileNameMapping()
         self.glyphMap = getGlyphMapFromGlyphSet(self.defaultDSSource.layer.glyphSet)
         self.savedGlyphModificationTimes: dict[str, set] = {}
-        if initFileWatcher:
-            self.fileWatcher: FileWatcher | None = None
-            self.fileWatcherCallbacks: list[Callable[[Any], Awaitable[None]]] = []
 
     def _reloadDesignSpaceFromFile(self):
-        self._initialize(DesignSpaceDocument.fromfile(self.dsDoc.path), False)
+        self._initialize(DesignSpaceDocument.fromfile(self.dsDoc.path))
 
     def updateAxisInfo(self):
         self.dsDoc.findDefault()

--- a/src/fontra/backends/designspace.py
+++ b/src/fontra/backends/designspace.py
@@ -602,14 +602,18 @@ class DesignspaceBackend:
     ) -> None:
         if self.fileWatcher is None:
             self.fileWatcher = FileWatcher(self._fileWatcherCallback)
-            self.fileWatcher.setPaths(self._getPathsToWatch())
+            self._updatePathsToWatch()
         self.fileWatcherCallbacks.append(callback)
 
-    def _getPathsToWatch(self):
+    def _updatePathsToWatch(self):
+        if self.fileWatcher is None:
+            return
+
         paths = sorted(set(self.ufoLayers.iterAttrs("path")))
         if self.dsDoc.path:
             paths.append(self.dsDoc.path)
-        return paths
+
+        self.fileWatcher.setPaths(paths)
 
     async def _fileWatcherCallback(self, changes: set[tuple[Change, str]]) -> None:
         reloadPattern = await self.processExternalChanges(changes)

--- a/src/fontra/backends/designspace.py
+++ b/src/fontra/backends/designspace.py
@@ -85,9 +85,9 @@ class DesignspaceBackend:
         return cls(dsDoc)
 
     def __init__(self, dsDoc: DesignSpaceDocument) -> None:
-        self._initialize(dsDoc)
         self.fileWatcher: FileWatcher | None = None
         self.fileWatcherCallbacks: list[Callable[[Any], Awaitable[None]]] = []
+        self._initialize(dsDoc)
 
     def _initialize(self, dsDoc: DesignSpaceDocument) -> None:
         self.dsDoc = dsDoc
@@ -174,6 +174,8 @@ class DesignspaceBackend:
                     isDefault=source == self.dsDoc.default,
                 )
             )
+
+        self._updatePathsToWatch()
 
     def buildGlyphFileNameMapping(self):
         glifFileNames = {}
@@ -478,6 +480,7 @@ class DesignspaceBackend:
                 name=ufoLayerName,
             )
             self.ufoLayers.append(ufoLayer)
+            self._updatePathsToWatch()
         else:
             # Create a new layer in the appropriate existing UFO
             atPole = {**self.defaultLocation, **atPole}

--- a/src/fontra/backends/designspace.py
+++ b/src/fontra/backends/designspace.py
@@ -606,7 +606,10 @@ class DesignspaceBackend:
         self.fileWatcherCallbacks.append(callback)
 
     def _getFilesToWatch(self):
-        return [self.dsDoc.path] + sorted(set(self.ufoLayers.iterAttrs("path")))
+        paths = sorted(set(self.ufoLayers.iterAttrs("path")))
+        if self.dsDoc.path:
+            paths.append(self.dsDoc.path)
+        return paths
 
     async def _fileWatcherCallback(self, changes: set[tuple[Change, str]]) -> None:
         reloadPattern = await self.processExternalChanges(changes)

--- a/src/fontra/backends/designspace.py
+++ b/src/fontra/backends/designspace.py
@@ -661,10 +661,9 @@ class DesignspaceBackend:
         return reloadPattern
 
     async def _analyzeExternalChanges(self, changes) -> SimpleNamespace | None:
-        for change, path in sorted(changes):
-            _, fileSuffix = os.path.splitext(path)
-            if fileSuffix == ".designspace":
-                return None
+        if any(os.path.splitext(path)[1] == ".designspace" for _, path in changes):
+            # .designspace changed, reload all the things
+            return None
 
         changedItems = SimpleNamespace(
             changedGlyphs=set(),

--- a/src/fontra/client/core/lru-cache.js
+++ b/src/fontra/client/core/lru-cache.js
@@ -9,7 +9,7 @@ export class LRUCache {
 
   clear() {
     this.map.clear();
-    // this are the boundaries for the double linked list
+    // these are the boundaries for the double linked list
     this.head = {};
     this.tail = {};
 

--- a/src/fontra/client/core/lru-cache.js
+++ b/src/fontra/client/core/lru-cache.js
@@ -8,6 +8,7 @@ export class LRUCache {
   }
 
   clear() {
+    this.map.clear();
     // this are the boundaries for the double linked list
     this.head = {};
     this.tail = {};

--- a/src/fontra/core/fonthandler.py
+++ b/src/fontra/core/fonthandler.py
@@ -465,7 +465,7 @@ class FontHandler:
 
         logger.info(
             f"broadcasting external changes to {len(connections)} "
-            f"clients: {reloadPattern}"
+            f"clients: {reloadPattern if reloadPattern is not None else 'reload everything'}"
         )
 
         await asyncio.gather(

--- a/src/fontra/core/fonthandler.py
+++ b/src/fontra/core/fonthandler.py
@@ -438,6 +438,7 @@ class FontHandler:
 
     async def reloadData(self, reloadPattern):
         if reloadPattern is None:
+            # A reloadPattern being None means: reload everything
             self.localData.clear()
         else:
             # Drop local data to ensure it gets reloaded from the backend

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -1890,6 +1890,14 @@ export class EditorController {
   }
 
   async reloadData(reloadPattern) {
+    if (!reloadPattern) {
+      // A reloadPattern of undefined or null means: reload all the things
+      await this.fontController.reloadEverything();
+      await this.sceneModel.updateScene();
+      this.canvasController.requestUpdate();
+      return;
+    }
+
     for (const rootKey of Object.keys(reloadPattern)) {
       if (rootKey == "glyphs") {
         const glyphNames = Object.keys(reloadPattern["glyphs"] || {});

--- a/src/fontra/views/fontinfo/fontinfo.js
+++ b/src/fontra/views/fontinfo/fontinfo.js
@@ -90,9 +90,11 @@ export class FontInfoController {
   }
 
   async reloadData(reloadPattern) {
-    if (!reloadPattern || "axes" in reloadPattern) {
-      this.fontController.reloadEverything();
-    }
+    // We have currently no way to refine update behavior based on the
+    // reloadPattern.
+    //
+    // reloadEverything() will trigger the appropriate listeners
+    this.fontController.reloadEverything();
   }
 
   handleRemoteClose(event) {

--- a/src/fontra/views/fontinfo/fontinfo.js
+++ b/src/fontra/views/fontinfo/fontinfo.js
@@ -90,7 +90,9 @@ export class FontInfoController {
   }
 
   async reloadData(reloadPattern) {
-    // if ("axes" in reloadPattern) -> reload axes panel
+    if (!reloadPattern || "axes" in reloadPattern) {
+      this.fontController.reloadEverything();
+    }
   }
 
   handleRemoteClose(event) {


### PR DESCRIPTION
This involved adding a special reload pattern (None/null) to indicate "reload all the things".

This also makes sure the list of paths to watch is kept up to date when adding new UFO sources.