### PR TITLE
Simplify decomposed transformation

### DIFF
--- a/src/fontra/client/core/glyph-controller.js
+++ b/src/fontra/client/core/glyph-controller.js
@@ -18,8 +18,8 @@ import {
 } from "./representation-cache.js";
 import {
   Transform,
-  decomposedFromTransform,
   decomposedToTransform,
+  prependTransformToDecomposed,
 } from "./transform.js";
 import { enumerate, range } from "./utils.js";
 import { addItemwise } from "./var-funcs.js";
@@ -875,11 +875,9 @@ export async function decomposeComponents(
     const t = decomposedToTransform(component.transformation);
     newPaths.push(compoInstance.path.transformed(t));
     for (const nestedCompo of compoInstance.components) {
-      const nestedT = decomposedToTransform(nestedCompo.transformation);
-      const newNestedT = t.transform(nestedT);
       newComponents.push({
         name: nestedCompo.name,
-        transformation: decomposedFromTransform(newNestedT),
+        transformation: prependTransformToDecomposed(t, nestedCompo.transformation),
         location: { ...nestedCompo.location },
       });
     }

--- a/src/fontra/client/core/transform.js
+++ b/src/fontra/client/core/transform.js
@@ -281,10 +281,6 @@ export function getDecomposedIdentity() {
 }
 
 export function prependTransformToDecomposed(prependTransform, decomposed) {
-  if (!prependTransform) {
-    prependTransform = new Transform();
-  }
-
   const [tCenterX, tCenterY] = [decomposed.tCenterX, decomposed.tCenterY];
 
   const newTransform = new Transform()

--- a/src/fontra/client/core/transform.js
+++ b/src/fontra/client/core/transform.js
@@ -279,3 +279,22 @@ const decomposedIdentity = {
 export function getDecomposedIdentity() {
   return { ...decomposedIdentity };
 }
+
+export function prependTransformToDecomposed(prependTransform, decomposed) {
+  if (!prependTransform) {
+    prependTransform = new Transform();
+  }
+
+  const [tCenterX, tCenterY] = [decomposed.tCenterX, decomposed.tCenterY];
+
+  const newTransform = new Transform()
+    .translate(-tCenterX, -tCenterY)
+    .transform(prependTransform)
+    .transform(decomposedToTransform(decomposed))
+    .translate(tCenterX, tCenterY);
+
+  const newDecomposed = decomposedFromTransform(newTransform);
+  newDecomposed.tCenterX = tCenterX;
+  newDecomposed.tCenterY = tCenterY;
+  return newDecomposed;
+}

--- a/src/fontra/client/core/transform.js
+++ b/src/fontra/client/core/transform.js
@@ -286,6 +286,8 @@ export function prependTransformToDecomposed(prependTransform, decomposed) {
   //
   // `prependTransform` is a `Transform` instance
   // `decomposed` is a decomposed transform
+  // The return value is a decomposed transform
+  //
   // This operation ensures the `tCenterX` and `tCenterY` properties of the
   // `decomposed` transform are not lost.
   //

--- a/src/fontra/client/core/transform.js
+++ b/src/fontra/client/core/transform.js
@@ -281,6 +281,14 @@ export function getDecomposedIdentity() {
 }
 
 export function prependTransformToDecomposed(prependTransform, decomposed) {
+  //
+  // Prepend `prependTransform` to `decomposed`
+  //
+  // `prependTransform` is a `Transform` instance
+  // `decomposed` is a decomposed transform
+  // This operation ensures the `tCenterX` and `tCenterY` properties of the
+  // `decomposed` transform are not lost.
+  //
   const [tCenterX, tCenterY] = [decomposed.tCenterX, decomposed.tCenterY];
 
   const newTransform = new Transform()

--- a/src/fontra/views/editor/panel-transformation.js
+++ b/src/fontra/views/editor/panel-transformation.js
@@ -11,7 +11,7 @@ import { rectFromPoints, rectSize, unionRect } from "/core/rectangle.js";
 import {
   Transform,
   decomposedFromTransform,
-  decomposedToTransform,
+  prependTransformToDecomposed,
 } from "/core/transform.js";
 import { enumerate, parseSelection } from "/core/utils.js";
 import { copyComponent } from "/core/var-glyph.js";
@@ -443,22 +443,11 @@ export default class TransformationPanel extends Panel {
         const pointTransformFunction = t.transformPointObject.bind(t);
 
         const componentTransformFunction = (component, componentIndex) => {
-          const [tCenterX, tCenterY] = [
-            component.transformation.tCenterX,
-            component.transformation.tCenterY,
-          ];
-
-          const editedT = new Transform()
-            .translate(-tCenterX, -tCenterY)
-            .transform(t)
-            .transform(decomposedToTransform(component.transformation))
-            .translate(tCenterX, tCenterY);
-
           component = copyComponent(component);
-          component.transformation = decomposedFromTransform(editedT);
-          component.transformation.tCenterX = tCenterX;
-          component.transformation.tCenterY = tCenterY;
-
+          component.transformation = prependTransformToDecomposed(
+            t,
+            component.transformation
+          );
           return component;
         };
 

--- a/test-js/test-transform.js
+++ b/test-js/test-transform.js
@@ -7,6 +7,7 @@ import {
   decomposedFromTransform,
   decomposedToTransform,
   getDecomposedIdentity,
+  prependTransformToDecomposed,
 } from "../src/fontra/client/core/transform.js";
 import { parametrize } from "./test-support.js";
 
@@ -144,6 +145,52 @@ describe("DecomposedTransform", () => {
           decomposedFromTransform(decomposedToTransform(decomposed))
         )
       ).to.deep.almost.equals(decomposedToTransform(decomposed));
+    }
+  );
+});
+
+describe("prependTransformToDecomposed", () => {
+  parametrize(
+    "test name",
+    [
+      {
+        prependTransform: new Transform(),
+        decomposed: {},
+        expectedResult: {},
+      },
+      {
+        prependTransform: new Transform(),
+        decomposed: { rotation: 30 },
+        expectedResult: { rotation: 30 },
+      },
+      {
+        prependTransform: new Transform().rotate((30 * Math.PI) / 180),
+        decomposed: { rotation: 30 },
+        expectedResult: { rotation: 60 },
+      },
+      {
+        prependTransform: new Transform().rotate((30 * Math.PI) / 180),
+        decomposed: { rotation: 30, tCenterX: 50, tCenterY: 50 },
+        expectedResult: {
+          rotation: 60,
+          translateX: -31.698729810778058,
+          translateY: 18.301270189221924,
+          tCenterX: 50,
+          tCenterY: 50,
+        },
+      },
+    ],
+    (testData) => {
+      const decomposed = { ...getDecomposedIdentity(), ...testData.decomposed };
+      const expectedResult = { ...getDecomposedIdentity(), ...testData.expectedResult };
+      const result = prependTransformToDecomposed(
+        testData.prependTransform,
+        decomposed
+      );
+      expect(result).to.deep.almost.equal(expectedResult);
+      expect(decomposedToTransform(result)).to.deep.almost.equal(
+        decomposedToTransform(expectedResult)
+      );
     }
   );
 });


### PR DESCRIPTION
Put the functionality of transforming a decomposed transform into a function. This simplifies client code, and additionally makes us not lose the tCenterX/Y when decomposing a nested composite.