### PR TITLE
Fix #1303: first time clicking on the edge of a sidebar

### DIFF
--- a/src/fontra/views/editor/sidebar.js
+++ b/src/fontra/views/editor/sidebar.js
@@ -103,6 +103,9 @@ export class Sidebar {
   }
 
   applyWidth(width, saveLocalStorage = false) {
+    if (width === undefined) {
+      return;
+    }
     if (saveLocalStorage) {
       localStorage.setItem(`fontra-sidebar-width-${this.identifier}`, width);
     }
@@ -176,8 +179,6 @@ export class Sidebar {
       document.addEventListener("pointerup", onPointerUp, { once: true });
     });
     const sidebarWidth = this.getStoredWidth();
-    if (sidebarWidth !== undefined) {
-      this.applyWidth(sidebarWidth);
-    }
+    this.applyWidth(sidebarWidth);
   }
 }


### PR DESCRIPTION
In `initResizeGutter()` of `views/editor/sidebar.js`:
https://github.com/googlefonts/fontra/blob/a723e8dc0d1613b7ee78d3bb64af49a1a99aeb58/src/fontra/views/editor/sidebar.js#L135-L156


width is initialized as `undefined`, and gets determined in the `onpointermove` event listener.

However, "clicking" does not triggers `pointermove` event, but only `pointerup` event.

So line 156 needs change, as width `undefined` is applied to the `applyWidth(width, saveLocalStroage)` method.

However also in line 179-181, null check is needed. https://github.com/googlefonts/fontra/blob/a723e8dc0d1613b7ee78d3bb64af49a1a99aeb58/src/fontra/views/editor/sidebar.js#L179-L181

Therefore I think refactoring `applyWidth(width, saveLocalStroage)` itself to contain null check is better.

This fixes #1303.