### PR TITLE
[copyFont] Optionally log getGlyph() errors and continue

### DIFF
--- a/src/fontra/backends/copy.py
+++ b/src/fontra/backends/copy.py
@@ -71,7 +71,13 @@ async def copyGlyphs(
         glyphName = glyphNamesToCopy.pop(0)
         glyphNamesCopied.update(glyphNamesToCopy)
         logger.debug(f"reading {glyphName}")
-        glyph = await sourceBackend.getGlyph(glyphName)
+
+        try:
+            glyph = await sourceBackend.getGlyph(glyphName)
+        except Exception as e:
+            logger.error(f"glyph {glyphName} caused an error: {e!r}")
+            continue
+
         if glyph is None:
             logger.warn(f"glyph {glyphName} not found")
             continue

--- a/src/fontra/workflow/actions.py
+++ b/src/fontra/workflow/actions.py
@@ -392,12 +392,14 @@ class OutputAction:
             except AttributeError:
                 pass
 
-    async def process(self, outputDir: os.PathLike = pathlib.Path()) -> None:
+    async def process(
+        self, outputDir: os.PathLike = pathlib.Path(), continueOnError=True
+    ) -> None:
         outputDir = pathlib.Path(outputDir)
         output = newFileSystemBackend((outputDir / self.destination).resolve())
 
         async with aclosing(output):
-            await copyFont(self.validatedInput, output)
+            await copyFont(self.validatedInput, output, continueOnError=continueOnError)
 
 
 @registerActionClass("rename-axes")

--- a/src/fontra/workflow/actions.py
+++ b/src/fontra/workflow/actions.py
@@ -65,7 +65,7 @@ class InputActionProtocol(Protocol):
 @runtime_checkable
 class OutputActionProtocol(Protocol):
     async def process(
-        self, outputDir: os.PathLike = pathlib.Path(), continueOnError=False
+        self, outputDir: os.PathLike = pathlib.Path(), *, continueOnError=False
     ) -> None:
         pass
 
@@ -395,7 +395,7 @@ class OutputAction:
                 pass
 
     async def process(
-        self, outputDir: os.PathLike = pathlib.Path(), continueOnError=False
+        self, outputDir: os.PathLike = pathlib.Path(), *, continueOnError=False
     ) -> None:
         outputDir = pathlib.Path(outputDir)
         output = newFileSystemBackend((outputDir / self.destination).resolve())

--- a/src/fontra/workflow/actions.py
+++ b/src/fontra/workflow/actions.py
@@ -393,7 +393,7 @@ class OutputAction:
                 pass
 
     async def process(
-        self, outputDir: os.PathLike = pathlib.Path(), continueOnError=True
+        self, outputDir: os.PathLike = pathlib.Path(), continueOnError=False
     ) -> None:
         outputDir = pathlib.Path(outputDir)
         output = newFileSystemBackend((outputDir / self.destination).resolve())

--- a/src/fontra/workflow/actions.py
+++ b/src/fontra/workflow/actions.py
@@ -64,7 +64,9 @@ class InputActionProtocol(Protocol):
 
 @runtime_checkable
 class OutputActionProtocol(Protocol):
-    async def process(self) -> None:
+    async def process(
+        self, outputDir: os.PathLike = pathlib.Path(), continueOnError=False
+    ) -> None:
         pass
 
 

--- a/src/fontra/workflow/command.py
+++ b/src/fontra/workflow/command.py
@@ -51,7 +51,7 @@ def existing_folder(path):
     return path
 
 
-async def mainAsync():
+async def mainAsync() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--output-dir",

--- a/src/fontra/workflow/command.py
+++ b/src/fontra/workflow/command.py
@@ -77,6 +77,12 @@ async def mainAsync():
         help="The logging level for the actions log file",
     )
     parser.add_argument(
+        "--continue-on-error",
+        action="store_true",
+        help="Continue copying if reading or processing a glyph causes an error. "
+        "The error will be logged, but the glyph will not be present in the output.",
+    )
+    parser.add_argument(
         "config",
         nargs="+",
         type=yaml_or_json,
@@ -123,7 +129,7 @@ async def mainAsync():
             nextInput = endPoints.endPoint
 
         for output in outputs:
-            await output.process(output_dir)
+            await output.process(output_dir, continueOnError=args.continue_on_error)
 
 
 def main():

--- a/test-py/data/workflow/input-error-glyph.fontra/font-data.json
+++ b/test-py/data/workflow/input-error-glyph.fontra/font-data.json
@@ -1,0 +1,7 @@
+{
+"unitsPerEm": 1000,
+"fontInfo": {},
+"axes": [],
+"sources": {},
+"customData": {}
+}

--- a/test-py/data/workflow/input-error-glyph.fontra/glyph-info.csv
+++ b/test-py/data/workflow/input-error-glyph.fontra/glyph-info.csv
@@ -1,0 +1,2 @@
+glyph name;code points
+A;U+0041,U+0061

--- a/test-py/data/workflow/input-error-glyph.fontra/glyphs/A^1.json
+++ b/test-py/data/workflow/input-error-glyph.fontra/glyphs/A^1.json
@@ -1,0 +1,1 @@
+json syntax error

--- a/test-py/data/workflow/output-error-glyph.fontra/font-data.json
+++ b/test-py/data/workflow/output-error-glyph.fontra/font-data.json
@@ -1,0 +1,7 @@
+{
+"unitsPerEm": 1000,
+"fontInfo": {},
+"axes": [],
+"sources": {},
+"customData": {}
+}

--- a/test-py/data/workflow/output-error-glyph.fontra/glyph-info.csv
+++ b/test-py/data/workflow/output-error-glyph.fontra/glyph-info.csv
@@ -1,0 +1,1 @@
+glyph name;code points

--- a/test-py/test_workflow.py
+++ b/test-py/test_workflow.py
@@ -625,6 +625,24 @@ def test_command(tmpdir, configYAMLSources):
             """,
             [],
         ),
+        (
+            "error-glyph",
+            """
+            steps:
+            - action: input
+              source: "test-py/data/workflow/input-error-glyph.fontra"
+
+            - action: output
+              destination: "output-error-glyph.fontra"
+            """,
+            [
+                (
+                    40,
+                    "glyph A caused an error: JSONDecodeError('Expecting value: line "
+                    "1 column 1 (char 0)')",
+                )
+            ],
+        ),
     ],
 )
 async def test_workflow_actions(testName, configSource, expectedLog, tmpdir, caplog):

--- a/test-py/test_workflow.py
+++ b/test-py/test_workflow.py
@@ -182,7 +182,14 @@ def test_command(tmpdir, configYAMLSources):
     expectedFileNames = [p.name for p in configPaths]
 
     subprocess.run(
-        ["fontra-workflow", *configPaths, "--output-dir", tmpdir], check=True
+        [
+            "fontra-workflow",
+            *configPaths,
+            "--output-dir",
+            tmpdir,
+            "--continue-on-error",
+        ],
+        check=True,
     )
     items = sorted([p.name for p in tmpdir.iterdir()])
     assert [*expectedFileNames, "testing.fontra"] == items

--- a/test-py/test_workflow.py
+++ b/test-py/test_workflow.py
@@ -656,7 +656,7 @@ async def test_workflow_actions(testName, configSource, expectedLog, tmpdir, cap
         assert endPoints.endPoint is not None
 
         for output in endPoints.outputs:
-            await output.process(tmpdir)
+            await output.process(tmpdir, continueOnError=True)
             expectedPath = workflowDataDir / output.destination
             resultPath = tmpdir / output.destination
             if expectedPath.is_file():


### PR DESCRIPTION
This adds `--continue-on-error` options to `fontra-copy` and `fonta-workflow`, and `continueOnError` arguments to `copyFont()` and `action.process()`.

Useful with wip fonts that contain interpolation errors.