### PR TITLE
Account for different XML parse errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,3 +145,7 @@ ignore_missing_imports = true
 [[tool.mypy.overrides]]
 module = "importlib.resources.abc"
 ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "lxml.etree"
+ignore_missing_imports = true

--- a/src/fontra/core/clipboard.py
+++ b/src/fontra/core/clipboard.py
@@ -1,3 +1,4 @@
+from typing import Any
 from xml.etree.ElementTree import ParseError
 
 from fontTools.pens.boundsPen import ControlBoundsPen
@@ -11,6 +12,14 @@ from fontTools.ufoLib.glifLib import readGlyphFromString, writeGlyphToString
 from ..backends.designspace import UFOGlyph, populateUFOLayerGlyph, readGlyphOrCreate
 from .classes import StaticGlyph
 from .path import PackedPathPointPen
+
+XMLErrors: tuple[Any, ...]
+try:
+    from lxml.etree import XMLSyntaxError
+except ImportError:
+    XMLErrors = (ParseError,)
+else:
+    XMLErrors = (ParseError, XMLSyntaxError)
 
 
 def parseClipboard(data: str) -> StaticGlyph | None:
@@ -26,7 +35,7 @@ def parseSVG(data: str) -> StaticGlyph | None:
         svgPath = SVGPath.fromstring(
             data.encode("utf-8"), transform=(1, 0, 0, -1, 0, 0)
         )
-    except ParseError:
+    except XMLErrors:
         return None
     recPen = RecordingPen()
     svgPath.draw(recPen)


### PR DESCRIPTION
Account for different XML parse errors: the exact exception depends on whether lxml is installed or not.

We don't require lxml, but the tests failed once lxml was installed.