### PR TITLE
Prepara data structures and backend API for multi-axis-mapping (avar-2-style mapping)

### DIFF
--- a/src/fontra/backends/copy.py
+++ b/src/fontra/backends/copy.py
@@ -21,7 +21,7 @@ async def copyFont(
     continueOnError=False,
 ) -> None:
     await destBackend.putFontInfo(await sourceBackend.getFontInfo())
-    await destBackend.putGlobalAxes(await sourceBackend.getGlobalAxes())
+    await destBackend.putAxes(await sourceBackend.getAxes())
     await destBackend.putSources(await sourceBackend.getSources())
     await destBackend.putCustomData(await sourceBackend.getCustomData())
     glyphMap = await sourceBackend.getGlyphMap()

--- a/src/fontra/backends/designspace.py
+++ b/src/fontra/backends/designspace.py
@@ -37,8 +37,8 @@ from ..core.classes import (
     FontMetric,
     FontSource,
     GlyphAxis,
+    GlyphSource,
     Layer,
-    Source,
     StaticGlyph,
     VariableGlyph,
 )
@@ -356,7 +356,7 @@ class DesignspaceBackend:
             ufoLayer = self.ufoLayers.findItem(path=ufoPath, name=ufoLayerName)
             assert ufoLayer is not None
             sources.append(
-                Source(
+                GlyphSource(
                     name=sourceName,
                     location=source["location"],
                     layerName=ufoLayer.fontraLayerName,
@@ -1039,7 +1039,7 @@ class DSSource:
     def newFontraSource(self, localDefaultOverride=None):
         if localDefaultOverride is None:
             localDefaultOverride = {}
-        return Source(
+        return GlyphSource(
             name=self.name,
             location={**self.location, **localDefaultOverride},
             layerName=self.layer.fontraLayerName,

--- a/src/fontra/backends/designspace.py
+++ b/src/fontra/backends/designspace.py
@@ -32,9 +32,9 @@ from ..core.classes import (
     AxisValueLabel,
     Component,
     FontInfo,
+    FontMetric,
     GlobalAxis,
     GlobalDiscreteAxis,
-    GlobalMetric,
     GlobalSource,
     Layer,
     LocalAxis,
@@ -950,7 +950,7 @@ def unpackDSSource(dsSource: DSSource, unitsPerEm: int) -> GlobalSource:
         value = getattr(fontInfo, name, None)
         if value is None:
             value = round(defaultFactor * unitsPerEm)
-        verticalMetrics[name] = GlobalMetric(value=value)
+        verticalMetrics[name] = FontMetric(value=value)
 
     return GlobalSource(
         name=dsSource.name,

--- a/src/fontra/backends/designspace.py
+++ b/src/fontra/backends/designspace.py
@@ -28,6 +28,7 @@ from fontTools.ufoLib import UFOReaderWriter
 from fontTools.ufoLib.glifLib import GlyphSet
 
 from ..core.classes import (
+    Axes,
     AxisValueLabel,
     Component,
     FontInfo,
@@ -646,12 +647,12 @@ class DesignspaceBackend:
                 infoDict[ufoName] = value
         self._updateUFOFontInfo(infoDict)
 
-    async def getGlobalAxes(self) -> list[GlobalAxis | GlobalDiscreteAxis]:
-        return self.axes
+    async def getAxes(self) -> Axes:
+        return Axes(axes=self.axes)
 
-    async def putGlobalAxes(self, axes):
+    async def putAxes(self, axes):
         self.dsDoc.axes = []
-        for axis in axes:
+        for axis in axes.axes:
             axisParameters = dict(
                 name=axis.name,
                 tag=axis.tag,
@@ -975,8 +976,8 @@ class UFOBackend(DesignspaceBackend):
         dsDoc = createDSDocFromUFOPath(path, "default")
         return cls(dsDoc)
 
-    async def putGlobalAxes(self, axes):
-        if axes:
+    async def putAxes(self, axes):
+        if axes.axes:
             raise ValueError("The single-UFO backend does not support variation axes")
 
     async def putSources(self, sources: dict[str, GlobalSource]) -> None:

--- a/src/fontra/backends/designspace.py
+++ b/src/fontra/backends/designspace.py
@@ -31,11 +31,11 @@ from ..core.classes import (
     Axes,
     AxisValueLabel,
     Component,
+    DiscreteFontAxis,
+    FontAxis,
     FontInfo,
     FontMetric,
     FontSource,
-    GlobalAxis,
-    GlobalDiscreteAxis,
     Layer,
     LocalAxis,
     Source,
@@ -660,11 +660,11 @@ class DesignspaceBackend:
                 map=deepcopy(axis.mapping) if axis.mapping else None,
                 axisLabels=packAxisLabels(axis.valueLabels),
             )
-            if isinstance(axis, GlobalAxis):
+            if isinstance(axis, FontAxis):
                 axisParameters["minimum"] = axis.minValue
                 axisParameters["maximum"] = axis.maxValue
             else:
-                assert isinstance(axis, GlobalDiscreteAxis)
+                assert isinstance(axis, DiscreteFontAxis)
                 axisParameters["values"] = axis.values
             self.dsDoc.addAxisDescriptor(**axisParameters)
         self._writeDesignSpaceDocument()
@@ -871,7 +871,7 @@ class DesignspaceBackend:
 
 @singledispatch
 def unpackDSAxis(dsAxis: AxisDescriptor):
-    axis = GlobalAxis(
+    axis = FontAxis(
         minValue=dsAxis.minimum,
         defaultValue=dsAxis.default,
         maxValue=dsAxis.maximum,
@@ -889,7 +889,7 @@ def unpackDSAxis(dsAxis: AxisDescriptor):
 
 @unpackDSAxis.register
 def _(dsAxis: DiscreteAxisDescriptor):
-    axis = GlobalDiscreteAxis(
+    axis = DiscreteFontAxis(
         values=dsAxis.values,
         defaultValue=dsAxis.default,
         label=dsAxis.name,

--- a/src/fontra/backends/designspace.py
+++ b/src/fontra/backends/designspace.py
@@ -36,8 +36,8 @@ from ..core.classes import (
     FontInfo,
     FontMetric,
     FontSource,
+    GlyphAxis,
     Layer,
-    LocalAxis,
     Source,
     StaticGlyph,
     VariableGlyph,
@@ -325,7 +325,7 @@ class DesignspaceBackend:
 
     def _unpackLocalDesignSpace(self, dsDict, defaultLayerName):
         axes = [
-            LocalAxis(
+            GlyphAxis(
                 name=axis["name"],
                 minValue=axis["minimum"],
                 defaultValue=axis["default"],

--- a/src/fontra/backends/designspace.py
+++ b/src/fontra/backends/designspace.py
@@ -33,9 +33,9 @@ from ..core.classes import (
     Component,
     FontInfo,
     FontMetric,
+    FontSource,
     GlobalAxis,
     GlobalDiscreteAxis,
-    GlobalSource,
     Layer,
     LocalAxis,
     Source,
@@ -671,14 +671,14 @@ class DesignspaceBackend:
         self.updateAxisInfo()
         self.loadUFOLayers()
 
-    async def getSources(self) -> dict[str, GlobalSource]:
+    async def getSources(self) -> dict[str, FontSource]:
         unitsPerEm = await self.getUnitsPerEm()
         return {
             dsSource.uuid: unpackDSSource(dsSource, unitsPerEm)
             for dsSource in self.dsSources
         }
 
-    async def putSources(self, sources: dict[str, GlobalSource]) -> None:
+    async def putSources(self, sources: dict[str, FontSource]) -> None:
         # TODO: this may require rewriting UFOs and UFO layers
         # Also: what to do if a source gets deleted?
         pass
@@ -942,7 +942,7 @@ def packAxisLabels(valueLabels):
     ]
 
 
-def unpackDSSource(dsSource: DSSource, unitsPerEm: int) -> GlobalSource:
+def unpackDSSource(dsSource: DSSource, unitsPerEm: int) -> FontSource:
     fontInfo = UFOFontInfo()
     dsSource.layer.reader.readInfo(fontInfo)
     verticalMetrics = {}
@@ -952,7 +952,7 @@ def unpackDSSource(dsSource: DSSource, unitsPerEm: int) -> GlobalSource:
             value = round(defaultFactor * unitsPerEm)
         verticalMetrics[name] = FontMetric(value=value)
 
-    return GlobalSource(
+    return FontSource(
         name=dsSource.name,
         location=dsSource.location,
         verticalMetrics=verticalMetrics,
@@ -980,7 +980,7 @@ class UFOBackend(DesignspaceBackend):
         if axes.axes:
             raise ValueError("The single-UFO backend does not support variation axes")
 
-    async def putSources(self, sources: dict[str, GlobalSource]) -> None:
+    async def putSources(self, sources: dict[str, FontSource]) -> None:
         if len(sources) > 1:
             raise ValueError("The single-UFO backend does not support multiple sources")
 

--- a/src/fontra/backends/fontra.py
+++ b/src/fontra/backends/fontra.py
@@ -12,7 +12,7 @@ from fontra.core.classes import (
     Axes,
     Font,
     FontInfo,
-    GlobalSource,
+    FontSource,
     VariableGlyph,
     structure,
     unstructure,
@@ -132,10 +132,10 @@ class FontraBackend:
         self.fontData.axes = deepcopy(axes)
         self._scheduler.schedule(self._writeFontData)
 
-    async def getSources(self) -> dict[str, GlobalSource]:
+    async def getSources(self) -> dict[str, FontSource]:
         return {}
 
-    async def putSources(self, sources: dict[str, GlobalSource]) -> None:
+    async def putSources(self, sources: dict[str, FontSource]) -> None:
         self.fontData.sources = deepcopy(sources)
         self._scheduler.schedule(self._writeFontData)
 

--- a/src/fontra/backends/fontra.py
+++ b/src/fontra/backends/fontra.py
@@ -9,10 +9,9 @@ from dataclasses import dataclass, field
 from typing import Any, Callable
 
 from fontra.core.classes import (
+    Axes,
     Font,
     FontInfo,
-    GlobalAxis,
-    GlobalDiscreteAxis,
     GlobalSource,
     VariableGlyph,
     structure,
@@ -126,10 +125,10 @@ class FontraBackend:
         self.fontData.fontInfo = deepcopy(fontInfo)
         self._scheduler.schedule(self._writeFontData)
 
-    async def getGlobalAxes(self) -> list[GlobalAxis | GlobalDiscreteAxis]:
+    async def getAxes(self) -> Axes:
         return deepcopy(self.fontData.axes)
 
-    async def putGlobalAxes(self, axes: list[GlobalAxis | GlobalDiscreteAxis]) -> None:
+    async def putAxes(self, axes: Axes) -> None:
         self.fontData.axes = deepcopy(axes)
         self._scheduler.schedule(self._writeFontData)
 

--- a/src/fontra/backends/opentype.py
+++ b/src/fontra/backends/opentype.py
@@ -8,6 +8,7 @@ from fontTools.ttLib import TTFont
 from fontra.core.protocols import ReadableFontBackend
 
 from ..core.classes import (
+    Axes,
     FontInfo,
     GlobalAxis,
     GlobalDiscreteAxis,
@@ -113,8 +114,8 @@ class OTFBackend:
     async def getFontInfo(self) -> FontInfo:
         return FontInfo()
 
-    async def getGlobalAxes(self) -> list[GlobalAxis | GlobalDiscreteAxis]:
-        return self.globalAxes
+    async def getAxes(self) -> Axes:
+        return Axes(axes=self.globalAxes)
 
     async def getSources(self) -> dict[str, GlobalSource]:
         return {}

--- a/src/fontra/backends/opentype.py
+++ b/src/fontra/backends/opentype.py
@@ -10,9 +10,9 @@ from fontra.core.protocols import ReadableFontBackend
 from ..core.classes import (
     Axes,
     FontInfo,
+    FontSource,
     GlobalAxis,
     GlobalDiscreteAxis,
-    GlobalSource,
     Layer,
     Source,
     StaticGlyph,
@@ -117,7 +117,7 @@ class OTFBackend:
     async def getAxes(self) -> Axes:
         return Axes(axes=self.globalAxes)
 
-    async def getSources(self) -> dict[str, GlobalSource]:
+    async def getSources(self) -> dict[str, FontSource]:
         return {}
 
     async def getUnitsPerEm(self) -> int:

--- a/src/fontra/backends/opentype.py
+++ b/src/fontra/backends/opentype.py
@@ -13,8 +13,8 @@ from ..core.classes import (
     FontAxis,
     FontInfo,
     FontSource,
+    GlyphSource,
     Layer,
-    Source,
     StaticGlyph,
     VariableGlyph,
 )
@@ -62,7 +62,7 @@ class OTFBackend:
         layers = {defaultLayerName: Layer(glyph=staticGlyph)}
         defaultLocation = {axis.name: 0.0 for axis in self.globalAxes}
         sources = [
-            Source(
+            GlyphSource(
                 location=defaultLocation,
                 name=defaultLayerName,
                 layerName=defaultLayerName,
@@ -77,7 +77,7 @@ class OTFBackend:
                 self.variationGlyphSets[locStr] = varGlyphSet
             varGlyph = buildStaticGlyph(varGlyphSet, glyphName)
             layers[locStr] = Layer(glyph=varGlyph)
-            sources.append(Source(location=fullLoc, name=locStr, layerName=locStr))
+            sources.append(GlyphSource(location=fullLoc, name=locStr, layerName=locStr))
         if self.charStrings is not None:
             checkAndFixCFF2Compatibility(glyphName, layers)
         glyph.layers = layers

--- a/src/fontra/backends/opentype.py
+++ b/src/fontra/backends/opentype.py
@@ -9,10 +9,10 @@ from fontra.core.protocols import ReadableFontBackend
 
 from ..core.classes import (
     Axes,
+    DiscreteFontAxis,
+    FontAxis,
     FontInfo,
     FontSource,
-    GlobalAxis,
-    GlobalDiscreteAxis,
     Layer,
     Source,
     StaticGlyph,
@@ -144,7 +144,7 @@ def getLocationsFromVarstore(
         yield location
 
 
-def unpackAxes(font: TTFont) -> list[GlobalAxis | GlobalDiscreteAxis]:
+def unpackAxes(font: TTFont) -> list[FontAxis | DiscreteFontAxis]:
     fvar = font.get("fvar")
     if fvar is None:
         return []
@@ -155,7 +155,7 @@ def unpackAxes(font: TTFont) -> list[GlobalAxis | GlobalDiscreteAxis]:
         if avar is not None
         else {}
     )
-    axisList: list[GlobalAxis | GlobalDiscreteAxis] = []
+    axisList: list[FontAxis | DiscreteFontAxis] = []
     for axis in fvar.axes:
         normMin = -1 if axis.minValue < axis.defaultValue else 0
         normMax = 1 if axis.maxValue > axis.defaultValue else 0
@@ -183,7 +183,7 @@ def unpackAxes(font: TTFont) -> list[GlobalAxis | GlobalDiscreteAxis]:
             axisNameRecord.toUnicode() if axisNameRecord is not None else axis.axisTag
         )
         axisList.append(
-            GlobalAxis(
+            FontAxis(
                 minValue=axis.minValue,
                 defaultValue=axis.defaultValue,
                 maxValue=axis.maxValue,

--- a/src/fontra/backends/workflow.py
+++ b/src/fontra/backends/workflow.py
@@ -3,13 +3,7 @@ from typing import Any
 
 import yaml
 
-from ..core.classes import (
-    FontInfo,
-    GlobalAxis,
-    GlobalDiscreteAxis,
-    GlobalSource,
-    VariableGlyph,
-)
+from ..core.classes import Axes, FontInfo, GlobalSource, VariableGlyph
 from ..core.protocols import ReadableFontBackend
 from ..workflow.workflow import Workflow
 
@@ -44,9 +38,9 @@ class WorkflowBackend:
         endPoint = await self._ensureSetup()
         return await endPoint.getFontInfo()
 
-    async def getGlobalAxes(self) -> list[GlobalAxis | GlobalDiscreteAxis]:
+    async def getAxes(self) -> Axes:
         endPoint = await self._ensureSetup()
-        return await endPoint.getGlobalAxes()
+        return await endPoint.getAxes()
 
     async def getSources(self) -> dict[str, GlobalSource]:
         endPoint = await self._ensureSetup()

--- a/src/fontra/backends/workflow.py
+++ b/src/fontra/backends/workflow.py
@@ -3,7 +3,7 @@ from typing import Any
 
 import yaml
 
-from ..core.classes import Axes, FontInfo, GlobalSource, VariableGlyph
+from ..core.classes import Axes, FontInfo, FontSource, VariableGlyph
 from ..core.protocols import ReadableFontBackend
 from ..workflow.workflow import Workflow
 
@@ -42,7 +42,7 @@ class WorkflowBackend:
         endPoint = await self._ensureSetup()
         return await endPoint.getAxes()
 
-    async def getSources(self) -> dict[str, GlobalSource]:
+    async def getSources(self) -> dict[str, FontSource]:
         endPoint = await self._ensureSetup()
         return await endPoint.getSources()
 

--- a/src/fontra/client/core/classes.json
+++ b/src/fontra/client/core/classes.json
@@ -94,7 +94,7 @@
     },
     "axes": {
       "type": "list",
-      "subtype": "LocalAxis"
+      "subtype": "GlyphAxis"
     },
     "sources": {
       "type": "list",
@@ -109,7 +109,7 @@
       "subtype": "Any"
     }
   },
-  "LocalAxis": {
+  "GlyphAxis": {
     "name": {
       "type": "str"
     },

--- a/src/fontra/client/core/classes.json
+++ b/src/fontra/client/core/classes.json
@@ -443,7 +443,7 @@
     },
     "verticalMetrics": {
       "type": "dict",
-      "subtype": "GlobalMetric"
+      "subtype": "FontMetric"
     },
     "guidelines": {
       "type": "list",
@@ -454,7 +454,7 @@
       "subtype": "Any"
     }
   },
-  "GlobalMetric": {
+  "FontMetric": {
     "value": {
       "type": "float"
     },

--- a/src/fontra/client/core/classes.json
+++ b/src/fontra/client/core/classes.json
@@ -314,7 +314,7 @@
   "Axes": {
     "axes": {
       "type": "list",
-      "subtype": "GlobalAxis"
+      "subtype": "FontAxis"
     },
     "mappings": {
       "type": "list",
@@ -329,7 +329,7 @@
       "subtype": "Any"
     }
   },
-  "GlobalAxis": {
+  "FontAxis": {
     "name": {
       "type": "str"
     },
@@ -390,7 +390,7 @@
       "type": "bool"
     }
   },
-  "GlobalDiscreteAxis": {
+  "DiscreteFontAxis": {
     "name": {
       "type": "str"
     },

--- a/src/fontra/client/core/classes.json
+++ b/src/fontra/client/core/classes.json
@@ -14,17 +14,16 @@
       "type": "dict",
       "subtype": "list"
     },
-    "customData": {
-      "type": "dict",
-      "subtype": "Any"
-    },
     "axes": {
-      "type": "list",
-      "subtype": "GlobalAxis"
+      "type": "Axes"
     },
     "sources": {
       "type": "dict",
       "subtype": "GlobalSource"
+    },
+    "customData": {
+      "type": "dict",
+      "subtype": "Any"
     }
   },
   "FontInfo": {
@@ -312,6 +311,24 @@
       "subtype": "Any"
     }
   },
+  "Axes": {
+    "axes": {
+      "type": "list",
+      "subtype": "GlobalAxis"
+    },
+    "mappings": {
+      "type": "list",
+      "subtype": "MultipleAxisMapping"
+    },
+    "elidedFallBackname": {
+      "type": "str",
+      "optional": true
+    },
+    "customData": {
+      "type": "dict",
+      "subtype": "Any"
+    }
+  },
   "GlobalAxis": {
     "name": {
       "type": "str"
@@ -404,6 +421,16 @@
     "customData": {
       "type": "dict",
       "subtype": "Any"
+    }
+  },
+  "MultipleAxisMapping": {
+    "inputLocation": {
+      "type": "dict",
+      "subtype": "float"
+    },
+    "outputLocation": {
+      "type": "dict",
+      "subtype": "float"
     }
   },
   "GlobalSource": {

--- a/src/fontra/client/core/classes.json
+++ b/src/fontra/client/core/classes.json
@@ -98,7 +98,7 @@
     },
     "sources": {
       "type": "list",
-      "subtype": "Source"
+      "subtype": "GlyphSource"
     },
     "layers": {
       "type": "dict",
@@ -127,7 +127,7 @@
       "subtype": "Any"
     }
   },
-  "Source": {
+  "GlyphSource": {
     "name": {
       "type": "str"
     },

--- a/src/fontra/client/core/classes.json
+++ b/src/fontra/client/core/classes.json
@@ -19,7 +19,7 @@
     },
     "sources": {
       "type": "dict",
-      "subtype": "GlobalSource"
+      "subtype": "FontSource"
     },
     "customData": {
       "type": "dict",
@@ -433,7 +433,7 @@
       "subtype": "float"
     }
   },
-  "GlobalSource": {
+  "FontSource": {
     "name": {
       "type": "str"
     },

--- a/src/fontra/client/core/font-controller.js
+++ b/src/fontra/client/core/font-controller.js
@@ -68,7 +68,7 @@ export class FontController {
   }
 
   get glyphMap() {
-    return this._rootObject["glyphMap"];
+    return this._rootObject.glyphMap;
   }
 
   get globalAxes() {
@@ -76,11 +76,11 @@ export class FontController {
   }
 
   get unitsPerEm() {
-    return this._rootObject["unitsPerEm"];
+    return this._rootObject.unitsPerEm;
   }
 
   get customData() {
-    return this._rootObject["customData"];
+    return this._rootObject.customData;
   }
 
   async getData(key) {

--- a/src/fontra/client/core/font-controller.js
+++ b/src/fontra/client/core/font-controller.js
@@ -71,6 +71,10 @@ export class FontController {
     return this._rootObject.glyphMap;
   }
 
+  get axes() {
+    return this._rootObject.axes;
+  }
+
   get globalAxes() {
     return this._rootObject.axes.axes;
   }

--- a/src/fontra/client/core/font-controller.js
+++ b/src/fontra/client/core/font-controller.js
@@ -41,7 +41,7 @@ export class FontController {
     this.characterMap = makeCharacterMapFromGlyphMap(glyphMap, false);
     this._rootObject = {};
     this._rootObject["glyphMap"] = getGlyphMapProxy(glyphMap, this.characterMap);
-    this._rootObject["axes"] = await this.font.getGlobalAxes();
+    this._rootObject["axes"] = await this.font.getAxes();
     this._rootObject["unitsPerEm"] = await this.font.getUnitsPerEm();
     this._rootObject["customData"] = await this.font.getCustomData();
     this._rootClassDef = (await getClassSchema())["Font"];
@@ -72,7 +72,7 @@ export class FontController {
   }
 
   get globalAxes() {
-    return this._rootObject["axes"];
+    return this._rootObject.axes.axes;
   }
 
   get unitsPerEm() {

--- a/src/fontra/client/core/ui-utils.js
+++ b/src/fontra/client/core/ui-utils.js
@@ -39,7 +39,9 @@ export function setupSortableList(listContainer) {
     });
 
     // Inserting the dragging item before the found sibling
-    listContainer.insertBefore(draggingItem, nextSibling);
+    if (draggingItem.nextSibling != nextSibling) {
+      listContainer.insertBefore(draggingItem, nextSibling);
+    }
   });
 
   listContainer.addEventListener("dragenter", (event) => event.preventDefault());

--- a/src/fontra/client/core/var-glyph.js
+++ b/src/fontra/client/core/var-glyph.js
@@ -9,7 +9,7 @@ export class VariableGlyph {
       obj.axes?.map((axis) => {
         return { ...axis };
       }) || [];
-    glyph.sources = obj.sources.map((source) => Source.fromObject(source));
+    glyph.sources = obj.sources.map((source) => GlyphSource.fromObject(source));
     glyph.layers = Object.fromEntries(
       Object.entries(obj.layers).map(([name, layer]) => [name, Layer.fromObject(layer)])
     );
@@ -31,9 +31,9 @@ export class Layer {
   }
 }
 
-export class Source {
+export class GlyphSource {
   static fromObject(obj) {
-    const source = new Source();
+    const source = new GlyphSource();
     source.name = obj.name;
     source.location = { ...obj.location } || {};
     source.layerName = obj.layerName;

--- a/src/fontra/core/classes.py
+++ b/src/fontra/core/classes.py
@@ -32,7 +32,7 @@ class FontInfo:
 
 @dataclass(kw_only=True)
 class Axes:
-    axes: list[Union[GlobalAxis, GlobalDiscreteAxis]] = field(default_factory=list)
+    axes: list[Union[FontAxis, DiscreteFontAxis]] = field(default_factory=list)
     mappings: list[MultipleAxisMapping] = field(default_factory=list)
     elidedFallBackname: Optional[str] = None
     customData: CustomData = field(default_factory=dict)
@@ -122,7 +122,7 @@ class AxisValueLabel:
 
 
 @dataclass(kw_only=True)
-class GlobalAxis:
+class FontAxis:
     name: str  # this identifies the axis
     label: str  # a user friendly label
     tag: str  # the opentype 4-char tag
@@ -136,7 +136,7 @@ class GlobalAxis:
 
 
 @dataclass(kw_only=True)
-class GlobalDiscreteAxis:
+class DiscreteFontAxis:
     name: str  # this identifies the axis
     label: str  # a user friendly label
     tag: str  # the opentype 4-char tag
@@ -314,9 +314,9 @@ def _structurePath(d, tp):
 
 def _structureGlobalAxis(d, tp):
     if "values" not in d:
-        return structure(d, GlobalAxis)
+        return structure(d, FontAxis)
     else:
-        return structure(d, GlobalDiscreteAxis)
+        return structure(d, DiscreteFontAxis)
 
 
 def _structureNumber(d, tp):
@@ -370,7 +370,7 @@ _cattrsConverter = cattrs.Converter()
 _cattrsConverter.register_unstructure_hook(float, _unstructureFloat)
 _cattrsConverter.register_structure_hook(Union[PackedPath, Path], _structurePath)
 _cattrsConverter.register_structure_hook(
-    Union[GlobalAxis, GlobalDiscreteAxis], _structureGlobalAxis
+    Union[FontAxis, DiscreteFontAxis], _structureGlobalAxis
 )
 _cattrsConverter.register_structure_hook(float, _structureNumber)
 _cattrsConverter.register_structure_hook(Point, _structurePoint)
@@ -424,8 +424,8 @@ registerHook(
     verticalMetrics=_unstructureDictSorted,
     customData=_unstructureDictSortedRecursively,
 )
-registerHook(GlobalAxis, customData=_unstructureDictSortedRecursively)
-registerHook(GlobalDiscreteAxis, customData=_unstructureDictSortedRecursively)
+registerHook(FontAxis, customData=_unstructureDictSortedRecursively)
+registerHook(DiscreteFontAxis, customData=_unstructureDictSortedRecursively)
 registerHook(FontInfo, customData=_unstructureDictSortedRecursively)
 registerHook(Axes, customData=_unstructureDictSortedRecursively)
 registerHook(

--- a/src/fontra/core/classes.py
+++ b/src/fontra/core/classes.py
@@ -149,7 +149,7 @@ class DiscreteFontAxis:
 
 
 @dataclass(kw_only=True)
-class LocalAxis:
+class GlyphAxis:
     name: str
     minValue: float
     defaultValue: float
@@ -160,7 +160,7 @@ class LocalAxis:
 @dataclass(kw_only=True)
 class VariableGlyph:
     name: str
-    axes: list[LocalAxis] = field(default_factory=list)
+    axes: list[GlyphAxis] = field(default_factory=list)
     sources: list[Source] = field(default_factory=list)
     layers: dict[str, Layer] = field(default_factory=dict)
     customData: CustomData = field(default_factory=dict)
@@ -401,7 +401,7 @@ registerHook(
     location=_unstructureDictSorted,
     customData=_unstructureDictSortedRecursively,
 )
-registerHook(LocalAxis, customData=_unstructureDictSortedRecursively)
+registerHook(GlyphAxis, customData=_unstructureDictSortedRecursively)
 registerHook(StaticGlyph, customData=_unstructureDictSortedRecursively)
 registerHook(
     Source,

--- a/src/fontra/core/classes.py
+++ b/src/fontra/core/classes.py
@@ -31,12 +31,32 @@ class FontInfo:
 
 
 @dataclass(kw_only=True)
+class Axes:
+    axes: list[Union[GlobalAxis, GlobalDiscreteAxis]] = field(default_factory=list)
+    mappings: list[MultipleAxisMapping] = field(default_factory=list)
+    elidedFallBackname: Optional[str] = None
+    customData: CustomData = field(default_factory=dict)
+
+
+@dataclass(kw_only=True)
+class MultipleAxisMapping:
+    inputLocation: Location
+    outputLocation: Location
+
+
+@dataclass(kw_only=True)
+class SingleAxisMapping:
+    inputUserValue: float
+    outputUserValue: float
+
+
+@dataclass(kw_only=True)
 class Font:
     unitsPerEm: int = 1000
     fontInfo: FontInfo = field(default_factory=FontInfo)
     glyphs: dict[str, VariableGlyph] = field(default_factory=dict)
     glyphMap: dict[str, list[int]] = field(default_factory=dict)
-    axes: list[Union[GlobalAxis, GlobalDiscreteAxis]] = field(default_factory=list)
+    axes: Axes = field(default_factory=Axes)
     sources: dict[str, GlobalSource] = field(default_factory=dict)
     customData: CustomData = field(default_factory=dict)
 
@@ -397,6 +417,7 @@ registerHook(
 registerHook(GlobalAxis, customData=_unstructureDictSortedRecursively)
 registerHook(GlobalDiscreteAxis, customData=_unstructureDictSortedRecursively)
 registerHook(FontInfo, customData=_unstructureDictSortedRecursively)
+registerHook(Axes, customData=_unstructureDictSortedRecursively)
 registerHook(
     Font,
     omitIfDefault=False,

--- a/src/fontra/core/classes.py
+++ b/src/fontra/core/classes.py
@@ -161,7 +161,7 @@ class GlyphAxis:
 class VariableGlyph:
     name: str
     axes: list[GlyphAxis] = field(default_factory=list)
-    sources: list[Source] = field(default_factory=list)
+    sources: list[GlyphSource] = field(default_factory=list)
     layers: dict[str, Layer] = field(default_factory=dict)
     customData: CustomData = field(default_factory=dict)
 
@@ -173,7 +173,7 @@ class VariableGlyph:
 
 
 @dataclass(kw_only=True)
-class Source:
+class GlyphSource:
     name: str
     layerName: str
     location: Location = field(default_factory=dict)
@@ -404,7 +404,7 @@ registerHook(
 registerHook(GlyphAxis, customData=_unstructureDictSortedRecursively)
 registerHook(StaticGlyph, customData=_unstructureDictSortedRecursively)
 registerHook(
-    Source,
+    GlyphSource,
     location=_unstructureDictSorted,
     customData=_unstructureDictSortedRecursively,
 )

--- a/src/fontra/core/classes.py
+++ b/src/fontra/core/classes.py
@@ -340,6 +340,15 @@ def _unstructurePointType(v):
     return int(v)
 
 
+def _structureAxes(v, tp):
+    if isinstance(v, list):
+        # old format
+        v = {"axes": v}
+
+    fieldTypes = get_type_hints(tp)
+    return Axes(**{n: structure(vv, fieldTypes[n]) for n, vv in v.items()})
+
+
 def _unstructureDictSorted(v):
     return unstructure(dict(sorted(v.items())))
 
@@ -369,6 +378,7 @@ _cattrsConverter.register_unstructure_hook(Point, _unstructurePoint)
 _cattrsConverter.register_structure_hook(bool, lambda x, y: x)
 _cattrsConverter.register_structure_hook(PointType, _structurePointType)
 _cattrsConverter.register_unstructure_hook(PointType, _unstructurePointType)
+_cattrsConverter.register_structure_hook(Axes, _structureAxes)
 
 
 def registerHook(cls, omitIfDefault=True, **fieldHooks):

--- a/src/fontra/core/classes.py
+++ b/src/fontra/core/classes.py
@@ -74,7 +74,7 @@ class Font:
 class GlobalSource:
     name: str
     location: Location = field(default_factory=dict)
-    verticalMetrics: dict[str, GlobalMetric] = field(default_factory=dict)
+    verticalMetrics: dict[str, FontMetric] = field(default_factory=dict)
     guidelines: list[Union[Guideline, HorizontalGuideline, VerticalGuideline]] = field(
         default_factory=list
     )
@@ -82,7 +82,7 @@ class GlobalSource:
 
 
 @dataclass(kw_only=True)
-class GlobalMetric:
+class FontMetric:
     value: float
     customData: CustomData = field(default_factory=dict)
 
@@ -417,7 +417,7 @@ registerHook(
 registerHook(Path)
 registerHook(PackedPath)
 registerHook(AxisValueLabel)
-registerHook(GlobalMetric, customData=_unstructureDictSortedRecursively)
+registerHook(FontMetric, customData=_unstructureDictSortedRecursively)
 registerHook(
     GlobalSource,
     location=_unstructureDictSorted,

--- a/src/fontra/core/classes.py
+++ b/src/fontra/core/classes.py
@@ -57,7 +57,7 @@ class Font:
     glyphs: dict[str, VariableGlyph] = field(default_factory=dict)
     glyphMap: dict[str, list[int]] = field(default_factory=dict)
     axes: Axes = field(default_factory=Axes)
-    sources: dict[str, GlobalSource] = field(default_factory=dict)
+    sources: dict[str, FontSource] = field(default_factory=dict)
     customData: CustomData = field(default_factory=dict)
 
     def _trackAssignedAttributeNames(self):
@@ -71,7 +71,7 @@ class Font:
 
 
 @dataclass(kw_only=True)
-class GlobalSource:
+class FontSource:
     name: str
     location: Location = field(default_factory=dict)
     verticalMetrics: dict[str, FontMetric] = field(default_factory=dict)
@@ -419,7 +419,7 @@ registerHook(PackedPath)
 registerHook(AxisValueLabel)
 registerHook(FontMetric, customData=_unstructureDictSortedRecursively)
 registerHook(
-    GlobalSource,
+    FontSource,
     location=_unstructureDictSorted,
     verticalMetrics=_unstructureDictSorted,
     customData=_unstructureDictSortedRecursively,

--- a/src/fontra/core/fonthandler.py
+++ b/src/fontra/core/fonthandler.py
@@ -193,7 +193,7 @@ class FontHandler:
             case "sources":
                 value = await self.backend.getSources()
             case "axes":
-                value = await self.backend.getGlobalAxes()
+                value = await self.backend.getAxes()
             case "glyphMap":
                 value = await self.backend.getGlyphMap()
             case "customData":
@@ -213,7 +213,7 @@ class FontHandler:
             case "sources":
                 await self.writableBackend.putSources(value)
             case "axes":
-                await self.writableBackend.putGlobalAxes(value)
+                await self.writableBackend.putAxes(value)
             case "glyphMap":
                 await self.writableBackend.putGlyphMap(value)
             case "customData":
@@ -237,7 +237,7 @@ class FontHandler:
         return await self.getData("sources")
 
     @remoteMethod
-    async def getGlobalAxes(self, *, connection):
+    async def getAxes(self, *, connection):
         return await self.getData("axes")
 
     @remoteMethod

--- a/src/fontra/core/fonthandler.py
+++ b/src/fontra/core/fonthandler.py
@@ -19,7 +19,7 @@ from .changes import (
     patternIntersect,
     patternUnion,
 )
-from .classes import Font, FontInfo, GlobalSource, VariableGlyph
+from .classes import Font, FontInfo, FontSource, VariableGlyph
 from .lrucache import LRUCache
 from .protocols import ReadableFontBackend, WatchableFontBackend, WritableFontBackend
 
@@ -233,7 +233,7 @@ class FontHandler:
         return await self.getData("fontInfo")
 
     @remoteMethod
-    async def getSources(self, *, connection=None) -> dict[str, GlobalSource]:
+    async def getSources(self, *, connection=None) -> dict[str, FontSource]:
         return await self.getData("sources")
 
     @remoteMethod

--- a/src/fontra/core/instancer.py
+++ b/src/fontra/core/instancer.py
@@ -16,8 +16,8 @@ from .classes import (
     Component,
     DiscreteFontAxis,
     FontAxis,
+    GlyphAxis,
     Layer,
-    LocalAxis,
     Source,
     StaticGlyph,
     VariableGlyph,
@@ -239,7 +239,7 @@ class GlyphInstancer:
         ]
 
     @cached_property
-    def combinedAxes(self) -> list[LocalAxis]:
+    def combinedAxes(self) -> list[GlyphAxis]:
         combinedAxes = list(self.glyph.axes)
         localAxisNames = {axis.name for axis in self.glyph.axes}
         for axis in self.globalAxes:
@@ -250,7 +250,7 @@ class GlyphInstancer:
                 # Skip discrete axes
                 continue
             combinedAxes.append(
-                LocalAxis(
+                GlyphAxis(
                     name=axis.name,
                     minValue=mapFunc(axis.minValue),
                     defaultValue=mapFunc(axis.defaultValue),

--- a/src/fontra/core/instancer.py
+++ b/src/fontra/core/instancer.py
@@ -17,8 +17,8 @@ from .classes import (
     DiscreteFontAxis,
     FontAxis,
     GlyphAxis,
+    GlyphSource,
     Layer,
-    Source,
     StaticGlyph,
     VariableGlyph,
 )
@@ -214,7 +214,7 @@ class GlyphInstancer:
         return {axis.name: axis.defaultValue for axis in self.combinedAxes}
 
     @cached_property
-    def defaultSource(self) -> Source:
+    def defaultSource(self) -> GlyphSource:
         defaultSourceLocation = self.defaultSourceLocation
         for source in self.activeSources:
             if defaultSourceLocation | source.location == defaultSourceLocation:
@@ -267,7 +267,7 @@ class GlyphInstancer:
         }
 
     @cached_property
-    def activeSources(self) -> list[Source]:
+    def activeSources(self) -> list[GlyphSource]:
         return [source for source in self.glyph.sources if not source.inactive]
 
     @cached_property

--- a/src/fontra/core/instancer.py
+++ b/src/fontra/core/instancer.py
@@ -45,7 +45,8 @@ class FontInstancer:
         glyphInstancer = self.glyphInstancers.get(glyphName)
         if glyphInstancer is None:
             if self.globalAxes is None:
-                self.globalAxes = await self.backend.getGlobalAxes()
+                self.globalAxes = (await self.backend.getAxes()).axes
+                print("XXX", type(self.backend), self.globalAxes)
             glyph = await self.backend.getGlyph(glyphName)
             assert glyph is not None, glyphName
             glyph = await self._ensureComponentLocationCompatibility(glyph)

--- a/src/fontra/core/instancer.py
+++ b/src/fontra/core/instancer.py
@@ -14,8 +14,8 @@ from fontTools.varLib.models import (
 
 from .classes import (
     Component,
-    GlobalAxis,
-    GlobalDiscreteAxis,
+    DiscreteFontAxis,
+    FontAxis,
     Layer,
     LocalAxis,
     Source,
@@ -37,7 +37,7 @@ class FontInstancer:
 
     def __post_init__(self) -> None:
         self.glyphInstancers: dict[str, GlyphInstancer] = {}
-        self.globalAxes: list[GlobalAxis | GlobalDiscreteAxis] | None = None
+        self.globalAxes: list[FontAxis | DiscreteFontAxis] | None = None
 
     async def getGlyphInstancer(
         self, glyphName: str, addToCache: bool = False
@@ -200,7 +200,7 @@ class GlyphInstancer:
         )
 
     @cached_property
-    def globalAxes(self) -> list[GlobalAxis | GlobalDiscreteAxis]:
+    def globalAxes(self) -> list[FontAxis | DiscreteFontAxis]:
         assert self.fontInstancer.globalAxes is not None
         return self.fontInstancer.globalAxes
 
@@ -246,7 +246,7 @@ class GlyphInstancer:
             if axis.name in localAxisNames:
                 continue
             mapFunc = makeAxisMapFunc(axis)
-            if not isinstance(axis, GlobalAxis):
+            if not isinstance(axis, FontAxis):
                 # Skip discrete axes
                 continue
             combinedAxes.append(

--- a/src/fontra/core/instancer.py
+++ b/src/fontra/core/instancer.py
@@ -205,7 +205,7 @@ class GlyphInstancer:
         return self.fontInstancer.globalAxes
 
     @cached_property
-    def defaultGlobalSourceLocation(self) -> dict[str, float]:
+    def defaultFontSourceLocation(self) -> dict[str, float]:
         location = {axis.name: axis.defaultValue for axis in self.globalAxes}
         return mapLocationFromUserToSource(location, self.globalAxes)
 

--- a/src/fontra/core/protocols.py
+++ b/src/fontra/core/protocols.py
@@ -6,7 +6,7 @@ from typing import Any, Awaitable, Callable, Protocol, runtime_checkable
 
 from aiohttp import web
 
-from .classes import Axes, FontInfo, GlobalSource, VariableGlyph
+from .classes import Axes, FontInfo, FontSource, VariableGlyph
 
 
 @runtime_checkable
@@ -23,7 +23,7 @@ class ReadableFontBackend(Protocol):
     async def getAxes(self) -> Axes:
         pass
 
-    async def getSources(self) -> dict[str, GlobalSource]:
+    async def getSources(self) -> dict[str, FontSource]:
         pass
 
     async def getGlyphMap(self) -> dict[str, list[int]]:
@@ -52,7 +52,7 @@ class WritableFontBackend(ReadableFontBackend, Protocol):
     async def putAxes(self, value: Axes) -> None:
         pass
 
-    async def putSources(self, sources: dict[str, GlobalSource]) -> None:
+    async def putSources(self, sources: dict[str, FontSource]) -> None:
         pass
 
     async def putGlyphMap(self, value: dict[str, list[int]]) -> None:

--- a/src/fontra/core/protocols.py
+++ b/src/fontra/core/protocols.py
@@ -6,13 +6,7 @@ from typing import Any, Awaitable, Callable, Protocol, runtime_checkable
 
 from aiohttp import web
 
-from .classes import (
-    FontInfo,
-    GlobalAxis,
-    GlobalDiscreteAxis,
-    GlobalSource,
-    VariableGlyph,
-)
+from .classes import Axes, FontInfo, GlobalSource, VariableGlyph
 
 
 @runtime_checkable
@@ -26,7 +20,7 @@ class ReadableFontBackend(Protocol):
     async def getFontInfo(self) -> FontInfo:
         pass
 
-    async def getGlobalAxes(self) -> list[GlobalAxis | GlobalDiscreteAxis]:
+    async def getAxes(self) -> Axes:
         pass
 
     async def getSources(self) -> dict[str, GlobalSource]:
@@ -55,7 +49,7 @@ class WritableFontBackend(ReadableFontBackend, Protocol):
     async def putFontInfo(self, fontInfo: FontInfo):
         pass
 
-    async def putGlobalAxes(self, value: list[GlobalAxis | GlobalDiscreteAxis]) -> None:
+    async def putAxes(self, value: Axes) -> None:
         pass
 
     async def putSources(self, sources: dict[str, GlobalSource]) -> None:

--- a/src/fontra/views/editor/panel-designspace-navigation.js
+++ b/src/fontra/views/editor/panel-designspace-navigation.js
@@ -14,7 +14,7 @@ import {
   scheduleCalls,
   throttleCalls,
 } from "/core/utils.js";
-import { Layer, Source } from "/core/var-glyph.js";
+import { GlyphSource, Layer } from "/core/var-glyph.js";
 import {
   locationToString,
   makeSparseLocation,
@@ -672,7 +672,7 @@ export default class DesignspaceNavigationPanel extends Panel {
 
     await this.sceneController.editGlyphAndRecordChanges((glyph) => {
       glyph.sources.push(
-        Source.fromObject({
+        GlyphSource.fromObject({
           name: sourceName,
           layerName: layerName,
           location: newLocation,

--- a/src/fontra/views/fontinfo/panel-axes.js
+++ b/src/fontra/views/fontinfo/panel-axes.js
@@ -75,8 +75,8 @@ export class AxesPanel extends BaseInfoPanel {
       style: "display: grid; gap: 0.5em;",
     });
 
-    const axes = this.fontController.globalAxes;
-    for (const index of range(axes.length)) {
+    const axes = this.fontController.axes;
+    for (const index of range(axes.axes.length)) {
       axisContainer.appendChild(
         new AxisBox(axes, index, this.postChange.bind(this), this.deleteAxis.bind(this))
       );
@@ -191,9 +191,9 @@ export class AxesPanel extends BaseInfoPanel {
     };
 
     const undoLabel = `add axis '${newAxis.name}'`;
-    const root = { axes: this.fontController.globalAxes };
+    const root = { axes: this.fontController.axes };
     const changes = recordChanges(root, (root) => {
-      root.axes.push(newAxis);
+      root.axes.axes.push(newAxis);
     });
     if (changes.hasChange) {
       this.postChange(changes.change, changes.rollbackChange, undoLabel);
@@ -202,18 +202,18 @@ export class AxesPanel extends BaseInfoPanel {
   }
 
   async replaceAxes(updatedAxes, undoLabel) {
-    const root = { axes: this.fontController.globalAxes };
+    const root = { axes: this.fontController.axes };
     const changes = recordChanges(root, (root) => {
-      root.axes.splice(0, root.axes.length, ...updatedAxes);
+      root.axes.axes.splice(0, root.axes.length, ...updatedAxes);
     });
     await this.postChange(changes.change, changes.rollbackChange, undoLabel);
   }
 
   async deleteAxis(axisIndex) {
-    const undoLabel = `delete axis '${this.fontController.globalAxes[axisIndex].name}'`;
-    const root = { axes: this.fontController.globalAxes };
+    const undoLabel = `delete axis '${this.fontController.axes.axes[axisIndex].name}'`;
+    const root = { axes: this.fontController.axes };
     const changes = recordChanges(root, (root) => {
-      root.axes.splice(axisIndex, 1);
+      root.axes.axes.splice(axisIndex, 1);
     });
     if (changes.hasChange) {
       this.postChange(changes.change, changes.rollbackChange, undoLabel);
@@ -285,13 +285,13 @@ class AxisBox extends HTMLElement {
   }
 
   get axis() {
-    return this.axes[this.axisIndex];
+    return this.axes.axes[this.axisIndex];
   }
 
   editAxis(editFunc, undoLabel) {
     const root = { axes: this.axes };
     const changes = recordChanges(root, (root) => {
-      editFunc(root.axes[this.axisIndex]);
+      editFunc(root.axes.axes[this.axisIndex]);
     });
     if (changes.hasChange) {
       this.postChange(changes.change, changes.rollbackChange, undoLabel);
@@ -301,7 +301,7 @@ class AxisBox extends HTMLElement {
   replaceAxis(newAxis, undoLabel) {
     const root = { axes: this.axes };
     const changes = recordChanges(root, (root) => {
-      root.axes[this.axisIndex] = newAxis;
+      root.axes.axes[this.axisIndex] = newAxis;
     });
     if (changes.hasChange) {
       this.postChange(changes.change, changes.rollbackChange, undoLabel);

--- a/src/fontra/views/fontinfo/panel-axes.js
+++ b/src/fontra/views/fontinfo/panel-axes.js
@@ -204,7 +204,7 @@ export class AxesPanel extends BaseInfoPanel {
   async replaceAxes(updatedAxes, undoLabel) {
     const root = { axes: this.fontController.axes };
     const changes = recordChanges(root, (root) => {
-      root.axes.axes.splice(0, root.axes.length, ...updatedAxes);
+      root.axes.axes.splice(0, root.axes.axes.length, ...updatedAxes);
     });
     await this.postChange(changes.change, changes.rollbackChange, undoLabel);
   }

--- a/src/fontra/workflow/actions.py
+++ b/src/fontra/workflow/actions.py
@@ -817,11 +817,12 @@ class MoveDefaultLocationAction(BaseFilterAction):
     @async_cached_property
     async def newDefaultSourceLocation(self):
         newDefaultUserLocation = self.newDefaultUserLocation
-        axes = [
-            axis
-            for axis in (await self.validatedInput.getAxes()).axes
-            if axis.name in newDefaultUserLocation
+        axes = await self.inputAxes
+
+        relevantAxes = [
+            axis for axis in axes.axes if axis.name in newDefaultUserLocation
         ]
+
         return {
             axis.name: (
                 piecewiseLinearMap(
@@ -830,10 +831,11 @@ class MoveDefaultLocationAction(BaseFilterAction):
                 if axis.mapping
                 else newDefaultUserLocation[axis.name]
             )
-            for axis in axes
+            for axis in relevantAxes
         }
 
-    async def processAxes(self, axes: Axes) -> Axes:
+    async def getAxes(self) -> Axes:
+        axes = await self.inputAxes
         newDefaultUserLocation = self.newDefaultUserLocation
         return replace(
             axes,

--- a/src/fontra/workflow/actions.py
+++ b/src/fontra/workflow/actions.py
@@ -33,8 +33,8 @@ from ..core.classes import (
     DiscreteFontAxis,
     FontInfo,
     FontSource,
+    GlyphSource,
     Layer,
-    Source,
     StaticGlyph,
     VariableGlyph,
     structure,
@@ -634,7 +634,7 @@ class DecomposeCompositesAction(BaseFilterAction):
         layerNames = [locationToString(location) for location in locationsToAdd]
 
         newSources = instancer.activeSources + [
-            Source(name=name, location=location, layerName=name)
+            GlyphSource(name=name, location=location, layerName=name)
             for location, name in zip(locationsToAdd, layerNames, strict=True)
         ]
         newLayers = {}
@@ -1032,7 +1032,7 @@ def updateSourcesAndLayers(instancer, newLocations) -> VariableGlyph:
         else:
             location = dict(locationTuple)
             name = locationToString(location)
-            source = Source(name=name, location=location, layerName=name)
+            source = GlyphSource(name=name, location=location, layerName=name)
             instance = instancer.instantiate(location)
             newLayers[source.layerName] = Layer(glyph=instance.glyph)
 

--- a/src/fontra/workflow/actions.py
+++ b/src/fontra/workflow/actions.py
@@ -558,9 +558,9 @@ class AdjustAxesAction(BaseFilterAction):
     @async_cached_property
     async def _adjustedAxesAndMapFunctions(self) -> tuple:
         mapFuncs: dict = {}
-        axes = (await self.validatedInput.getAxes()).axes
+        axes = await self.validatedInput.getAxes()
         adjustedAxes = []
-        for axis in axes:
+        for axis in axes.axes:
             newValues = self.axes.get(axis.name)
             if newValues is not None:
                 if isinstance(axis, GlobalDiscreteAxis):
@@ -588,10 +588,10 @@ class AdjustAxesAction(BaseFilterAction):
 
                 axis = newAxis
             adjustedAxes.append(axis)
-        return adjustedAxes, mapFuncs
+        return replace(axes, axes=adjustedAxes), mapFuncs
 
-    async def processAxes(self, axes: Axes) -> Axes:
-        return replace(axes, axes=await self.adjustedAxes)
+    async def getAxes(self) -> Axes:
+        return await self.adjustedAxes
 
     async def processGlyph(self, glyph: VariableGlyph) -> VariableGlyph:
         return _remapSourceLocations(glyph, await self.axisValueMapFunctions)

--- a/src/fontra/workflow/actions.py
+++ b/src/fontra/workflow/actions.py
@@ -756,7 +756,7 @@ class SubsetAxesAction(BaseFilterAction):
         return {n: v for n, v in location.items() if n not in keepAxisNames}
 
     async def processAxes(self, axes: Axes) -> Axes:
-        keepAxisNames = self.getAxisNamesToKeep(axes)
+        keepAxisNames = self.getAxisNamesToKeep(axes.axes)
         return replace(
             axes, axes=[axis for axis in axes.axes if axis.name in keepAxisNames]
         )
@@ -976,8 +976,9 @@ class TrimAxesAction(BaseFilterAction):
         return trimmedAxes, sourceRanges
 
     async def getAxes(self) -> Axes:
+        axes = await self.validatedInput.getAxes()
         trimmedAxes, _ = await self._trimmedAxesAndSourceRanges
-        return trimmedAxes
+        return replace(axes, axes=trimmedAxes)
 
     async def getGlyph(self, glyphName: str) -> VariableGlyph:
         instancer = await self.fontInstancer.getGlyphInstancer(glyphName)

--- a/src/fontra/workflow/actions.py
+++ b/src/fontra/workflow/actions.py
@@ -30,9 +30,9 @@ from ..core.async_property import async_cached_property
 from ..core.classes import (
     Axes,
     Component,
+    DiscreteFontAxis,
     FontInfo,
     FontSource,
-    GlobalDiscreteAxis,
     Layer,
     Source,
     StaticGlyph,
@@ -571,7 +571,7 @@ class AdjustAxesAction(BaseFilterAction):
         for axis in axes.axes:
             newValues = self.axes.get(axis.name)
             if newValues is not None:
-                if isinstance(axis, GlobalDiscreteAxis):
+                if isinstance(axis, DiscreteFontAxis):
                     raise ActionError("adjust-axes: discrete axes are not supported")
                 names = {"minValue", "defaultValue", "maxValue"}
                 newValues = {k: v for k, v in newValues.items() if k in names}

--- a/src/fontra/workflow/actions.py
+++ b/src/fontra/workflow/actions.py
@@ -908,11 +908,11 @@ class TrimAxesAction(BaseFilterAction):
 
     @async_cached_property
     async def _trimmedAxesAndSourceRanges(self):
-        axes = (await self.validatedInput.getAxes()).axes
+        axes = await self.validatedInput.getAxes()
         trimmedAxes = []
         sourceRanges = {}
 
-        for axis in axes:
+        for axis in axes.axes:
             trimmedAxis = deepcopy(axis)
             trimmedAxes.append(trimmedAxis)
 
@@ -973,12 +973,11 @@ class TrimAxesAction(BaseFilterAction):
                 if trimmedAxis.minValue <= label.value <= trimmedAxis.maxValue
             ]
 
-        return trimmedAxes, sourceRanges
+        return replace(axes, axes=trimmedAxes), sourceRanges
 
     async def getAxes(self) -> Axes:
-        axes = await self.validatedInput.getAxes()
         trimmedAxes, _ = await self._trimmedAxesAndSourceRanges
-        return replace(axes, axes=trimmedAxes)
+        return trimmedAxes
 
     async def getGlyph(self, glyphName: str) -> VariableGlyph:
         instancer = await self.fontInstancer.getGlyphInstancer(glyphName)

--- a/src/fontra/workflow/merger.py
+++ b/src/fontra/workflow/merger.py
@@ -4,7 +4,7 @@ from copy import deepcopy
 from dataclasses import dataclass, replace
 from typing import Any
 
-from ..core.classes import Axes, FontInfo, GlobalSource, VariableGlyph, unstructure
+from ..core.classes import Axes, FontInfo, FontSource, VariableGlyph, unstructure
 from ..core.protocols import ReadableFontBackend
 
 logger = logging.getLogger(__name__)
@@ -76,7 +76,7 @@ class FontBackendMerger:
 
         return replace(axesA, axes=mergedAxes)
 
-    async def getSources(self) -> dict[str, GlobalSource]:
+    async def getSources(self) -> dict[str, FontSource]:
         sourcesA = await self.inputA.getSources()
         sourcesB = await self.inputB.getSources()
         return sourcesA | sourcesB

--- a/src/fontra/workflow/merger.py
+++ b/src/fontra/workflow/merger.py
@@ -1,17 +1,10 @@
 import logging
 from collections import defaultdict
 from copy import deepcopy
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any
 
-from ..core.classes import (
-    FontInfo,
-    GlobalAxis,
-    GlobalDiscreteAxis,
-    GlobalSource,
-    VariableGlyph,
-    unstructure,
-)
+from ..core.classes import Axes, FontInfo, GlobalSource, VariableGlyph, unstructure
 from ..core.protocols import ReadableFontBackend
 
 logger = logging.getLogger(__name__)
@@ -66,22 +59,22 @@ class FontBackendMerger:
         fontInfoB = await self.inputB.getFontInfo()
         return FontInfo(**(unstructure(fontInfoA) | unstructure(fontInfoB)))
 
-    async def getGlobalAxes(self) -> list[GlobalAxis | GlobalDiscreteAxis]:
-        axesA = await self.inputA.getGlobalAxes()
-        axesB = await self.inputB.getGlobalAxes()
-        axesByNameA = {axis.name: axis for axis in axesA}
-        axisNamesB = {axis.name for axis in axesB}
+    async def getAxes(self) -> Axes:
+        axesA = await self.inputA.getAxes()
+        axesB = await self.inputB.getAxes()
+        axesByNameA = {axis.name: axis for axis in axesA.axes}
+        axisNamesB = {axis.name for axis in axesB.axes}
         mergedAxes = []
-        for axis in axesB:
+        for axis in axesB.axes:
             if axis.name in axesByNameA:
                 axis = _mergeAxes(axesByNameA[axis.name], axis)
             mergedAxes.append(axis)
 
-        for axis in axesA:
+        for axis in axesA.axes:
             if axis.name not in axisNamesB:
                 mergedAxes.append(axis)
 
-        return mergedAxes
+        return replace(axesA, axes=mergedAxes)
 
     async def getSources(self) -> dict[str, GlobalSource]:
         sourcesA = await self.inputA.getSources()

--- a/test-common/fonts/MutatorSans.fontra/font-data.json
+++ b/test-common/fonts/MutatorSans.fontra/font-data.json
@@ -1,6 +1,7 @@
 {
 "unitsPerEm": 1000,
 "fontInfo": {},
+"axes": {
 "axes": [
 {
 "name": "width",
@@ -38,7 +39,8 @@
 ],
 "defaultValue": 0
 }
-],
+]
+},
 "sources": {},
 "customData": {}
 }

--- a/test-js/test-classes.js
+++ b/test-js/test-classes.js
@@ -17,8 +17,8 @@ describe("schema tests", () => {
     [
       ["glyphs", "dict<VariableGlyph>"],
       ["<anything>", "VariableGlyph"],
-      ["sources", "list<Source>"],
-      [999, "Source"],
+      ["sources", "list<GlyphSource>"],
+      [999, "GlyphSource"],
       ["location", "dict<float>"],
       ["<anything>", "float"],
     ],

--- a/test-py/data/workflow/input-check-interpolation.fontra/font-data.json
+++ b/test-py/data/workflow/input-check-interpolation.fontra/font-data.json
@@ -1,6 +1,7 @@
 {
 "unitsPerEm": 1000,
 "fontInfo": {},
+"axes": {
 "axes": [
 {
 "name": "weight",
@@ -10,7 +11,8 @@
 "defaultValue": 400,
 "maxValue": 900
 }
-],
+]
+},
 "sources": {},
 "customData": {}
 }

--- a/test-py/data/workflow/input-composites.fontra/font-data.json
+++ b/test-py/data/workflow/input-composites.fontra/font-data.json
@@ -1,6 +1,7 @@
 {
 "unitsPerEm": 1000,
 "fontInfo": {},
+"axes": {
 "axes": [
 {
 "name": "width",
@@ -38,7 +39,8 @@
 ],
 "defaultValue": 0
 }
-],
+]
+},
 "sources": {},
 "customData": {}
 }

--- a/test-py/data/workflow/input-drop-unreachable-glyphs.fontra/font-data.json
+++ b/test-py/data/workflow/input-drop-unreachable-glyphs.fontra/font-data.json
@@ -1,6 +1,7 @@
 {
 "unitsPerEm": 1000,
 "fontInfo": {},
+"axes": {
 "axes": [
 {
 "name": "width",
@@ -38,7 +39,8 @@
 ],
 "defaultValue": 0
 }
-],
+]
+},
 "sources": {},
 "customData": {}
 }

--- a/test-py/data/workflow/input-drop-unused-sources-and-layers.fontra/font-data.json
+++ b/test-py/data/workflow/input-drop-unused-sources-and-layers.fontra/font-data.json
@@ -1,6 +1,7 @@
 {
 "unitsPerEm": 1000,
 "fontInfo": {},
+"axes": {
 "axes": [
 {
 "name": "width",
@@ -38,7 +39,8 @@
 ],
 "defaultValue": 0
 }
-],
+]
+},
 "sources": {},
 "customData": {}
 }

--- a/test-py/data/workflow/input-error-glyph.fontra/font-data.json
+++ b/test-py/data/workflow/input-error-glyph.fontra/font-data.json
@@ -1,7 +1,7 @@
 {
 "unitsPerEm": 1000,
 "fontInfo": {},
-"axes": [],
+"axes": {},
 "sources": {},
 "customData": {}
 }

--- a/test-py/data/workflow/input-merge-codepoint-conflict.fontra/font-data.json
+++ b/test-py/data/workflow/input-merge-codepoint-conflict.fontra/font-data.json
@@ -1,6 +1,7 @@
 {
 "unitsPerEm": 1000,
 "fontInfo": {},
+"axes": {
 "axes": [
 {
 "name": "width",
@@ -38,7 +39,8 @@
 ],
 "defaultValue": 0
 }
-],
+]
+},
 "sources": {},
 "customData": {}
 }

--- a/test-py/data/workflow/input-move-default-location.fontra/font-data.json
+++ b/test-py/data/workflow/input-move-default-location.fontra/font-data.json
@@ -1,6 +1,7 @@
 {
 "unitsPerEm": 1000,
 "fontInfo": {},
+"axes": {
 "axes": [
 {
 "name": "width",
@@ -38,7 +39,8 @@
 ],
 "defaultValue": 0
 }
-],
+]
+},
 "sources": {},
 "customData": {}
 }

--- a/test-py/data/workflow/input-set-font-info.fontra/font-data.json
+++ b/test-py/data/workflow/input-set-font-info.fontra/font-data.json
@@ -3,7 +3,7 @@
 "fontInfo": {
 "copyright": "© 2024"
 },
-"axes": [],
+"axes": {},
 "sources": {},
 "customData": {}
 }

--- a/test-py/data/workflow/input-trim-axes.fontra/font-data.json
+++ b/test-py/data/workflow/input-trim-axes.fontra/font-data.json
@@ -1,6 +1,7 @@
 {
 "unitsPerEm": 1000,
 "fontInfo": {},
+"axes": {
 "axes": [
 {
 "name": "width",
@@ -28,7 +29,8 @@
 ]
 ]
 }
-],
+]
+},
 "sources": {},
 "customData": {}
 }

--- a/test-py/data/workflow/input-variable-composites-deep-axes.fontra/font-data.json
+++ b/test-py/data/workflow/input-variable-composites-deep-axes.fontra/font-data.json
@@ -1,6 +1,7 @@
 {
 "unitsPerEm": 1000,
 "fontInfo": {},
+"axes": {
 "axes": [
 {
 "name": "weight",
@@ -18,7 +19,8 @@
 "defaultValue": 100,
 "maxValue": 200
 }
-],
+]
+},
 "sources": {},
 "customData": {}
 }

--- a/test-py/data/workflow/input-variable-composites.fontra/font-data.json
+++ b/test-py/data/workflow/input-variable-composites.fontra/font-data.json
@@ -1,6 +1,7 @@
 {
 "unitsPerEm": 1000,
 "fontInfo": {},
+"axes": {
 "axes": [
 {
 "name": "wght",
@@ -40,7 +41,8 @@
 ]
 ]
 }
-],
+]
+},
 "sources": {},
 "customData": {
 "fontra.sourceStatusFieldDefinitions": [

--- a/test-py/data/workflow/input1-A.fontra/font-data.json
+++ b/test-py/data/workflow/input1-A.fontra/font-data.json
@@ -1,6 +1,7 @@
 {
 "unitsPerEm": 1000,
 "fontInfo": {},
+"axes": {
 "axes": [
 {
 "name": "width",
@@ -38,7 +39,8 @@
 ],
 "defaultValue": 0
 }
-],
+]
+},
 "sources": {},
 "customData": {}
 }

--- a/test-py/data/workflow/input1-B.fontra/font-data.json
+++ b/test-py/data/workflow/input1-B.fontra/font-data.json
@@ -1,6 +1,7 @@
 {
 "unitsPerEm": 1000,
 "fontInfo": {},
+"axes": {
 "axes": [
 {
 "name": "width",
@@ -38,7 +39,8 @@
 ],
 "defaultValue": 0
 }
-],
+]
+},
 "sources": {},
 "customData": {}
 }

--- a/test-py/data/workflow/input2-A.fontra/font-data.json
+++ b/test-py/data/workflow/input2-A.fontra/font-data.json
@@ -1,6 +1,7 @@
 {
 "unitsPerEm": 1000,
 "fontInfo": {},
+"axes": {
 "axes": [
 {
 "name": "width",
@@ -28,7 +29,8 @@
 ],
 "defaultValue": 0
 }
-],
+]
+},
 "sources": {},
 "customData": {}
 }

--- a/test-py/data/workflow/input2-B.fontra/font-data.json
+++ b/test-py/data/workflow/input2-B.fontra/font-data.json
@@ -1,6 +1,7 @@
 {
 "unitsPerEm": 1000,
 "fontInfo": {},
+"axes": {
 "axes": [
 {
 "name": "width",
@@ -28,7 +29,8 @@
 ],
 "defaultValue": 0
 }
-],
+]
+},
 "sources": {},
 "customData": {}
 }

--- a/test-py/data/workflow/output-adjust-axes-no-mapping-no-source-remap.fontra/font-data.json
+++ b/test-py/data/workflow/output-adjust-axes-no-mapping-no-source-remap.fontra/font-data.json
@@ -1,6 +1,7 @@
 {
 "unitsPerEm": 1000,
 "fontInfo": {},
+"axes": {
 "axes": [
 {
 "name": "width",
@@ -28,7 +29,8 @@
 ],
 "defaultValue": 0
 }
-],
+]
+},
 "sources": {},
 "customData": {}
 }

--- a/test-py/data/workflow/output-adjust-axes-no-mapping.fontra/font-data.json
+++ b/test-py/data/workflow/output-adjust-axes-no-mapping.fontra/font-data.json
@@ -1,6 +1,7 @@
 {
 "unitsPerEm": 1000,
 "fontInfo": {},
+"axes": {
 "axes": [
 {
 "name": "width",
@@ -28,7 +29,8 @@
 ],
 "defaultValue": 0
 }
-],
+]
+},
 "sources": {},
 "customData": {}
 }

--- a/test-py/data/workflow/output-adjust-axes-no-source-remap.fontra/font-data.json
+++ b/test-py/data/workflow/output-adjust-axes-no-source-remap.fontra/font-data.json
@@ -1,6 +1,7 @@
 {
 "unitsPerEm": 1000,
 "fontInfo": {},
+"axes": {
 "axes": [
 {
 "name": "width",
@@ -38,7 +39,8 @@
 ],
 "defaultValue": 0
 }
-],
+]
+},
 "sources": {},
 "customData": {}
 }

--- a/test-py/data/workflow/output-adjust-axes.fontra/font-data.json
+++ b/test-py/data/workflow/output-adjust-axes.fontra/font-data.json
@@ -1,6 +1,7 @@
 {
 "unitsPerEm": 1000,
 "fontInfo": {},
+"axes": {
 "axes": [
 {
 "name": "width",
@@ -38,7 +39,8 @@
 ],
 "defaultValue": 0
 }
-],
+]
+},
 "sources": {},
 "customData": {}
 }

--- a/test-py/data/workflow/output-check-interpolation.fontra/font-data.json
+++ b/test-py/data/workflow/output-check-interpolation.fontra/font-data.json
@@ -1,6 +1,7 @@
 {
 "unitsPerEm": 1000,
 "fontInfo": {},
+"axes": {
 "axes": [
 {
 "name": "weight",
@@ -10,7 +11,8 @@
 "defaultValue": 400,
 "maxValue": 900
 }
-],
+]
+},
 "sources": {},
 "customData": {}
 }

--- a/test-py/data/workflow/output-decompose-composites.fontra/font-data.json
+++ b/test-py/data/workflow/output-decompose-composites.fontra/font-data.json
@@ -1,6 +1,7 @@
 {
 "unitsPerEm": 1000,
 "fontInfo": {},
+"axes": {
 "axes": [
 {
 "name": "width",
@@ -38,7 +39,8 @@
 ],
 "defaultValue": 0
 }
-],
+]
+},
 "sources": {},
 "customData": {}
 }

--- a/test-py/data/workflow/output-decompose-only-variable-composites.fontra/font-data.json
+++ b/test-py/data/workflow/output-decompose-only-variable-composites.fontra/font-data.json
@@ -1,6 +1,7 @@
 {
 "unitsPerEm": 1000,
 "fontInfo": {},
+"axes": {
 "axes": [
 {
 "name": "width",
@@ -38,7 +39,8 @@
 ],
 "defaultValue": 0
 }
-],
+]
+},
 "sources": {},
 "customData": {}
 }

--- a/test-py/data/workflow/output-decompose-variable-composites-deep-axes.fontra/font-data.json
+++ b/test-py/data/workflow/output-decompose-variable-composites-deep-axes.fontra/font-data.json
@@ -1,6 +1,7 @@
 {
 "unitsPerEm": 1000,
 "fontInfo": {},
+"axes": {
 "axes": [
 {
 "name": "weight",
@@ -18,7 +19,8 @@
 "defaultValue": 100,
 "maxValue": 200
 }
-],
+]
+},
 "sources": {},
 "customData": {}
 }

--- a/test-py/data/workflow/output-decompose-variable-composites.fontra/font-data.json
+++ b/test-py/data/workflow/output-decompose-variable-composites.fontra/font-data.json
@@ -1,6 +1,7 @@
 {
 "unitsPerEm": 1000,
 "fontInfo": {},
+"axes": {
 "axes": [
 {
 "name": "wght",
@@ -40,7 +41,8 @@
 ]
 ]
 }
-],
+]
+},
 "sources": {},
 "customData": {
 "fontra.sourceStatusFieldDefinitions": [

--- a/test-py/data/workflow/output-drop-axis-mapping-noop.fontra/font-data.json
+++ b/test-py/data/workflow/output-drop-axis-mapping-noop.fontra/font-data.json
@@ -1,6 +1,7 @@
 {
 "unitsPerEm": 1000,
 "fontInfo": {},
+"axes": {
 "axes": [
 {
 "name": "width",
@@ -38,7 +39,8 @@
 ],
 "defaultValue": 0
 }
-],
+]
+},
 "sources": {},
 "customData": {}
 }

--- a/test-py/data/workflow/output-drop-axis-mapping.fontra/font-data.json
+++ b/test-py/data/workflow/output-drop-axis-mapping.fontra/font-data.json
@@ -1,6 +1,7 @@
 {
 "unitsPerEm": 1000,
 "fontInfo": {},
+"axes": {
 "axes": [
 {
 "name": "width",
@@ -28,7 +29,8 @@
 ],
 "defaultValue": 0
 }
-],
+]
+},
 "sources": {},
 "customData": {}
 }

--- a/test-py/data/workflow/output-drop-unreachable-glyphs-composed.fontra/font-data.json
+++ b/test-py/data/workflow/output-drop-unreachable-glyphs-composed.fontra/font-data.json
@@ -1,6 +1,7 @@
 {
 "unitsPerEm": 1000,
 "fontInfo": {},
+"axes": {
 "axes": [
 {
 "name": "width",
@@ -38,7 +39,8 @@
 ],
 "defaultValue": 0
 }
-],
+]
+},
 "sources": {},
 "customData": {}
 }

--- a/test-py/data/workflow/output-drop-unreachable-glyphs-decomposed.fontra/font-data.json
+++ b/test-py/data/workflow/output-drop-unreachable-glyphs-decomposed.fontra/font-data.json
@@ -1,6 +1,7 @@
 {
 "unitsPerEm": 1000,
 "fontInfo": {},
+"axes": {
 "axes": [
 {
 "name": "width",
@@ -38,7 +39,8 @@
 ],
 "defaultValue": 0
 }
-],
+]
+},
 "sources": {},
 "customData": {}
 }

--- a/test-py/data/workflow/output-drop-unused-sources-and-layers.fontra/font-data.json
+++ b/test-py/data/workflow/output-drop-unused-sources-and-layers.fontra/font-data.json
@@ -1,6 +1,7 @@
 {
 "unitsPerEm": 1000,
 "fontInfo": {},
+"axes": {
 "axes": [
 {
 "name": "width",
@@ -38,7 +39,8 @@
 ],
 "defaultValue": 0
 }
-],
+]
+},
 "sources": {},
 "customData": {}
 }

--- a/test-py/data/workflow/output-error-glyph.fontra/font-data.json
+++ b/test-py/data/workflow/output-error-glyph.fontra/font-data.json
@@ -1,7 +1,7 @@
 {
 "unitsPerEm": 1000,
 "fontInfo": {},
-"axes": [],
+"axes": {},
 "sources": {},
 "customData": {}
 }

--- a/test-py/data/workflow/output-merge-codepoint-conflict.fontra/font-data.json
+++ b/test-py/data/workflow/output-merge-codepoint-conflict.fontra/font-data.json
@@ -1,6 +1,7 @@
 {
 "unitsPerEm": 1000,
 "fontInfo": {},
+"axes": {
 "axes": [
 {
 "name": "width",
@@ -38,7 +39,8 @@
 ],
 "defaultValue": 0
 }
-],
+]
+},
 "sources": {},
 "customData": {}
 }

--- a/test-py/data/workflow/output-move-default-location.fontra/font-data.json
+++ b/test-py/data/workflow/output-move-default-location.fontra/font-data.json
@@ -1,6 +1,7 @@
 {
 "unitsPerEm": 1000,
 "fontInfo": {},
+"axes": {
 "axes": [
 {
 "name": "width",
@@ -28,7 +29,8 @@
 ]
 ]
 }
-],
+]
+},
 "sources": {},
 "customData": {}
 }

--- a/test-py/data/workflow/output-rename-axes.fontra/font-data.json
+++ b/test-py/data/workflow/output-rename-axes.fontra/font-data.json
@@ -1,6 +1,7 @@
 {
 "unitsPerEm": 1000,
 "fontInfo": {},
+"axes": {
 "axes": [
 {
 "name": "width",
@@ -38,7 +39,8 @@
 ],
 "defaultValue": 0
 }
-],
+]
+},
 "sources": {},
 "customData": {}
 }

--- a/test-py/data/workflow/output-set-font-info.fontra/font-data.json
+++ b/test-py/data/workflow/output-set-font-info.fontra/font-data.json
@@ -5,7 +5,7 @@
 "copyright": "© 2024",
 "designer": "Joe Font Designer"
 },
-"axes": [],
+"axes": {},
 "sources": {},
 "customData": {}
 }

--- a/test-py/data/workflow/output-subset-axes.fontra/font-data.json
+++ b/test-py/data/workflow/output-subset-axes.fontra/font-data.json
@@ -1,6 +1,7 @@
 {
 "unitsPerEm": 1000,
 "fontInfo": {},
+"axes": {
 "axes": [
 {
 "name": "weight",
@@ -20,7 +21,8 @@
 ]
 ]
 }
-],
+]
+},
 "sources": {},
 "customData": {}
 }

--- a/test-py/data/workflow/output-subset-by-development-status-no.fontra/font-data.json
+++ b/test-py/data/workflow/output-subset-by-development-status-no.fontra/font-data.json
@@ -1,6 +1,7 @@
 {
 "unitsPerEm": 1000,
 "fontInfo": {},
+"axes": {
 "axes": [
 {
 "name": "wght",
@@ -40,7 +41,8 @@
 ]
 ]
 }
-],
+]
+},
 "sources": {},
 "customData": {
 "fontra.sourceStatusFieldDefinitions": [

--- a/test-py/data/workflow/output-subset-by-development-status-yes.fontra/font-data.json
+++ b/test-py/data/workflow/output-subset-by-development-status-yes.fontra/font-data.json
@@ -1,6 +1,7 @@
 {
 "unitsPerEm": 1000,
 "fontInfo": {},
+"axes": {
 "axes": [
 {
 "name": "wght",
@@ -40,7 +41,8 @@
 ]
 ]
 }
-],
+]
+},
 "sources": {},
 "customData": {
 "fontra.sourceStatusFieldDefinitions": [

--- a/test-py/data/workflow/output-subset-keep-drop-glyphs.fontra/font-data.json
+++ b/test-py/data/workflow/output-subset-keep-drop-glyphs.fontra/font-data.json
@@ -1,6 +1,7 @@
 {
 "unitsPerEm": 1000,
 "fontInfo": {},
+"axes": {
 "axes": [
 {
 "name": "width",
@@ -38,7 +39,8 @@
 ],
 "defaultValue": 0
 }
-],
+]
+},
 "sources": {},
 "customData": {}
 }

--- a/test-py/data/workflow/output-trim-axes.fontra/font-data.json
+++ b/test-py/data/workflow/output-trim-axes.fontra/font-data.json
@@ -1,6 +1,7 @@
 {
 "unitsPerEm": 1000,
 "fontInfo": {},
+"axes": {
 "axes": [
 {
 "name": "width",
@@ -28,7 +29,8 @@
 ]
 ]
 }
-],
+]
+},
 "sources": {},
 "customData": {}
 }

--- a/test-py/data/workflow/output1.fontra/font-data.json
+++ b/test-py/data/workflow/output1.fontra/font-data.json
@@ -1,6 +1,7 @@
 {
 "unitsPerEm": 1000,
 "fontInfo": {},
+"axes": {
 "axes": [
 {
 "name": "width",
@@ -38,7 +39,8 @@
 ],
 "defaultValue": 0
 }
-],
+]
+},
 "sources": {},
 "customData": {}
 }

--- a/test-py/data/workflow/output2.fontra/font-data.json
+++ b/test-py/data/workflow/output2.fontra/font-data.json
@@ -1,6 +1,7 @@
 {
 "unitsPerEm": 1000,
 "fontInfo": {},
+"axes": {
 "axes": [
 {
 "name": "width",
@@ -28,7 +29,8 @@
 ],
 "defaultValue": 0
 }
-],
+]
+},
 "sources": {},
 "customData": {}
 }

--- a/test-py/data/workflow/output3.fontra/font-data.json
+++ b/test-py/data/workflow/output3.fontra/font-data.json
@@ -1,6 +1,7 @@
 {
 "unitsPerEm": 1000,
 "fontInfo": {},
+"axes": {
 "axes": [
 {
 "name": "width",
@@ -38,7 +39,8 @@
 ],
 "defaultValue": 0
 }
-],
+]
+},
 "sources": {},
 "customData": {}
 }

--- a/test-py/test_backends_designspace.py
+++ b/test-py/test_backends_designspace.py
@@ -11,8 +11,8 @@ from fontra.backends.designspace import DesignspaceBackend, UFOBackend
 from fontra.core.classes import (
     FontAxis,
     GlyphAxis,
+    GlyphSource,
     Layer,
-    Source,
     StaticGlyph,
     unstructure,
 )
@@ -132,7 +132,7 @@ async def test_addNewSparseSource(writableTestFont, location, expectedDSSource):
     glyph = await writableTestFont.getGlyph(glyphName)
     dsSources = unpackSources(writableTestFont.dsDoc.sources)
 
-    glyph.sources.append(Source(name="mid", location=location, layerName="mid"))
+    glyph.sources.append(GlyphSource(name="mid", location=location, layerName="mid"))
     glyph.layers["mid"] = Layer(glyph=StaticGlyph())
 
     await writableTestFont.putGlyph(glyphName, glyph, glyphMap[glyphName])
@@ -157,7 +157,7 @@ async def test_addNewDenseSource(writableTestFont):
     dsSources = unpackSources(writableTestFont.dsDoc.sources)
 
     glyph.sources.append(
-        Source(name="widest", location={"width": 1500}, layerName="widest")
+        GlyphSource(name="widest", location={"width": 1500}, layerName="widest")
     )
     glyph.layers["widest"] = Layer(glyph=StaticGlyph())
 
@@ -198,7 +198,7 @@ async def test_addLocalAxisAndSource(writableTestFont):
 
     glyph.axes.append(GlyphAxis(name="test", minValue=0, defaultValue=50, maxValue=100))
     glyph.sources.append(
-        Source(name="test", location={"test": 100}, layerName=layerName)
+        GlyphSource(name="test", location={"test": 100}, layerName=layerName)
     )
     glyph.layers[layerName] = Layer(glyph=StaticGlyph(xAdvance=0))
 

--- a/test-py/test_backends_designspace.py
+++ b/test-py/test_backends_designspace.py
@@ -10,8 +10,8 @@ from fontra.backends import getFileSystemBackend, newFileSystemBackend
 from fontra.backends.designspace import DesignspaceBackend, UFOBackend
 from fontra.core.classes import (
     FontAxis,
+    GlyphAxis,
     Layer,
-    LocalAxis,
     Source,
     StaticGlyph,
     unstructure,
@@ -180,7 +180,7 @@ async def test_addLocalAxis(writableTestFont):
     glyphMap = await writableTestFont.getGlyphMap()
     glyph = await writableTestFont.getGlyph(glyphName)
 
-    glyph.axes.append(LocalAxis(name="test", minValue=0, defaultValue=50, maxValue=100))
+    glyph.axes.append(GlyphAxis(name="test", minValue=0, defaultValue=50, maxValue=100))
 
     await writableTestFont.putGlyph(glyphName, glyph, glyphMap[glyphName])
 
@@ -196,7 +196,7 @@ async def test_addLocalAxisAndSource(writableTestFont):
 
     layerName = "test"
 
-    glyph.axes.append(LocalAxis(name="test", minValue=0, defaultValue=50, maxValue=100))
+    glyph.axes.append(GlyphAxis(name="test", minValue=0, defaultValue=50, maxValue=100))
     glyph.sources.append(
         Source(name="test", location={"test": 100}, layerName=layerName)
     )

--- a/test-py/test_backends_designspace.py
+++ b/test-py/test_backends_designspace.py
@@ -9,7 +9,7 @@ from fontTools.designspaceLib import DesignSpaceDocument
 from fontra.backends import getFileSystemBackend, newFileSystemBackend
 from fontra.backends.designspace import DesignspaceBackend, UFOBackend
 from fontra.core.classes import (
-    GlobalAxis,
+    FontAxis,
     Layer,
     LocalAxis,
     Source,
@@ -212,7 +212,7 @@ async def test_addLocalAxisAndSource(writableTestFont):
 async def test_putAxes(writableTestFont):
     axes = await writableTestFont.getAxes()
     axes.axes.append(
-        GlobalAxis(
+        FontAxis(
             name="Testing",
             tag="TEST",
             label="Testing",

--- a/test-py/test_backends_designspace.py
+++ b/test-py/test_backends_designspace.py
@@ -209,9 +209,9 @@ async def test_addLocalAxisAndSource(writableTestFont):
     assert asdict(glyph) == asdict(savedGlyph)
 
 
-async def test_putGlobalAxes(writableTestFont):
-    axes = await writableTestFont.getGlobalAxes()
-    axes.append(
+async def test_putAxes(writableTestFont):
+    axes = await writableTestFont.getAxes()
+    axes.axes.append(
         GlobalAxis(
             name="Testing",
             tag="TEST",
@@ -222,11 +222,11 @@ async def test_putGlobalAxes(writableTestFont):
             mapping=[[10, 0], [20, 100], [20, 200]],
         )
     )
-    await writableTestFont.putGlobalAxes(axes)
+    await writableTestFont.putAxes(axes)
 
     path = writableTestFont.dsDoc.path
     newFont = DesignspaceBackend.fromPath(path)
-    newAxes = await newFont.getGlobalAxes()
+    newAxes = await newFont.getAxes()
     assert axes == newAxes
 
 
@@ -259,11 +259,11 @@ async def test_newFileSystemBackend(
     tmpdir = pathlib.Path(tmpdir)
     destPath = tmpdir / fileName
     font = newFileSystemBackend(destPath)
-    assert [] == await font.getGlobalAxes()
+    assert [] == (await font.getAxes()).axes
     assert initialExpectedFileNames == fileNamesFromDir(tmpdir)
 
-    axes = await sourceFont.getGlobalAxes()
-    await font.putGlobalAxes(axes)
+    axes = await sourceFont.getAxes()
+    await font.putAxes(axes)
     glyphMap = await sourceFont.getGlyphMap()
     glyph = await sourceFont.getGlyph("A")
     await font.putGlyph("A", glyph, glyphMap["A"])
@@ -297,8 +297,8 @@ async def test_writeCorrectLayers(tmpdir, testFont):
     dsPath = tmpdir / "Test.designspace"
     font = newFileSystemBackend(dsPath)
 
-    axes = await testFont.getGlobalAxes()
-    await font.putGlobalAxes(axes)
+    axes = await testFont.getAxes()
+    await font.putAxes(axes)
     glyphMap = await testFont.getGlyphMap()
     glyph = await testFont.getGlyph("A")
     await font.putGlyph("A", glyph, glyphMap["A"])

--- a/test-py/test_backends_fontra.py
+++ b/test-py/test_backends_fontra.py
@@ -46,7 +46,7 @@ async def test_copy_to_fontra(testDSFont, newFontraFont):
             srcGlyph = await testDSFont.getGlyph(glyphName)
             dstGlyph = await dstFont.getGlyph(glyphName)
             assert srcGlyph == dstGlyph
-        assert await testDSFont.getGlobalAxes() == await dstFont.getGlobalAxes()
+        assert await testDSFont.getAxes() == await dstFont.getAxes()
 
 
 async def test_fontraFormat(testFontraFont, newFontraFont):
@@ -59,7 +59,7 @@ async def test_fontraFormat(testFontraFont, newFontraFont):
         assert testFontraFont.getGlyphData(glyphName) == newFontraFont.getGlyphData(
             glyphName
         )
-    assert await testFontraFont.getGlobalAxes() == await newFontraFont.getGlobalAxes()
+    assert await testFontraFont.getAxes() == await newFontraFont.getAxes()
 
     assert testFontraFont.fontDataPath.read_text(
         encoding="utf-8"

--- a/test-py/test_classes.py
+++ b/test-py/test_classes.py
@@ -3,8 +3,8 @@ import pathlib
 
 from fontra.backends.fontra import deserializeGlyph
 from fontra.core.classes import (
+    GlyphSource,
     Layer,
-    Source,
     VariableGlyph,
     classCastFuncs,
     serializableClassSchema,
@@ -42,7 +42,7 @@ def test_cast():
     assert str(glyph) == str(originalGlyph)
 
     sourcesList = unstructure(glyph.sources)
-    sources = classCastFuncs[list[Source]](sourcesList)
+    sources = classCastFuncs[list[GlyphSource]](sourcesList)
     assert glyph.sources == sources
 
     layersDict = unstructure(glyph.layers)

--- a/test-py/test_font.py
+++ b/test-py/test_font.py
@@ -976,7 +976,7 @@ async def test_getGlyph(testFontName, expectedGlyph):
         assert asdict(glyph) == asdict(expectedGlyph)
 
 
-getGlobalAxesTestData = [
+getAxesTestData = [
     (
         "designspace",
         [
@@ -1025,7 +1025,7 @@ getGlobalAxesTestData = [
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("testFontName, expectedGlobalAxes", getGlobalAxesTestData)
+@pytest.mark.parametrize("testFontName, expectedGlobalAxes", getAxesTestData)
 async def test_getGlobalAxes(testFontName, expectedGlobalAxes):
     font = getTestFont(testFontName)
     globalAxes = (await font.getAxes()).axes

--- a/test-py/test_font.py
+++ b/test-py/test_font.py
@@ -1028,7 +1028,7 @@ getGlobalAxesTestData = [
 @pytest.mark.parametrize("testFontName, expectedGlobalAxes", getGlobalAxesTestData)
 async def test_getGlobalAxes(testFontName, expectedGlobalAxes):
     font = getTestFont(testFontName)
-    globalAxes = await font.getGlobalAxes()
+    globalAxes = (await font.getAxes()).axes
     assert expectedGlobalAxes == globalAxes
 
 

--- a/test-py/test_font.py
+++ b/test-py/test_font.py
@@ -7,8 +7,8 @@ import pytest
 from fontra.backends import getFileSystemBackend
 from fontra.core.classes import (
     AxisValueLabel,
-    GlobalAxis,
-    GlobalDiscreteAxis,
+    DiscreteFontAxis,
+    FontAxis,
     VariableGlyph,
     structure,
 )
@@ -980,7 +980,7 @@ getAxesTestData = [
     (
         "designspace",
         [
-            GlobalAxis(
+            FontAxis(
                 defaultValue=0.0,
                 maxValue=1000.0,
                 minValue=0.0,
@@ -988,7 +988,7 @@ getAxesTestData = [
                 name="width",
                 tag="wdth",
             ),
-            GlobalAxis(
+            FontAxis(
                 defaultValue=100.0,
                 maxValue=900.0,
                 mapping=[[100.0, 150.0], [900.0, 850.0]],
@@ -997,7 +997,7 @@ getAxesTestData = [
                 name="weight",
                 tag="wght",
             ),
-            GlobalDiscreteAxis(
+            DiscreteFontAxis(
                 name="italic",
                 label="italic",
                 tag="ital",

--- a/test-py/test_font.py
+++ b/test-py/test_font.py
@@ -1026,7 +1026,7 @@ getAxesTestData = [
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("testFontName, expectedGlobalAxes", getAxesTestData)
-async def test_getGlobalAxes(testFontName, expectedGlobalAxes):
+async def test_getAxes(testFontName, expectedGlobalAxes):
     font = getTestFont(testFontName)
     globalAxes = (await font.getAxes()).axes
     assert expectedGlobalAxes == globalAxes


### PR DESCRIPTION
Fixes #1280

This PR also contains a bunch of class renames that are not strictly related. We'll need counterpart PRs in fontra-rcjk, fontra-glyphs and fontra-compile, having this bundled in one bigger PR is practical from that perspective.