### PR TITLE
Add support for global sources and font info

### DIFF
--- a/src/fontra/backends/copy.py
+++ b/src/fontra/backends/copy.py
@@ -20,6 +20,7 @@ async def copyFont(
     progressInterval=0,
 ) -> None:
     await destBackend.putGlobalAxes(await sourceBackend.getGlobalAxes())
+    await destBackend.putSources(await sourceBackend.getSources())
     await destBackend.putCustomData(await sourceBackend.getCustomData())
     glyphMap = await sourceBackend.getGlyphMap()
     glyphNamesInFont = set(glyphMap)

--- a/src/fontra/backends/copy.py
+++ b/src/fontra/backends/copy.py
@@ -19,6 +19,7 @@ async def copyFont(
     numTasks=1,
     progressInterval=0,
 ) -> None:
+    await destBackend.putFontInfo(await sourceBackend.getFontInfo())
     await destBackend.putGlobalAxes(await sourceBackend.getGlobalAxes())
     await destBackend.putSources(await sourceBackend.getSources())
     await destBackend.putCustomData(await sourceBackend.getCustomData())

--- a/src/fontra/backends/designspace.py
+++ b/src/fontra/backends/designspace.py
@@ -938,7 +938,7 @@ def packAxisLabels(valueLabels):
     ]
 
 
-def unpackDSSource(dsSource, unitsPerEm):
+def unpackDSSource(dsSource: DSSource, unitsPerEm: int) -> GlobalSource:
     fontInfo = UFOFontInfo()
     dsSource.layer.reader.readInfo(fontInfo)
     verticalMetrics = {}

--- a/src/fontra/backends/designspace.py
+++ b/src/fontra/backends/designspace.py
@@ -63,10 +63,8 @@ defaultUFOInfoAttrs = {
     "descender": -250,
     "xHeight": 500,
     "capHeight": 750,
-    "familyName": None,
-    "copyright": None,
-    "year": None,
 }
+
 
 verticalMetricsDefaults = {
     "descender": -0.25,
@@ -534,7 +532,7 @@ class DesignspaceBackend:
             assert not os.path.exists(ufoPath)
             reader = manager.getReader(ufoPath)  # this creates the UFO
             info = UFOFontInfo()
-            for infoAttr in defaultUFOInfoAttrs:
+            for _, infoAttr in fontInfoNameMapping:
                 value = getattr(self.defaultFontInfo, infoAttr, None)
                 if value is not None:
                     setattr(info, infoAttr, value)

--- a/src/fontra/backends/designspace.py
+++ b/src/fontra/backends/designspace.py
@@ -639,6 +639,9 @@ class DesignspaceBackend:
             for dsSource in self.dsSources
         }
 
+    async def putSources(self, sources: dict[str, GlobalSource]) -> None:
+        pass
+
     async def getUnitsPerEm(self) -> int:
         return self.defaultFontInfo.unitsPerEm
 
@@ -930,6 +933,10 @@ class UFOBackend(DesignspaceBackend):
     async def putGlobalAxes(self, axes):
         if axes:
             raise ValueError("The single-UFO backend does not support variation axes")
+
+    async def putSources(self, sources: dict[str, GlobalSource]) -> None:
+        if len(sources) > 1:
+            raise ValueError("The single-UFO backend does not support multiple sources")
 
 
 def createDSDocFromUFOPath(ufoPath, styleName):

--- a/src/fontra/backends/designspace.py
+++ b/src/fontra/backends/designspace.py
@@ -678,6 +678,8 @@ class DesignspaceBackend:
         }
 
     async def putSources(self, sources: dict[str, GlobalSource]) -> None:
+        # TODO: this may require rewriting UFOs and UFO layers
+        # Also: what to do if a source gets deleted?
         pass
 
     async def getUnitsPerEm(self) -> int:

--- a/src/fontra/backends/designspace.py
+++ b/src/fontra/backends/designspace.py
@@ -30,6 +30,7 @@ from fontTools.ufoLib.glifLib import GlyphSet
 from ..core.classes import (
     AxisValueLabel,
     Component,
+    FontInfo,
     GlobalAxis,
     GlobalDiscreteAxis,
     GlobalMetric,
@@ -74,6 +75,25 @@ verticalMetricsDefaults = {
     "ascender": 0.75,
     "italicAngle": 0,
 }
+
+
+fontInfoNameMapping = [
+    # (Fontra, UFO)
+    ("familyName", "familyName"),
+    ("versionMajor", "versionMajor"),
+    ("versionMinor", "versionMinor"),
+    ("copyright", "copyright"),
+    ("trademark", "trademark"),
+    ("description", "openTypeNameDescription"),
+    ("sampleText", "openTypeNameSampleText"),
+    ("designer", "openTypeNameDesigner"),
+    ("designerURL", "openTypeNameDesignerURL"),
+    ("manufacturer", "openTypeNameManufacturer"),
+    ("manufacturerURL", "openTypeNameManufacturerURL"),
+    ("licenseDescription", "openTypeNameLicense"),
+    ("licenseInfoURL", "openTypeNameLicenseURL"),
+    ("vendorID", "vendorID"),
+]
 
 
 class DesignspaceBackend:
@@ -607,6 +627,12 @@ class DesignspaceBackend:
         self.savedGlyphModificationTimes[glyphName] = None
         if self._glyphDependencies is not None:
             self._glyphDependencies.update(glyphName, ())
+
+    async def getFontInfo(self) -> FontInfo:
+        return FontInfo()
+
+    async def putFontInfo(self, fontInfo: FontInfo):
+        pass
 
     async def getGlobalAxes(self) -> list[GlobalAxis | GlobalDiscreteAxis]:
         return self.axes

--- a/src/fontra/backends/designspace.py
+++ b/src/fontra/backends/designspace.py
@@ -5,6 +5,7 @@ import logging
 import os
 import pathlib
 import shutil
+import uuid
 from collections import defaultdict
 from copy import deepcopy
 from dataclasses import asdict, dataclass
@@ -212,6 +213,7 @@ class DesignspaceBackend:
 
             self.dsSources.append(
                 DSSource(
+                    uuid=str(uuid.uuid4()),
                     name=sourceName,
                     layer=sourceLayer,
                     location={**self.defaultLocation, **source.location},
@@ -552,6 +554,7 @@ class DesignspaceBackend:
         self._writeDesignSpaceDocument()
 
         dsSource = DSSource(
+            uuid=str(uuid.uuid4()),
             name=source.name,
             layer=ufoLayer,
             location=globalLocation,
@@ -629,9 +632,12 @@ class DesignspaceBackend:
         self.updateAxisInfo()
         self.loadUFOLayers()
 
-    async def getSources(self) -> list[GlobalSource]:
+    async def getSources(self) -> dict[str, GlobalSource]:
         unitsPerEm = await self.getUnitsPerEm()
-        return [unpackDSSource(dsSource, unitsPerEm) for dsSource in self.dsSources]
+        return {
+            dsSource.uuid: unpackDSSource(dsSource, unitsPerEm)
+            for dsSource in self.dsSources
+        }
 
     async def getUnitsPerEm(self) -> int:
         return self.defaultFontInfo.unitsPerEm
@@ -886,6 +892,7 @@ def packAxisLabels(valueLabels):
         for label in valueLabels
     ]
 
+
 def unpackDSSource(dsSource, unitsPerEm):
     fontInfo = UFOFontInfo()
     dsSource.layer.reader.readInfo(fontInfo)
@@ -966,6 +973,7 @@ class UFOManager:
 
 @dataclass(kw_only=True, frozen=True)
 class DSSource:
+    uuid: str
     name: str
     layer: UFOLayer
     location: dict[str, float]

--- a/src/fontra/backends/designspace.py
+++ b/src/fontra/backends/designspace.py
@@ -31,6 +31,7 @@ from ..core.classes import (
     Component,
     GlobalAxis,
     GlobalDiscreteAxis,
+    GlobalSource,
     Layer,
     LocalAxis,
     Source,
@@ -618,6 +619,9 @@ class DesignspaceBackend:
         self._writeDesignSpaceDocument()
         self.updateAxisInfo()
         self.loadUFOLayers()
+
+    async def getSources(self) -> list[GlobalSource]:
+        return []
 
     async def getUnitsPerEm(self) -> int:
         return self.defaultFontInfo.unitsPerEm

--- a/src/fontra/backends/designspace.py
+++ b/src/fontra/backends/designspace.py
@@ -216,6 +216,8 @@ class DesignspaceBackend:
 
         makeUniqueSourceName = uniqueNameMaker()
         for source in self.dsDoc.sources:
+            if not hasattr(source, "fontraUUID"):
+                source.fontraUUID = str(uuid.uuid4())
             reader = manager.getReader(source.path)
             defaultLayerName = reader.getDefaultLayerName()
             ufoLayerName = source.layerName or defaultLayerName
@@ -231,7 +233,7 @@ class DesignspaceBackend:
 
             self.dsSources.append(
                 DSSource(
-                    uuid=str(uuid.uuid4()),
+                    uuid=source.fontraUUID,
                     name=sourceName,
                     layer=sourceLayer,
                     location={**self.defaultLocation, **source.location},
@@ -563,16 +565,17 @@ class DesignspaceBackend:
             )
             ufoLayerName = ufoLayer.name
 
-        self.dsDoc.addSourceDescriptor(
+        dsDocSource = self.dsDoc.addSourceDescriptor(
             styleName=source.name,
             location=globalLocation,
             path=ufoPath,
             layerName=ufoLayerName,
         )
+        dsDocSource.fontraUUID = str(uuid.uuid4())
         self._writeDesignSpaceDocument()
 
         dsSource = DSSource(
-            uuid=str(uuid.uuid4()),
+            uuid=dsDocSource.fontraUUID,
             name=source.name,
             layer=ufoLayer,
             location=globalLocation,

--- a/src/fontra/backends/designspace.py
+++ b/src/fontra/backends/designspace.py
@@ -627,7 +627,13 @@ class DesignspaceBackend:
             self._glyphDependencies.update(glyphName, ())
 
     async def getFontInfo(self) -> FontInfo:
-        return FontInfo()
+        ufoInfo = self.defaultFontInfo
+        info = {}
+        for fontraName, ufoName in fontInfoNameMapping:
+            value = getattr(ufoInfo, ufoName, None)
+            if value is not None:
+                info[fontraName] = value
+        return FontInfo(**info)
 
     async def putFontInfo(self, fontInfo: FontInfo):
         pass

--- a/src/fontra/backends/fontra.py
+++ b/src/fontra/backends/fontra.py
@@ -13,6 +13,7 @@ from fontra.core.classes import (
     Font,
     GlobalAxis,
     GlobalDiscreteAxis,
+    GlobalSource,
     VariableGlyph,
     structure,
     unstructure,
@@ -119,6 +120,9 @@ class FontraBackend:
     async def putGlobalAxes(self, axes: list[GlobalAxis | GlobalDiscreteAxis]) -> None:
         self.fontData.axes = deepcopy(axes)
         self._scheduler.schedule(self._writeFontData)
+
+    async def getSources(self) -> list[GlobalSource]:
+        return []
 
     async def getCustomData(self) -> dict[str, Any]:
         return deepcopy(self.fontData.customData)

--- a/src/fontra/backends/fontra.py
+++ b/src/fontra/backends/fontra.py
@@ -122,7 +122,11 @@ class FontraBackend:
         self._scheduler.schedule(self._writeFontData)
 
     async def getSources(self) -> dict[str, GlobalSource]:
-        return []
+        return {}
+
+    async def putSources(self, sources: dict[str, GlobalSource]) -> None:
+        self.fontData.sources = deepcopy(sources)
+        self._scheduler.schedule(self._writeFontData)
 
     async def getCustomData(self) -> dict[str, Any]:
         return deepcopy(self.fontData.customData)

--- a/src/fontra/backends/fontra.py
+++ b/src/fontra/backends/fontra.py
@@ -121,7 +121,7 @@ class FontraBackend:
         self.fontData.axes = deepcopy(axes)
         self._scheduler.schedule(self._writeFontData)
 
-    async def getSources(self) -> list[GlobalSource]:
+    async def getSources(self) -> dict[str, GlobalSource]:
         return []
 
     async def getCustomData(self) -> dict[str, Any]:

--- a/src/fontra/backends/fontra.py
+++ b/src/fontra/backends/fontra.py
@@ -11,6 +11,7 @@ from typing import Any, Callable
 
 from fontra.core.classes import (
     Font,
+    FontInfo,
     GlobalAxis,
     GlobalDiscreteAxis,
     GlobalSource,
@@ -113,6 +114,13 @@ class FontraBackend:
         filePath.unlink()
         del self.glyphMap[glyphName]
         self._scheduler.schedule(self._writeGlyphInfo)
+
+    async def getFontInfo(self) -> FontInfo:
+        return deepcopy(self.fontData.fontInfo)
+
+    async def putFontInfo(self, fontInfo: FontInfo):
+        self.fontData.fontInfo = deepcopy(fontInfo)
+        self._scheduler.schedule(self._writeFontData)
 
     async def getGlobalAxes(self) -> list[GlobalAxis | GlobalDiscreteAxis]:
         return deepcopy(self.fontData.axes)

--- a/src/fontra/backends/opentype.py
+++ b/src/fontra/backends/opentype.py
@@ -112,7 +112,7 @@ class OTFBackend:
     async def getGlobalAxes(self) -> list[GlobalAxis | GlobalDiscreteAxis]:
         return self.globalAxes
 
-    async def getSources(self) -> list[GlobalSource]:
+    async def getSources(self) -> dict[str, GlobalSource]:
         return []
 
     async def getUnitsPerEm(self) -> int:

--- a/src/fontra/backends/opentype.py
+++ b/src/fontra/backends/opentype.py
@@ -10,6 +10,7 @@ from fontra.core.protocols import ReadableFontBackend
 from ..core.classes import (
     GlobalAxis,
     GlobalDiscreteAxis,
+    GlobalSource,
     Layer,
     Source,
     StaticGlyph,
@@ -110,6 +111,9 @@ class OTFBackend:
 
     async def getGlobalAxes(self) -> list[GlobalAxis | GlobalDiscreteAxis]:
         return self.globalAxes
+
+    async def getSources(self) -> list[GlobalSource]:
+        return []
 
     async def getUnitsPerEm(self) -> int:
         return self.font["head"].unitsPerEm

--- a/src/fontra/backends/opentype.py
+++ b/src/fontra/backends/opentype.py
@@ -113,7 +113,7 @@ class OTFBackend:
         return self.globalAxes
 
     async def getSources(self) -> dict[str, GlobalSource]:
-        return []
+        return {}
 
     async def getUnitsPerEm(self) -> int:
         return self.font["head"].unitsPerEm

--- a/src/fontra/backends/opentype.py
+++ b/src/fontra/backends/opentype.py
@@ -8,6 +8,7 @@ from fontTools.ttLib import TTFont
 from fontra.core.protocols import ReadableFontBackend
 
 from ..core.classes import (
+    FontInfo,
     GlobalAxis,
     GlobalDiscreteAxis,
     GlobalSource,
@@ -108,6 +109,9 @@ class OTFBackend:
                 for loc in getLocationsFromVarstore(varDataIndex, varStore, fvarAxes)
             }
         return [dict(loc) for loc in sorted(locations)]
+
+    async def getFontInfo(self) -> FontInfo:
+        return FontInfo()
 
     async def getGlobalAxes(self) -> list[GlobalAxis | GlobalDiscreteAxis]:
         return self.globalAxes

--- a/src/fontra/backends/workflow.py
+++ b/src/fontra/backends/workflow.py
@@ -3,7 +3,13 @@ from typing import Any
 
 import yaml
 
-from ..core.classes import GlobalAxis, GlobalDiscreteAxis, GlobalSource, VariableGlyph
+from ..core.classes import (
+    FontInfo,
+    GlobalAxis,
+    GlobalDiscreteAxis,
+    GlobalSource,
+    VariableGlyph,
+)
 from ..core.protocols import ReadableFontBackend
 from ..workflow.workflow import Workflow
 
@@ -33,6 +39,10 @@ class WorkflowBackend:
     async def getGlyph(self, glyphName: str) -> VariableGlyph | None:
         endPoint = await self._ensureSetup()
         return await endPoint.getGlyph(glyphName)
+
+    async def getFontInfo(self) -> FontInfo:
+        endPoint = await self._ensureSetup()
+        return await endPoint.getFontInfo()
 
     async def getGlobalAxes(self) -> list[GlobalAxis | GlobalDiscreteAxis]:
         endPoint = await self._ensureSetup()

--- a/src/fontra/backends/workflow.py
+++ b/src/fontra/backends/workflow.py
@@ -38,7 +38,7 @@ class WorkflowBackend:
         endPoint = await self._ensureSetup()
         return await endPoint.getGlobalAxes()
 
-    async def getSources(self) -> list[GlobalSource]:
+    async def getSources(self) -> dict[str, GlobalSource]:
         endPoint = await self._ensureSetup()
         return await endPoint.getSources()
 

--- a/src/fontra/backends/workflow.py
+++ b/src/fontra/backends/workflow.py
@@ -3,7 +3,7 @@ from typing import Any
 
 import yaml
 
-from ..core.classes import GlobalAxis, GlobalDiscreteAxis, VariableGlyph
+from ..core.classes import GlobalAxis, GlobalDiscreteAxis, GlobalSource, VariableGlyph
 from ..core.protocols import ReadableFontBackend
 from ..workflow.workflow import Workflow
 
@@ -37,6 +37,10 @@ class WorkflowBackend:
     async def getGlobalAxes(self) -> list[GlobalAxis | GlobalDiscreteAxis]:
         endPoint = await self._ensureSetup()
         return await endPoint.getGlobalAxes()
+
+    async def getSources(self) -> list[GlobalSource]:
+        endPoint = await self._ensureSetup()
+        return await endPoint.getSources()
 
     async def getGlyphMap(self) -> dict[str, list[int]]:
         endPoint = await self._ensureSetup()

--- a/src/fontra/client/core/classes.json
+++ b/src/fontra/client/core/classes.json
@@ -3,6 +3,9 @@
     "unitsPerEm": {
       "type": "int"
     },
+    "fontInfo": {
+      "type": "FontInfo"
+    },
     "glyphs": {
       "type": "dict",
       "subtype": "VariableGlyph"
@@ -22,6 +25,57 @@
     "sources": {
       "type": "dict",
       "subtype": "GlobalSource"
+    }
+  },
+  "FontInfo": {
+    "familyName": {
+      "type": "str"
+    },
+    "versionMajor": {
+      "type": "int"
+    },
+    "versionMinor": {
+      "type": "int"
+    },
+    "year": {
+      "type": "int"
+    },
+    "copyright": {
+      "type": "str"
+    },
+    "trademark": {
+      "type": "str"
+    },
+    "description": {
+      "type": "str"
+    },
+    "sampleText": {
+      "type": "str"
+    },
+    "designer": {
+      "type": "str"
+    },
+    "designerURL": {
+      "type": "str"
+    },
+    "manufacturer": {
+      "type": "str"
+    },
+    "manufacturerURL": {
+      "type": "str"
+    },
+    "licenseDescription": {
+      "type": "str"
+    },
+    "licenseInfoURL": {
+      "type": "str"
+    },
+    "vendorID": {
+      "type": "str"
+    },
+    "customData": {
+      "type": "dict",
+      "subtype": "Any"
     }
   },
   "VariableGlyph": {

--- a/src/fontra/client/core/classes.json
+++ b/src/fontra/client/core/classes.json
@@ -40,10 +40,6 @@
       "type": "int",
       "optional": true
     },
-    "year": {
-      "type": "int",
-      "optional": true
-    },
     "copyright": {
       "type": "str",
       "optional": true

--- a/src/fontra/client/core/classes.json
+++ b/src/fontra/client/core/classes.json
@@ -20,7 +20,7 @@
       "subtype": "GlobalAxis"
     },
     "sources": {
-      "type": "list",
+      "type": "dict",
       "subtype": "GlobalSource"
     }
   },

--- a/src/fontra/client/core/classes.json
+++ b/src/fontra/client/core/classes.json
@@ -29,49 +29,64 @@
   },
   "FontInfo": {
     "familyName": {
-      "type": "str"
+      "type": "str",
+      "optional": true
     },
     "versionMajor": {
-      "type": "int"
+      "type": "int",
+      "optional": true
     },
     "versionMinor": {
-      "type": "int"
+      "type": "int",
+      "optional": true
     },
     "year": {
-      "type": "int"
+      "type": "int",
+      "optional": true
     },
     "copyright": {
-      "type": "str"
+      "type": "str",
+      "optional": true
     },
     "trademark": {
-      "type": "str"
+      "type": "str",
+      "optional": true
     },
     "description": {
-      "type": "str"
+      "type": "str",
+      "optional": true
     },
     "sampleText": {
-      "type": "str"
+      "type": "str",
+      "optional": true
     },
     "designer": {
-      "type": "str"
+      "type": "str",
+      "optional": true
     },
     "designerURL": {
-      "type": "str"
+      "type": "str",
+      "optional": true
     },
     "manufacturer": {
-      "type": "str"
+      "type": "str",
+      "optional": true
     },
     "manufacturerURL": {
-      "type": "str"
+      "type": "str",
+      "optional": true
     },
     "licenseDescription": {
-      "type": "str"
+      "type": "str",
+      "optional": true
     },
     "licenseInfoURL": {
-      "type": "str"
+      "type": "str",
+      "optional": true
     },
     "vendorID": {
-      "type": "str"
+      "type": "str",
+      "optional": true
     },
     "customData": {
       "type": "dict",

--- a/src/fontra/core/classes.py
+++ b/src/fontra/core/classes.py
@@ -18,7 +18,7 @@ class Font:
     glyphMap: dict[str, list[int]] = field(default_factory=dict)
     customData: CustomData = field(default_factory=dict)
     axes: list[Union[GlobalAxis, GlobalDiscreteAxis]] = field(default_factory=list)
-    sources: list[GlobalSource] = field(default_factory=list)
+    sources: dict[str, GlobalSource] = field(default_factory=dict)
 
     def _trackAssignedAttributeNames(self):
         # see fonthandler.py

--- a/src/fontra/core/classes.py
+++ b/src/fontra/core/classes.py
@@ -12,8 +12,29 @@ from .path import PackedPath, Path, Point, PointType
 
 
 @dataclass(kw_only=True)
+class FontInfo:
+    familyName: str = ""
+    versionMajor: int = 0
+    versionMinor: int = 0
+    year: int = 0
+    copyright: str = ""
+    trademark: str = ""
+    description: str = ""
+    sampleText: str = ""
+    designer: str = ""
+    designerURL: str = ""
+    manufacturer: str = ""
+    manufacturerURL: str = ""
+    licenseDescription: str = ""
+    licenseInfoURL: str = ""
+    vendorID: str = ""
+    customData: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(kw_only=True)
 class Font:
     unitsPerEm: int = 1000
+    fontInfo: FontInfo = field(default_factory=FontInfo)
     glyphs: dict[str, VariableGlyph] = field(default_factory=dict)
     glyphMap: dict[str, list[int]] = field(default_factory=dict)
     customData: CustomData = field(default_factory=dict)
@@ -335,6 +356,7 @@ registerOmitDefaultHook(GlobalDiscreteAxis)
 registerOmitDefaultHook(AxisValueLabel)
 registerOmitDefaultHook(GlobalMetric)
 registerOmitDefaultHook(GlobalSource)
+registerOmitDefaultHook(FontInfo)
 
 
 def structure(obj, cls):

--- a/src/fontra/core/classes.py
+++ b/src/fontra/core/classes.py
@@ -16,7 +16,6 @@ class FontInfo:
     familyName: Optional[str] = None
     versionMajor: Optional[int] = None
     versionMinor: Optional[int] = None
-    year: Optional[int] = None
     copyright: Optional[str] = None
     trademark: Optional[str] = None
     description: Optional[str] = None

--- a/src/fontra/core/classes.py
+++ b/src/fontra/core/classes.py
@@ -13,21 +13,21 @@ from .path import PackedPath, Path, Point, PointType
 
 @dataclass(kw_only=True)
 class FontInfo:
-    familyName: str = ""
-    versionMajor: int = 0
-    versionMinor: int = 0
-    year: int = 0
-    copyright: str = ""
-    trademark: str = ""
-    description: str = ""
-    sampleText: str = ""
-    designer: str = ""
-    designerURL: str = ""
-    manufacturer: str = ""
-    manufacturerURL: str = ""
-    licenseDescription: str = ""
-    licenseInfoURL: str = ""
-    vendorID: str = ""
+    familyName: Optional[str] = None
+    versionMajor: Optional[int] = None
+    versionMinor: Optional[int] = None
+    year: Optional[int] = None
+    copyright: Optional[str] = None
+    trademark: Optional[str] = None
+    description: Optional[str] = None
+    sampleText: Optional[str] = None
+    designer: Optional[str] = None
+    designerURL: Optional[str] = None
+    manufacturer: Optional[str] = None
+    manufacturerURL: Optional[str] = None
+    licenseDescription: Optional[str] = None
+    licenseInfoURL: Optional[str] = None
+    vendorID: Optional[str] = None
     customData: dict[str, Any] = field(default_factory=dict)
 
 

--- a/src/fontra/core/classes.py
+++ b/src/fontra/core/classes.py
@@ -333,6 +333,8 @@ registerOmitDefaultHook(PackedPath)
 registerOmitDefaultHook(GlobalAxis)
 registerOmitDefaultHook(GlobalDiscreteAxis)
 registerOmitDefaultHook(AxisValueLabel)
+registerOmitDefaultHook(GlobalMetric)
+registerOmitDefaultHook(GlobalSource)
 
 
 def structure(obj, cls):

--- a/src/fontra/core/protocols.py
+++ b/src/fontra/core/protocols.py
@@ -6,7 +6,13 @@ from typing import Any, Awaitable, Callable, Protocol, runtime_checkable
 
 from aiohttp import web
 
-from .classes import GlobalAxis, GlobalDiscreteAxis, GlobalSource, VariableGlyph
+from .classes import (
+    FontInfo,
+    GlobalAxis,
+    GlobalDiscreteAxis,
+    GlobalSource,
+    VariableGlyph,
+)
 
 
 @runtime_checkable
@@ -15,6 +21,9 @@ class ReadableFontBackend(Protocol):
         pass
 
     async def getGlyph(self, glyphName: str) -> VariableGlyph | None:
+        pass
+
+    async def getFontInfo(self) -> FontInfo:
         pass
 
     async def getGlobalAxes(self) -> list[GlobalAxis | GlobalDiscreteAxis]:
@@ -41,6 +50,9 @@ class WritableFontBackend(ReadableFontBackend, Protocol):
         pass
 
     async def deleteGlyph(self, glyphName: str) -> None:
+        pass
+
+    async def putFontInfo(self, fontInfo: FontInfo):
         pass
 
     async def putGlobalAxes(self, value: list[GlobalAxis | GlobalDiscreteAxis]) -> None:

--- a/src/fontra/core/protocols.py
+++ b/src/fontra/core/protocols.py
@@ -21,7 +21,7 @@ class ReadableFontBackend(Protocol):
         pass
 
     async def getSources(self) -> list[GlobalSource]:
-        ...
+        pass
 
     async def getGlyphMap(self) -> dict[str, list[int]]:
         pass

--- a/src/fontra/core/protocols.py
+++ b/src/fontra/core/protocols.py
@@ -20,7 +20,7 @@ class ReadableFontBackend(Protocol):
     async def getGlobalAxes(self) -> list[GlobalAxis | GlobalDiscreteAxis]:
         pass
 
-    async def getSources(self) -> list[GlobalSource]:
+    async def getSources(self) -> dict[str, GlobalSource]:
         pass
 
     async def getGlyphMap(self) -> dict[str, list[int]]:

--- a/src/fontra/core/protocols.py
+++ b/src/fontra/core/protocols.py
@@ -46,6 +46,9 @@ class WritableFontBackend(ReadableFontBackend, Protocol):
     async def putGlobalAxes(self, value: list[GlobalAxis | GlobalDiscreteAxis]) -> None:
         pass
 
+    async def putSources(self, sources: dict[str, GlobalSource]) -> None:
+        pass
+
     async def putGlyphMap(self, value: dict[str, list[int]]) -> None:
         pass
 

--- a/src/fontra/core/protocols.py
+++ b/src/fontra/core/protocols.py
@@ -6,7 +6,7 @@ from typing import Any, Awaitable, Callable, Protocol, runtime_checkable
 
 from aiohttp import web
 
-from .classes import GlobalAxis, GlobalDiscreteAxis, VariableGlyph
+from .classes import GlobalAxis, GlobalDiscreteAxis, GlobalSource, VariableGlyph
 
 
 @runtime_checkable
@@ -19,6 +19,9 @@ class ReadableFontBackend(Protocol):
 
     async def getGlobalAxes(self) -> list[GlobalAxis | GlobalDiscreteAxis]:
         pass
+
+    async def getSources(self) -> list[GlobalSource]:
+        ...
 
     async def getGlyphMap(self) -> dict[str, list[int]]:
         pass

--- a/src/fontra/workflow/actions.py
+++ b/src/fontra/workflow/actions.py
@@ -112,7 +112,7 @@ class BaseFilterAction:
         axes = await self.validatedInput.getGlobalAxes()
         return await self.processGlobalAxes(axes)
 
-    async def getSources(self) -> list[GlobalSource]:
+    async def getSources(self) -> dict[str, GlobalSource]:
         sources = await self.validatedInput.getSources()
         return await self.processSources(sources)
 
@@ -140,7 +140,9 @@ class BaseFilterAction:
     ) -> list[GlobalAxis | GlobalDiscreteAxis]:
         return axes
 
-    async def processSources(self, sources: list[GlobalSource]) -> list[GlobalSource]:
+    async def processSources(
+        self, sources: dict[str, GlobalSource]
+    ) -> dict[str, GlobalSource]:
         return sources
 
     async def processGlyphMap(

--- a/src/fontra/workflow/actions.py
+++ b/src/fontra/workflow/actions.py
@@ -16,6 +16,7 @@ from ..backends import getFileSystemBackend, newFileSystemBackend
 from ..backends.copy import copyFont
 from ..core.classes import (
     Component,
+    FontInfo,
     GlobalAxis,
     GlobalDiscreteAxis,
     GlobalSource,
@@ -108,6 +109,10 @@ class BaseFilterAction:
             return None
         return await self.processGlyph(glyph)
 
+    async def getFontInfo(self) -> FontInfo:
+        fontInfo = await self.validatedInput.getFontInfo()
+        return await self.processFontInfo(fontInfo)
+
     async def getGlobalAxes(self) -> list[GlobalAxis | GlobalDiscreteAxis]:
         axes = await self.validatedInput.getGlobalAxes()
         return await self.processGlobalAxes(axes)
@@ -134,6 +139,9 @@ class BaseFilterAction:
 
     async def processGlyph(self, glyph: VariableGlyph) -> VariableGlyph:
         return glyph
+
+    async def processFontInfo(self, fontInfo: FontInfo) -> FontInfo:
+        return fontInfo
 
     async def processGlobalAxes(
         self, axes: list[GlobalAxis | GlobalDiscreteAxis]

--- a/src/fontra/workflow/actions.py
+++ b/src/fontra/workflow/actions.py
@@ -18,6 +18,7 @@ from ..core.classes import (
     Component,
     GlobalAxis,
     GlobalDiscreteAxis,
+    GlobalSource,
     Layer,
     Source,
     StaticGlyph,
@@ -111,6 +112,10 @@ class BaseFilterAction:
         axes = await self.validatedInput.getGlobalAxes()
         return await self.processGlobalAxes(axes)
 
+    async def getSources(self) -> list[GlobalSource]:
+        sources = await self.validatedInput.getSources()
+        return await self.processSources(sources)
+
     async def getGlyphMap(self) -> dict[str, list[int]]:
         glyphMap = await self.validatedInput.getGlyphMap()
         return await self.processGlyphMap(glyphMap)
@@ -134,6 +139,9 @@ class BaseFilterAction:
         self, axes: list[GlobalAxis | GlobalDiscreteAxis]
     ) -> list[GlobalAxis | GlobalDiscreteAxis]:
         return axes
+
+    async def processSources(self, sources: list[GlobalSource]) -> list[GlobalSource]:
+        return sources
 
     async def processGlyphMap(
         self, glyphMap: dict[str, list[int]]

--- a/src/fontra/workflow/merger.py
+++ b/src/fontra/workflow/merger.py
@@ -2,7 +2,14 @@ from copy import deepcopy
 from dataclasses import dataclass
 from typing import Any
 
-from ..core.classes import GlobalAxis, GlobalDiscreteAxis, GlobalSource, VariableGlyph
+from ..core.classes import (
+    FontInfo,
+    GlobalAxis,
+    GlobalDiscreteAxis,
+    GlobalSource,
+    VariableGlyph,
+    unstructure,
+)
 from ..core.protocols import ReadableFontBackend
 from .actions import actionLogger
 
@@ -40,6 +47,11 @@ class FontBackendMerger:
         elif glyphName in self._glyphNamesA:
             return await self.inputA.getGlyph(glyphName)
         return None
+
+    async def getFontInfo(self) -> FontInfo:
+        fontInfoA = await self.inputA.getFontInfo()
+        fontInfoB = await self.inputB.getFontInfo()
+        return FontInfo(**(unstructure(fontInfoA) | unstructure(fontInfoB)))
 
     async def getGlobalAxes(self) -> list[GlobalAxis | GlobalDiscreteAxis]:
         axesA = await self.inputA.getGlobalAxes()

--- a/src/fontra/workflow/merger.py
+++ b/src/fontra/workflow/merger.py
@@ -61,7 +61,7 @@ class FontBackendMerger:
     async def getSources(self) -> dict[str, GlobalSource]:
         sourcesA = await self.inputA.getSources()
         sourcesB = await self.inputB.getSources()
-        return sourcesA + sourcesB
+        return sourcesA | sourcesB
 
     async def getGlyphMap(self) -> dict[str, list[int]]:
         await self._prepareGlyphMap()

--- a/src/fontra/workflow/merger.py
+++ b/src/fontra/workflow/merger.py
@@ -2,7 +2,7 @@ from copy import deepcopy
 from dataclasses import dataclass
 from typing import Any
 
-from ..core.classes import GlobalAxis, GlobalDiscreteAxis, VariableGlyph
+from ..core.classes import GlobalAxis, GlobalDiscreteAxis, GlobalSource, VariableGlyph
 from ..core.protocols import ReadableFontBackend
 from .actions import actionLogger
 
@@ -57,6 +57,11 @@ class FontBackendMerger:
                 mergedAxes.append(axis)
 
         return mergedAxes
+
+    async def getSources(self) -> list[GlobalSource]:
+        sourcesA = await self.inputA.getSources()
+        sourcesB = await self.inputB.getSources()
+        return sourcesA + sourcesB
 
     async def getGlyphMap(self) -> dict[str, list[int]]:
         await self._prepareGlyphMap()

--- a/src/fontra/workflow/merger.py
+++ b/src/fontra/workflow/merger.py
@@ -58,7 +58,7 @@ class FontBackendMerger:
 
         return mergedAxes
 
-    async def getSources(self) -> list[GlobalSource]:
+    async def getSources(self) -> dict[str, GlobalSource]:
         sourcesA = await self.inputA.getSources()
         sourcesB = await self.inputB.getSources()
         return sourcesA + sourcesB

--- a/test-common/fonts/MutatorSans.fontra/font-data.json
+++ b/test-common/fonts/MutatorSans.fontra/font-data.json
@@ -39,5 +39,5 @@
 "defaultValue": 0
 }
 ],
-"sources": []
+"sources": {}
 }

--- a/test-common/fonts/MutatorSans.fontra/font-data.json
+++ b/test-common/fonts/MutatorSans.fontra/font-data.json
@@ -1,5 +1,6 @@
 {
 "unitsPerEm": 1000,
+"fontInfo": {},
 "customData": {},
 "axes": [
 {

--- a/test-py/data/workflow/input-composites.fontra/font-data.json
+++ b/test-py/data/workflow/input-composites.fontra/font-data.json
@@ -39,5 +39,5 @@
 "defaultValue": 0
 }
 ],
-"sources": []
+"sources": {}
 }

--- a/test-py/data/workflow/input-composites.fontra/font-data.json
+++ b/test-py/data/workflow/input-composites.fontra/font-data.json
@@ -1,5 +1,6 @@
 {
 "unitsPerEm": 1000,
+"fontInfo": {},
 "customData": {},
 "axes": [
 {

--- a/test-py/data/workflow/input-drop-unused-sources-and-layers.fontra/font-data.json
+++ b/test-py/data/workflow/input-drop-unused-sources-and-layers.fontra/font-data.json
@@ -39,5 +39,5 @@
 "defaultValue": 0
 }
 ],
-"sources": []
+"sources": {}
 }

--- a/test-py/data/workflow/input-drop-unused-sources-and-layers.fontra/font-data.json
+++ b/test-py/data/workflow/input-drop-unused-sources-and-layers.fontra/font-data.json
@@ -1,5 +1,6 @@
 {
 "unitsPerEm": 1000,
+"fontInfo": {},
 "customData": {},
 "axes": [
 {

--- a/test-py/data/workflow/input-variable-composites-deep-axes.fontra/font-data.json
+++ b/test-py/data/workflow/input-variable-composites-deep-axes.fontra/font-data.json
@@ -19,5 +19,5 @@
 "maxValue": 200
 }
 ],
-"sources": []
+"sources": {}
 }

--- a/test-py/data/workflow/input-variable-composites-deep-axes.fontra/font-data.json
+++ b/test-py/data/workflow/input-variable-composites-deep-axes.fontra/font-data.json
@@ -1,5 +1,6 @@
 {
 "unitsPerEm": 1000,
+"fontInfo": {},
 "customData": {},
 "axes": [
 {

--- a/test-py/data/workflow/input-variable-composites.fontra/font-data.json
+++ b/test-py/data/workflow/input-variable-composites.fontra/font-data.json
@@ -1,5 +1,6 @@
 {
 "unitsPerEm": 1000,
+"fontInfo": {},
 "customData": {
 "fontra.sourceStatusFieldDefinitions": [
 {

--- a/test-py/data/workflow/input-variable-composites.fontra/font-data.json
+++ b/test-py/data/workflow/input-variable-composites.fontra/font-data.json
@@ -95,5 +95,5 @@
 ]
 }
 ],
-"sources": []
+"sources": {}
 }

--- a/test-py/data/workflow/input1-A.fontra/font-data.json
+++ b/test-py/data/workflow/input1-A.fontra/font-data.json
@@ -1,5 +1,6 @@
 {
 "unitsPerEm": 1000,
+"fontInfo": {},
 "customData": {},
 "axes": [
 {

--- a/test-py/data/workflow/input1-A.fontra/font-data.json
+++ b/test-py/data/workflow/input1-A.fontra/font-data.json
@@ -44,5 +44,5 @@
 "hidden": false
 }
 ],
-"sources": []
+"sources": {}
 }

--- a/test-py/data/workflow/input1-B.fontra/font-data.json
+++ b/test-py/data/workflow/input1-B.fontra/font-data.json
@@ -1,5 +1,6 @@
 {
 "unitsPerEm": 1000,
+"fontInfo": {},
 "customData": {},
 "axes": [
 {

--- a/test-py/data/workflow/input1-B.fontra/font-data.json
+++ b/test-py/data/workflow/input1-B.fontra/font-data.json
@@ -44,5 +44,5 @@
 "hidden": false
 }
 ],
-"sources": []
+"sources": {}
 }

--- a/test-py/data/workflow/input2-A.fontra/font-data.json
+++ b/test-py/data/workflow/input2-A.fontra/font-data.json
@@ -35,5 +35,5 @@
 "hidden": false
 }
 ],
-"sources": []
+"sources": {}
 }

--- a/test-py/data/workflow/input2-A.fontra/font-data.json
+++ b/test-py/data/workflow/input2-A.fontra/font-data.json
@@ -1,5 +1,6 @@
 {
 "unitsPerEm": 1000,
+"fontInfo": {},
 "customData": {},
 "axes": [
 {

--- a/test-py/data/workflow/input2-B.fontra/font-data.json
+++ b/test-py/data/workflow/input2-B.fontra/font-data.json
@@ -35,5 +35,5 @@
 "hidden": false
 }
 ],
-"sources": []
+"sources": {}
 }

--- a/test-py/data/workflow/input2-B.fontra/font-data.json
+++ b/test-py/data/workflow/input2-B.fontra/font-data.json
@@ -1,5 +1,6 @@
 {
 "unitsPerEm": 1000,
+"fontInfo": {},
 "customData": {},
 "axes": [
 {

--- a/test-py/data/workflow/output-adjust-axes-no-mapping-no-source-remap.fontra/font-data.json
+++ b/test-py/data/workflow/output-adjust-axes-no-mapping-no-source-remap.fontra/font-data.json
@@ -1,5 +1,6 @@
 {
 "unitsPerEm": 1000,
+"fontInfo": {},
 "customData": {},
 "axes": [
 {

--- a/test-py/data/workflow/output-adjust-axes-no-mapping-no-source-remap.fontra/font-data.json
+++ b/test-py/data/workflow/output-adjust-axes-no-mapping-no-source-remap.fontra/font-data.json
@@ -29,5 +29,5 @@
 "defaultValue": 0
 }
 ],
-"sources": []
+"sources": {}
 }

--- a/test-py/data/workflow/output-adjust-axes-no-mapping.fontra/font-data.json
+++ b/test-py/data/workflow/output-adjust-axes-no-mapping.fontra/font-data.json
@@ -1,5 +1,6 @@
 {
 "unitsPerEm": 1000,
+"fontInfo": {},
 "customData": {},
 "axes": [
 {

--- a/test-py/data/workflow/output-adjust-axes-no-mapping.fontra/font-data.json
+++ b/test-py/data/workflow/output-adjust-axes-no-mapping.fontra/font-data.json
@@ -29,5 +29,5 @@
 "defaultValue": 0
 }
 ],
-"sources": []
+"sources": {}
 }

--- a/test-py/data/workflow/output-adjust-axes-no-source-remap.fontra/font-data.json
+++ b/test-py/data/workflow/output-adjust-axes-no-source-remap.fontra/font-data.json
@@ -39,5 +39,5 @@
 "defaultValue": 0
 }
 ],
-"sources": []
+"sources": {}
 }

--- a/test-py/data/workflow/output-adjust-axes-no-source-remap.fontra/font-data.json
+++ b/test-py/data/workflow/output-adjust-axes-no-source-remap.fontra/font-data.json
@@ -1,5 +1,6 @@
 {
 "unitsPerEm": 1000,
+"fontInfo": {},
 "customData": {},
 "axes": [
 {

--- a/test-py/data/workflow/output-adjust-axes.fontra/font-data.json
+++ b/test-py/data/workflow/output-adjust-axes.fontra/font-data.json
@@ -39,5 +39,5 @@
 "defaultValue": 0
 }
 ],
-"sources": []
+"sources": {}
 }

--- a/test-py/data/workflow/output-adjust-axes.fontra/font-data.json
+++ b/test-py/data/workflow/output-adjust-axes.fontra/font-data.json
@@ -1,5 +1,6 @@
 {
 "unitsPerEm": 1000,
+"fontInfo": {},
 "customData": {},
 "axes": [
 {

--- a/test-py/data/workflow/output-decompose-composites.fontra/font-data.json
+++ b/test-py/data/workflow/output-decompose-composites.fontra/font-data.json
@@ -39,5 +39,5 @@
 "defaultValue": 0
 }
 ],
-"sources": []
+"sources": {}
 }

--- a/test-py/data/workflow/output-decompose-composites.fontra/font-data.json
+++ b/test-py/data/workflow/output-decompose-composites.fontra/font-data.json
@@ -1,5 +1,6 @@
 {
 "unitsPerEm": 1000,
+"fontInfo": {},
 "customData": {},
 "axes": [
 {

--- a/test-py/data/workflow/output-decompose-only-variable-composites.fontra/font-data.json
+++ b/test-py/data/workflow/output-decompose-only-variable-composites.fontra/font-data.json
@@ -39,5 +39,5 @@
 "defaultValue": 0
 }
 ],
-"sources": []
+"sources": {}
 }

--- a/test-py/data/workflow/output-decompose-only-variable-composites.fontra/font-data.json
+++ b/test-py/data/workflow/output-decompose-only-variable-composites.fontra/font-data.json
@@ -1,5 +1,6 @@
 {
 "unitsPerEm": 1000,
+"fontInfo": {},
 "customData": {},
 "axes": [
 {

--- a/test-py/data/workflow/output-decompose-variable-composites-deep-axes.fontra/font-data.json
+++ b/test-py/data/workflow/output-decompose-variable-composites-deep-axes.fontra/font-data.json
@@ -19,5 +19,5 @@
 "maxValue": 200
 }
 ],
-"sources": []
+"sources": {}
 }

--- a/test-py/data/workflow/output-decompose-variable-composites-deep-axes.fontra/font-data.json
+++ b/test-py/data/workflow/output-decompose-variable-composites-deep-axes.fontra/font-data.json
@@ -1,5 +1,6 @@
 {
 "unitsPerEm": 1000,
+"fontInfo": {},
 "customData": {},
 "axes": [
 {

--- a/test-py/data/workflow/output-decompose-variable-composites.fontra/font-data.json
+++ b/test-py/data/workflow/output-decompose-variable-composites.fontra/font-data.json
@@ -1,5 +1,6 @@
 {
 "unitsPerEm": 1000,
+"fontInfo": {},
 "customData": {
 "fontra.sourceStatusFieldDefinitions": [
 {

--- a/test-py/data/workflow/output-decompose-variable-composites.fontra/font-data.json
+++ b/test-py/data/workflow/output-decompose-variable-composites.fontra/font-data.json
@@ -95,5 +95,5 @@
 ]
 }
 ],
-"sources": []
+"sources": {}
 }

--- a/test-py/data/workflow/output-drop-axis-mapping-noop.fontra/font-data.json
+++ b/test-py/data/workflow/output-drop-axis-mapping-noop.fontra/font-data.json
@@ -39,5 +39,5 @@
 "defaultValue": 0
 }
 ],
-"sources": []
+"sources": {}
 }

--- a/test-py/data/workflow/output-drop-axis-mapping-noop.fontra/font-data.json
+++ b/test-py/data/workflow/output-drop-axis-mapping-noop.fontra/font-data.json
@@ -1,5 +1,6 @@
 {
 "unitsPerEm": 1000,
+"fontInfo": {},
 "customData": {},
 "axes": [
 {

--- a/test-py/data/workflow/output-drop-axis-mapping.fontra/font-data.json
+++ b/test-py/data/workflow/output-drop-axis-mapping.fontra/font-data.json
@@ -1,5 +1,6 @@
 {
 "unitsPerEm": 1000,
+"fontInfo": {},
 "customData": {},
 "axes": [
 {

--- a/test-py/data/workflow/output-drop-axis-mapping.fontra/font-data.json
+++ b/test-py/data/workflow/output-drop-axis-mapping.fontra/font-data.json
@@ -29,5 +29,5 @@
 "defaultValue": 0
 }
 ],
-"sources": []
+"sources": {}
 }

--- a/test-py/data/workflow/output-drop-unused-sources-and-layers.fontra/font-data.json
+++ b/test-py/data/workflow/output-drop-unused-sources-and-layers.fontra/font-data.json
@@ -39,5 +39,5 @@
 "defaultValue": 0
 }
 ],
-"sources": []
+"sources": {}
 }

--- a/test-py/data/workflow/output-drop-unused-sources-and-layers.fontra/font-data.json
+++ b/test-py/data/workflow/output-drop-unused-sources-and-layers.fontra/font-data.json
@@ -1,5 +1,6 @@
 {
 "unitsPerEm": 1000,
+"fontInfo": {},
 "customData": {},
 "axes": [
 {

--- a/test-py/data/workflow/output-rename-axes.fontra/font-data.json
+++ b/test-py/data/workflow/output-rename-axes.fontra/font-data.json
@@ -39,5 +39,5 @@
 "defaultValue": 0
 }
 ],
-"sources": []
+"sources": {}
 }

--- a/test-py/data/workflow/output-rename-axes.fontra/font-data.json
+++ b/test-py/data/workflow/output-rename-axes.fontra/font-data.json
@@ -1,5 +1,6 @@
 {
 "unitsPerEm": 1000,
+"fontInfo": {},
 "customData": {},
 "axes": [
 {

--- a/test-py/data/workflow/output1.fontra/font-data.json
+++ b/test-py/data/workflow/output1.fontra/font-data.json
@@ -39,5 +39,5 @@
 "defaultValue": 0
 }
 ],
-"sources": []
+"sources": {}
 }

--- a/test-py/data/workflow/output1.fontra/font-data.json
+++ b/test-py/data/workflow/output1.fontra/font-data.json
@@ -1,5 +1,6 @@
 {
 "unitsPerEm": 1000,
+"fontInfo": {},
 "customData": {},
 "axes": [
 {

--- a/test-py/data/workflow/output2.fontra/font-data.json
+++ b/test-py/data/workflow/output2.fontra/font-data.json
@@ -1,5 +1,6 @@
 {
 "unitsPerEm": 1000,
+"fontInfo": {},
 "customData": {},
 "axes": [
 {

--- a/test-py/data/workflow/output2.fontra/font-data.json
+++ b/test-py/data/workflow/output2.fontra/font-data.json
@@ -29,5 +29,5 @@
 "defaultValue": 0
 }
 ],
-"sources": []
+"sources": {}
 }

--- a/test-py/data/workflow/output3.fontra/font-data.json
+++ b/test-py/data/workflow/output3.fontra/font-data.json
@@ -39,5 +39,5 @@
 "defaultValue": 0
 }
 ],
-"sources": []
+"sources": {}
 }

--- a/test-py/data/workflow/output3.fontra/font-data.json
+++ b/test-py/data/workflow/output3.fontra/font-data.json
@@ -1,5 +1,6 @@
 {
 "unitsPerEm": 1000,
+"fontInfo": {},
 "customData": {},
 "axes": [
 {

--- a/test-py/test_backends_designspace.py
+++ b/test-py/test_backends_designspace.py
@@ -449,7 +449,8 @@ getSourcesTestData = [
 async def test_getSources(testFont):
     sources = await testFont.getSources()
     sources = unstructure(sources)
-    assert sources == getSourcesTestData
+    sourcesList = list(sources.values())  # ignore UUIDs
+    assert sourcesList == getSourcesTestData
 
 
 def fileNamesFromDir(path):

--- a/test-py/test_backends_designspace.py
+++ b/test-py/test_backends_designspace.py
@@ -8,7 +8,14 @@ from fontTools.designspaceLib import DesignSpaceDocument
 
 from fontra.backends import getFileSystemBackend, newFileSystemBackend
 from fontra.backends.designspace import DesignspaceBackend, UFOBackend
-from fontra.core.classes import GlobalAxis, Layer, LocalAxis, Source, StaticGlyph
+from fontra.core.classes import (
+    GlobalAxis,
+    Layer,
+    LocalAxis,
+    Source,
+    StaticGlyph,
+    unstructure,
+)
 
 dataDir = pathlib.Path(__file__).resolve().parent / "data"
 
@@ -345,6 +352,104 @@ async def test_findGlyphsThatUseGlyph(writableTestFont):
             "B",
             "varcotest1",
         ] == await writableTestFont.findGlyphsThatUseGlyph("A")
+
+
+getSourcesTestData = [
+    {
+        "location": {"italic": 0.0, "weight": 150.0, "width": 0.0},
+        "name": "LightCondensed",
+        "verticalMetrics": {
+            "ascender": {"value": 700},
+            "capHeight": {"value": 700},
+            "descender": {"value": -200},
+            "italicAngle": {"value": 0},
+            "xHeight": {"value": 500},
+        },
+    },
+    {
+        "location": {"italic": 0.0, "weight": 850.0, "width": 0.0},
+        "name": "BoldCondensed",
+        "verticalMetrics": {
+            "ascender": {"value": 800},
+            "capHeight": {"value": 800},
+            "descender": {"value": -200},
+            "italicAngle": {"value": 0},
+            "xHeight": {"value": 500},
+        },
+    },
+    {
+        "location": {"italic": 0.0, "weight": 150.0, "width": 1000.0},
+        "name": "LightWide",
+        "verticalMetrics": {
+            "ascender": {"value": 700},
+            "capHeight": {"value": 700},
+            "descender": {"value": -200},
+            "italicAngle": {"value": 0},
+            "xHeight": {"value": 500},
+        },
+    },
+    {
+        "location": {"italic": 0.0, "weight": 850.0, "width": 1000.0},
+        "name": "BoldWide",
+        "verticalMetrics": {
+            "ascender": {"value": 800},
+            "capHeight": {"value": 800},
+            "descender": {"value": -200},
+            "italicAngle": {"value": 0},
+            "xHeight": {"value": 500},
+        },
+    },
+    {
+        "location": {"italic": 0.0, "weight": 595.0, "width": 0.0},
+        "name": "support.crossbar",
+        "verticalMetrics": {
+            "ascender": {"value": 700},
+            "capHeight": {"value": 700},
+            "descender": {"value": -200},
+            "italicAngle": {"value": 0},
+            "xHeight": {"value": 500},
+        },
+    },
+    {
+        "location": {"italic": 0.0, "weight": 595.0, "width": 1000.0},
+        "name": "support.S.wide",
+        "verticalMetrics": {
+            "ascender": {"value": 700},
+            "capHeight": {"value": 700},
+            "descender": {"value": -200},
+            "italicAngle": {"value": 0},
+            "xHeight": {"value": 500},
+        },
+    },
+    {
+        "location": {"italic": 0.0, "weight": 595.0, "width": 569.078},
+        "name": "support.S.middle",
+        "verticalMetrics": {
+            "ascender": {"value": 700},
+            "capHeight": {"value": 700},
+            "descender": {"value": -200},
+            "italicAngle": {"value": 0},
+            "xHeight": {"value": 500},
+        },
+    },
+    {
+        "location": {"italic": 1.0, "weight": 150.0, "width": 0.0},
+        "name": "LightCondensedItalic",
+        "verticalMetrics": {
+            "ascender": {"value": 750},
+            "capHeight": {"value": 750},
+            "descender": {"value": -250},
+            "italicAngle": {"value": 0},
+            "xHeight": {"value": 500},
+        },
+    },
+]
+
+
+async def test_getSources(testFont):
+    sources = await testFont.getSources()
+    sources = unstructure(sources)
+    assert sources == getSourcesTestData
 
 
 def fileNamesFromDir(path):

--- a/test-py/test_workflow.py
+++ b/test-py/test_workflow.py
@@ -233,7 +233,7 @@ def test_command(tmpdir, configYAMLSources):
             steps:
 
             - action: input
-              source: "test-py/data/mutatorsans/MutatorSans.designspace"
+              source: "test-common/fonts/MutatorSans.fontra"
               steps:
               - action: scale
                 scaleFactor: 0.75


### PR DESCRIPTION
Part of #907, #909, #78

This requires matching changes in fontra-glyphs and fontra-rcjk.

Writing sources to .designspace is to be done, it is a bigger task as it requires rewriting UFO sources to some extent.