### PR TITLE
Protect against 'foreign' source location axis values

### DIFF
--- a/src/fontra/backends/designspace.py
+++ b/src/fontra/backends/designspace.py
@@ -187,6 +187,7 @@ class DesignspaceBackend:
             for mapping in self.dsDoc.axisMappings
         ]
 
+        self.axisNames = set(defaultLocation)
         self.axisPolePositions = axisPolePositions
         self.defaultLocation = defaultLocation
 
@@ -624,10 +625,11 @@ class DesignspaceBackend:
         return ufoLayer
 
     def _getGlobalPortionOfLocation(self, location, localAxisNames):
+        fontAxisNames = self.axisNames
         globalLocation = {
             name: value
             for name, value in location.items()
-            if name not in localAxisNames
+            if name in fontAxisNames and name not in localAxisNames
         }
         return {**self.defaultLocation, **globalLocation}
 

--- a/src/fontra/core/instancer.py
+++ b/src/fontra/core/instancer.py
@@ -266,6 +266,10 @@ class GlyphInstancer:
         }
 
     @cached_property
+    def combinedAxisNames(self) -> set[str]:
+        return {axis.name for axis in self.combinedAxes}
+
+    @cached_property
     def activeSources(self) -> list[GlyphSource]:
         return [source for source in self.glyph.sources if not source.inactive]
 

--- a/src/fontra/workflow/actions.py
+++ b/src/fontra/workflow/actions.py
@@ -754,6 +754,10 @@ def tuplifyLocation(loc: dict[str, float]) -> tuple:
     return tuple(sorted(loc.items()))
 
 
+def filterLocation(loc: dict[str, float], axisNames: set[str]) -> dict[str, float]:
+    return {name: value for name, value in loc.items() if name in axisNames}
+
+
 def getActiveSources(sources):
     return [source for source in sources if not source.inactive]
 
@@ -1051,12 +1055,16 @@ class TrimAxesAction(BaseFilterAction):
 
 
 def updateSourcesAndLayers(instancer, newLocations) -> VariableGlyph:
+    axisNames = instancer.combinedAxisNames
     glyph = instancer.glyph
 
     sourcesByLocation = {
-        tuplifyLocation(source.location): source for source in instancer.activeSources
+        tuplifyLocation(filterLocation(source.location, axisNames)): source
+        for source in instancer.activeSources
     }
-    locationTuples = sorted({tuplifyLocation(loc) for loc in newLocations})
+    locationTuples = sorted(
+        {tuplifyLocation(filterLocation(loc, axisNames)) for loc in newLocations}
+    )
 
     newSources = []
     newLayers = {}


### PR DESCRIPTION
It is possible (ie. we have data that contains examples) for source locations to contain values for axes that don't exist. Most likely an axis got deleted, but the source wasn't cleaned up. This can cause problems in a couple of places:
- The designspace backend would output too many sources, causing fontmake to chaoke
- Various axis manipulation actions in fontra-workflow could accidentally output non-unique source locations

This PR fixes both problems.