### PR TITLE
Don't set the layerName of a DS source if it is the default layer name

### DIFF
--- a/src/fontra/backends/designspace.py
+++ b/src/fontra/backends/designspace.py
@@ -580,11 +580,14 @@ class DesignspaceBackend:
             )
             ufoLayerName = ufoLayer.name
 
+        reader = manager.getReader(ufoPath)
+        defaultLayerName = reader.getDefaultLayerName()
+
         dsDocSource = self.dsDoc.addSourceDescriptor(
             styleName=source.name,
             location=globalLocation,
             path=ufoPath,
-            layerName=ufoLayerName,
+            layerName=ufoLayerName if ufoLayerName != defaultLayerName else None,
         )
         dsDocSource.fontraUUID = str(uuid.uuid4())
         self._writeDesignSpaceDocument()

--- a/test-py/test_backends_designspace.py
+++ b/test-py/test_backends_designspace.py
@@ -174,7 +174,7 @@ async def test_addNewDenseSource(writableTestFont):
         location=dict(italic=0, weight=150, width=1500),
         styleName="widest",
         filename="MutatorSans_widest.ufo",
-        layerName="public.default",
+        layerName=None,
     )
 
 


### PR DESCRIPTION
Fontmake will consider a designspace source sparse when it has its layername attribute set, even if it is the default layer name. This is fixed by not setting the layer name at all.