### PR TITLE
[avar-2 designspace] Add support for mappings descriptions

### DIFF
--- a/src/fontra/backends/designspace.py
+++ b/src/fontra/backends/designspace.py
@@ -178,6 +178,8 @@ class DesignspaceBackend:
 
         self.axisMappings = [
             MultipleAxisMapping(
+                description=mapping.description,
+                groupDescription=mapping.groupDescription,
                 inputLocation=dict(mapping.inputLocation),
                 outputLocation=dict(mapping.outputLocation),
             )
@@ -685,6 +687,8 @@ class DesignspaceBackend:
 
         for mapping in axes.mappings:
             self.dsDoc.addAxisMappingDescriptor(
+                description=mapping.description,
+                groupDescription=mapping.groupDescription,
                 inputLocation=mapping.inputLocation,
                 outputLocation=mapping.outputLocation,
             )

--- a/src/fontra/client/core/classes.json
+++ b/src/fontra/client/core/classes.json
@@ -424,6 +424,14 @@
     }
   },
   "MultipleAxisMapping": {
+    "description": {
+      "type": "str",
+      "optional": true
+    },
+    "groupDescription": {
+      "type": "str",
+      "optional": true
+    },
     "inputLocation": {
       "type": "dict",
       "subtype": "float"

--- a/src/fontra/core/classes.py
+++ b/src/fontra/core/classes.py
@@ -40,6 +40,8 @@ class Axes:
 
 @dataclass(kw_only=True)
 class MultipleAxisMapping:
+    description: Optional[str] = None
+    groupDescription: Optional[str] = None
     inputLocation: Location
     outputLocation: Location
 

--- a/test-py/data/avar2/DemoAvar2.designspace
+++ b/test-py/data/avar2/DemoAvar2.designspace
@@ -4,9 +4,9 @@
     <axis tag="DIAG" name="Diagonal" minimum="0" maximum="100" default="0"/>
     <axis tag="HORI" name="Horizontal" minimum="0" maximum="100" default="0" hidden="true"/>
     <axis tag="VERT" name="Vertical" minimum="0" maximum="100" default="0" hidden="true"/>
-    <mappings>
+    <mappings description="Mappings group one">
 
-      <mapping>
+      <mapping description="Default mapping">
         <input>
           <dimension name="Diagonal" xvalue="0"/>
         </input>

--- a/test-py/test_backends_designspace.py
+++ b/test-py/test_backends_designspace.py
@@ -486,18 +486,23 @@ expectedAxesWithMappings = Axes(
     ],
     mappings=[
         MultipleAxisMapping(
+            description="Default mapping",
+            groupDescription="Mappings group one",
             inputLocation={"Diagonal": 0.0},
             outputLocation={"Horizontal": 0.0, "Vertical": 0.0},
         ),
         MultipleAxisMapping(
+            groupDescription="Mappings group one",
             inputLocation={"Diagonal": 25.0},
             outputLocation={"Horizontal": 0.0, "Vertical": 33.0},
         ),
         MultipleAxisMapping(
+            groupDescription="Mappings group one",
             inputLocation={"Diagonal": 75.0},
             outputLocation={"Horizontal": 100.0, "Vertical": 67.0},
         ),
         MultipleAxisMapping(
+            groupDescription="Mappings group one",
             inputLocation={"Diagonal": 100.0},
             outputLocation={"Horizontal": 100.0, "Vertical": 100.0},
         ),


### PR DESCRIPTION
I modeled the Fontra mappings data structure after the designspaceLib *API*, not the format. I don't quite agree with the format (allowing multiple `<mappings>` sections), and am more at peace with the API (which emulates the grouping through the groupDescription attribute).

This is a followup for #1282.

This PR allows us to round-trip .designspace with `<mappings>` as well as the designspaceLib API allows.