### PR TITLE
Action memory-cache and disk-cache actions

### DIFF
--- a/test-py/test_workflow.py
+++ b/test-py/test_workflow.py
@@ -685,6 +685,19 @@ def test_command(tmpdir, configYAMLSources):
             """,
             [],
         ),
+        (
+            "cache-tests",
+            """
+            steps:
+            - action: input
+              source: "test-py/data/workflow/input1-A.fontra"
+            - action: memory-cache
+            - action: disk-cache
+            - action: output
+              destination: "input1-A.fontra"
+            """,
+            [],
+        ),
     ],
 )
 async def test_workflow_actions(testName, configSource, expectedLog, tmpdir, caplog):

--- a/test-py/test_workflow.py
+++ b/test-py/test_workflow.py
@@ -235,7 +235,7 @@ def test_command(tmpdir, configYAMLSources):
             ],
         ),
         (
-            "susbset+scale",
+            "subset+scale",
             """
             steps:
 


### PR DESCRIPTION
This fixes #1260.

These actions cache glyph data, either in memory, or on disk.