### PR TITLE
Implement "find glyphs that use glyph" for designspace backend

### DIFF
--- a/src/fontra/backends/designspace.py
+++ b/src/fontra/backends/designspace.py
@@ -40,9 +40,9 @@ from ..core.classes import (
 from ..core.glyphdependencies import GlyphDependencies
 from ..core.path import PackedPathPointPen
 from ..core.protocols import WritableFontBackend
+from ..core.subprocess import runInSubProcess
 from .filewatcher import Change, FileWatcher
 from .ufo_utils import extractGlyphNameAndCodePoints
-from .utils import runInProcess
 
 logger = logging.getLogger(__name__)
 
@@ -1179,7 +1179,7 @@ class ComponentsOnlyPointPen(PackedPathPointPen):
 async def extractGlyphDependenciesFromUFO(
     ufoPath: str, layerName: str
 ) -> GlyphDependencies:
-    componentInfo = await runInProcess(
+    componentInfo = await runInSubProcess(
         partial(_extractComponentInfoFromUFO, ufoPath, layerName)
     )
     dependencies = GlyphDependencies()

--- a/src/fontra/backends/designspace.py
+++ b/src/fontra/backends/designspace.py
@@ -42,6 +42,7 @@ from ..core.path import PackedPathPointPen
 from ..core.protocols import WritableFontBackend
 from .filewatcher import Change, FileWatcher
 from .ufo_utils import extractGlyphNameAndCodePoints
+from .utils import runInProcess
 
 logger = logging.getLogger(__name__)
 
@@ -1198,14 +1199,6 @@ def _extractComponentInfoFromUFO(ufoPath: str, layerName: str) -> dict[str, set[
         if glyph.components:
             componentInfo[glyphName] = {compo.name for compo in glyph.components}
     return componentInfo
-
-
-async def runInProcess(func):
-    import concurrent.futures
-
-    loop = asyncio.get_running_loop()
-    with concurrent.futures.ProcessPoolExecutor() as pool:
-        return await loop.run_in_executor(pool, func)
 
 
 def componentNamesFromGlyph(glyph):

--- a/src/fontra/backends/designspace.py
+++ b/src/fontra/backends/designspace.py
@@ -118,6 +118,9 @@ class DesignspaceBackend:
             )
         return self._glyphDependenciesTask
 
+    async def getGlyphsUsedBy(self, glyphName):
+        return sorted((await self.glyphDependencies).usedBy.get(glyphName, []))
+
     def _reloadDesignSpaceFromFile(self):
         self._initialize(DesignSpaceDocument.fromfile(self.dsDoc.path))
 

--- a/src/fontra/backends/designspace.py
+++ b/src/fontra/backends/designspace.py
@@ -591,6 +591,8 @@ class DesignspaceBackend:
                 glyphSet.writeContents()
         del self.glyphMap[glyphName]
         self.savedGlyphModificationTimes[glyphName] = None
+        if self._glyphDependencies is not None:
+            self._glyphDependencies.update(glyphName, ())
 
     async def getGlobalAxes(self) -> list[GlobalAxis | GlobalDiscreteAxis]:
         return self.axes

--- a/src/fontra/backends/designspace.py
+++ b/src/fontra/backends/designspace.py
@@ -127,7 +127,7 @@ class DesignspaceBackend:
 
         return self._glyphDependenciesTask
 
-    async def getGlyphsUsedBy(self, glyphName):
+    async def findGlyphsThatUseGlyph(self, glyphName):
         return sorted((await self.glyphDependencies).usedBy.get(glyphName, []))
 
     def _reloadDesignSpaceFromFile(self):

--- a/src/fontra/backends/utils.py
+++ b/src/fontra/backends/utils.py
@@ -1,0 +1,23 @@
+import asyncio
+import atexit
+import concurrent.futures
+
+_processPool = None
+
+
+async def runInProcess(func):
+    global _processPool
+
+    if _processPool is None:
+        _processPool = concurrent.futures.ProcessPoolExecutor()
+
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(_processPool, func)
+
+
+def _shutdownProcessPool():
+    if _processPool is not None:
+        _processPool.shutdown()
+
+
+atexit.register(_shutdownProcessPool)

--- a/src/fontra/client/core/font-controller.js
+++ b/src/fontra/client/core/font-controller.js
@@ -571,9 +571,9 @@ export class FontController {
     }
   }
 
-  async getGlyphsUsedBy(glyphName) {
+  async findGlyphsThatUseGlyph(glyphName) {
     // Ask the backend about which glyphs use glyph `glyphName` as a component, non-recursively.
-    return await this.font.getGlyphsUsedBy(glyphName);
+    return await this.font.findGlyphsThatUseGlyph(glyphName);
   }
 
   _purgeGlyphCache(glyphName) {

--- a/src/fontra/core/fonthandler.py
+++ b/src/fontra/core/fonthandler.py
@@ -155,7 +155,9 @@ class FontHandler:
     @remoteMethod
     async def getBackEndInfo(self, *, connection=None) -> dict:
         features = {}
-        for key, methodName in [("glyphs-used-by", "getGlyphsUsedBy")]:
+        for key, methodName in [
+            ("find-glyphs-that-use-glyph", "findGlyphsThatUseGlyph")
+        ]:
             features[key] = hasattr(self.backend, methodName)
         return dict(name=self.backend.__class__.__name__, features=features)
 
@@ -237,9 +239,9 @@ class FontHandler:
         self.clientData[connection.clientUUID][key] = value
 
     @remoteMethod
-    async def getGlyphsUsedBy(self, glyphName: str, *, connection) -> list[str]:
-        if hasattr(self.backend, "getGlyphsUsedBy"):
-            return await self.backend.getGlyphsUsedBy(glyphName)
+    async def findGlyphsThatUseGlyph(self, glyphName: str, *, connection) -> list[str]:
+        if hasattr(self.backend, "findGlyphsThatUseGlyph"):
+            return await self.backend.findGlyphsThatUseGlyph(glyphName)
         return []
 
     @remoteMethod

--- a/src/fontra/core/fonthandler.py
+++ b/src/fontra/core/fonthandler.py
@@ -52,6 +52,8 @@ class FontHandler:
         self.localData = LRUCache()
         self._dataScheduledForWriting = {}
         self.glyphMap = {}
+        if hasattr(self.backend, "startOptionalBackgroundTasks"):
+            self.backend.startOptionalBackgroundTasks()
 
     @cached_property
     def writableBackend(self) -> WritableFontBackend | None:

--- a/src/fontra/core/glyphdependencies.py
+++ b/src/fontra/core/glyphdependencies.py
@@ -1,0 +1,29 @@
+from dataclasses import dataclass, field
+from typing import Sequence
+
+
+@dataclass(kw_only=True)
+class GlyphDependencies:
+    usedBy: dict[str, set[str]] = field(init=False, default_factory=dict)
+    madeOf: dict[str, set[str]] = field(init=False, default_factory=dict)
+
+    def update(self, glyphName: str, componentNames: Sequence[str]) -> None:
+        # Zap previous used-by data for this glyph, if any
+        for componentName in self.madeOf.get(glyphName, ()):
+            if componentName in self.usedBy:
+                self.usedBy[componentName].discard(glyphName)
+                if not self.usedBy[componentName]:
+                    del self.usedBy[componentName]
+
+        # Update made-of
+        if componentNames:
+            self.madeOf[glyphName] = set(componentNames)
+        else:
+            # Discard
+            self.madeOf.pop(glyphName, None)
+
+        # Update used-by
+        for componentName in componentNames:
+            if componentName not in self.usedBy:
+                self.usedBy[componentName] = set()
+            self.usedBy[componentName].add(glyphName)

--- a/src/fontra/core/server.py
+++ b/src/fontra/core/server.py
@@ -27,6 +27,7 @@ from aiohttp import WSCloseCode, web
 from .protocols import ProjectManager
 from .remote import RemoteObjectConnection, RemoteObjectConnectionException
 from .serverutils import apiFunctions
+from .subprocess import shutdownProcessPool
 
 logger = logging.getLogger(__name__)
 
@@ -97,6 +98,7 @@ class FontraServer:
             self.httpApp.on_startup.append(self.launchWebBrowserCallback)
         self.httpApp.on_shutdown.append(self.closeActiveWebsockets)
         self.httpApp.on_shutdown.append(self.closeProjectManager)
+        self.httpApp.on_shutdown.append(self.shutdownProcessPool)
         self._activeWebsockets: set = set()
 
     def run(self, showLaunchBanner: bool = True) -> None:
@@ -137,6 +139,9 @@ class FontraServer:
 
     async def closeProjectManager(self, httpApp: web.Application) -> None:
         await self.projectManager.aclose()
+
+    async def shutdownProcessPool(self, httpApp: web.Application) -> None:
+        shutdownProcessPool()
 
     async def websocketHandler(self, request: web.Request) -> web.WebSocketResponse:
         path = "/" + request.match_info["path"]

--- a/src/fontra/core/subprocess.py
+++ b/src/fontra/core/subprocess.py
@@ -5,7 +5,7 @@ import concurrent.futures
 _processPool = None
 
 
-async def runInProcess(func):
+async def runInSubProcess(func):
     global _processPool
 
     if _processPool is None:
@@ -15,9 +15,11 @@ async def runInProcess(func):
     return await loop.run_in_executor(_processPool, func)
 
 
-def _shutdownProcessPool():
+def shutdownProcessPool():
+    global _processPool
     if _processPool is not None:
-        _processPool.shutdown()
+        _processPool.shutdown(wait=False)
+        _processPool = None
 
 
-atexit.register(_shutdownProcessPool)
+atexit.register(shutdownProcessPool)

--- a/src/fontra/core/subprocess.py
+++ b/src/fontra/core/subprocess.py
@@ -17,6 +17,7 @@ async def runInSubProcess(func):
 
 def shutdownProcessPool():
     global _processPool
+
     if _processPool is not None:
         _processPool.shutdown(wait=False)
         _processPool = None

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -958,8 +958,9 @@ export class EditorController {
 
     this.glyphSelectedContextMenuItems.push({
       title: () => `Find glyphs that use '${this.sceneSettings.selectedGlyphName}'`,
-      enabled: () => this.fontController.backendInfo.features["glyphs-used-by"],
-      callback: () => this.doFindGlyphsUsedBy(),
+      enabled: () =>
+        this.fontController.backendInfo.features["find-glyphs-that-use-glyph"],
+      callback: () => this.doFindGlyphsThatUseGlyph(),
     });
   }
 
@@ -1740,10 +1741,12 @@ export class EditorController {
     this.sceneSettings.selectedSourceIndex = newSourceIndex;
   }
 
-  async doFindGlyphsUsedBy() {
+  async doFindGlyphsThatUseGlyph() {
     const glyphName = this.sceneSettings.selectedGlyphName;
 
-    const usedBy = await loaderSpinner(this.fontController.getGlyphsUsedBy(glyphName));
+    const usedBy = await loaderSpinner(
+      this.fontController.findGlyphsThatUseGlyph(glyphName)
+    );
 
     if (!usedBy.length) {
       await message(

--- a/test-py/test_backends_designspace.py
+++ b/test-py/test_backends_designspace.py
@@ -1,5 +1,6 @@
 import pathlib
 import shutil
+from contextlib import aclosing
 from dataclasses import asdict
 
 import pytest
@@ -323,6 +324,28 @@ async def test_deleteGlyphRaisesKeyError(writableTestFont):
     glyphName = "A.doesnotexist"
     with pytest.raises(KeyError, match="Glyph 'A.doesnotexist' does not exist"):
         await writableTestFont.deleteGlyph(glyphName)
+
+
+async def test_getGlyphsUsedBy(writableTestFont):
+    async with aclosing(writableTestFont):
+        assert [
+            "Aacute",
+            "Adieresis",
+            "varcotest1",
+        ] == await writableTestFont.getGlyphsUsedBy("A")
+        await writableTestFont.deleteGlyph("Adieresis")
+        assert [
+            "Aacute",
+            "varcotest1",
+        ] == await writableTestFont.getGlyphsUsedBy("A")
+        glyph = await writableTestFont.getGlyph("Aacute")
+        # glyph.layers[glyph.sources[0].layerName].glyph.components.append(Component(name="A"))
+        await writableTestFont.putGlyph("B", glyph, [ord("B")])
+        assert [
+            "Aacute",
+            "B",
+            "varcotest1",
+        ] == await writableTestFont.getGlyphsUsedBy("A")
 
 
 def fileNamesFromDir(path):

--- a/test-py/test_backends_designspace.py
+++ b/test-py/test_backends_designspace.py
@@ -339,7 +339,6 @@ async def test_getGlyphsUsedBy(writableTestFont):
             "varcotest1",
         ] == await writableTestFont.getGlyphsUsedBy("A")
         glyph = await writableTestFont.getGlyph("Aacute")
-        # glyph.layers[glyph.sources[0].layerName].glyph.components.append(Component(name="A"))
         await writableTestFont.putGlyph("B", glyph, [ord("B")])
         assert [
             "Aacute",

--- a/test-py/test_backends_designspace.py
+++ b/test-py/test_backends_designspace.py
@@ -326,25 +326,25 @@ async def test_deleteGlyphRaisesKeyError(writableTestFont):
         await writableTestFont.deleteGlyph(glyphName)
 
 
-async def test_getGlyphsUsedBy(writableTestFont):
+async def test_findGlyphsThatUseGlyph(writableTestFont):
     async with aclosing(writableTestFont):
         assert [
             "Aacute",
             "Adieresis",
             "varcotest1",
-        ] == await writableTestFont.getGlyphsUsedBy("A")
+        ] == await writableTestFont.findGlyphsThatUseGlyph("A")
         await writableTestFont.deleteGlyph("Adieresis")
         assert [
             "Aacute",
             "varcotest1",
-        ] == await writableTestFont.getGlyphsUsedBy("A")
+        ] == await writableTestFont.findGlyphsThatUseGlyph("A")
         glyph = await writableTestFont.getGlyph("Aacute")
         await writableTestFont.putGlyph("B", glyph, [ord("B")])
         assert [
             "Aacute",
             "B",
             "varcotest1",
-        ] == await writableTestFont.getGlyphsUsedBy("A")
+        ] == await writableTestFont.findGlyphsThatUseGlyph("A")
 
 
 def fileNamesFromDir(path):

--- a/test-py/test_glyphdependencies.py
+++ b/test-py/test_glyphdependencies.py
@@ -1,0 +1,36 @@
+import pytest
+
+from fontra.core.glyphdependencies import GlyphDependencies
+
+
+@pytest.mark.parametrize(
+    "updates, expectedUsedBy, expectedMadeOf",
+    [
+        ([], {}, {}),
+        (
+            [("Adieresis", ["A", "dieresis"])],
+            {"A": {"Adieresis"}, "dieresis": {"Adieresis"}},
+            {"Adieresis": {"A", "dieresis"}},
+        ),
+        (
+            [
+                ("Adieresis", ["A", "dieresis"]),
+                ("Agrave", ["A", "grave"]),
+                ("Adieresis", ["A", "foo"]),
+            ],
+            {"A": {"Adieresis", "Agrave"}, "foo": {"Adieresis"}, "grave": {"Agrave"}},
+            {"Adieresis": {"A", "foo"}, "Agrave": {"A", "grave"}},
+        ),
+        (
+            [("Adieresis", ["A", "dieresis"]), ("Adieresis", [])],
+            {},
+            {},
+        ),
+    ],
+)
+def test_glyphdependencies(updates, expectedUsedBy, expectedMadeOf):
+    deps = GlyphDependencies()
+    for glyphName, componentNames in updates:
+        deps.update(glyphName, componentNames)
+    assert expectedUsedBy == deps.usedBy
+    assert expectedMadeOf == deps.madeOf


### PR DESCRIPTION
- add fontra.backends.utils module for small functions that have no good other place
- add fontra.backends.glyphdependencies helper module to keep track of glyph dependencies
- rename `getGlyphsUsedBy()` to `findGlyphsThatUseGlyph()` (less ambiguous)
- add optional `startOptionalBackgroundTasks()` method to give backends a chance do some indexing without blocking regular loading