### PR TITLE
Fix #1290: Dragging a slider in a dialog closes the dialog

### DIFF
--- a/src/fontra/client/web-components/modal-dialog.js
+++ b/src/fontra/client/web-components/modal-dialog.js
@@ -145,8 +145,13 @@ export class ModalDialog extends SimpleElement {
       onkeydown: (event) => this._handleKeyDown(event),
     });
     this.dialogElement = document.createElement("dialog");
-    this.dialogElement.addEventListener("click", (event) => {
-      if (event.target.nodeName == "DIALOG") {
+    let downInBackdrop;
+    this.dialogElement.addEventListener("pointerdown", (event) => {
+      downInBackdrop = event.target.nodeName == "DIALOG";
+    });
+    this.dialogElement.addEventListener("pointerup", (event) => {
+      const upInBackdrop = event.target.nodeName == "DIALOG";
+      if (upInBackdrop && downInBackdrop) {
         this._dialogDone(null);
       }
     });


### PR DESCRIPTION
I found out that Material UI team had a similar issue: https://github.com/mui/material-ui/issues/22151

They solved it by ensuring that mousedown also happened "outside the dialog box", or "in a backdrop": https://github.com/mui/material-ui/pull/22310/files

First, I implemented it the same way as they did:
1. Record where mousedown happened.
2. Check in a click event listener that mousedown did happen in a backdrop.

But I changed two things:
1. To support more devices, I used pointerdown and pointerup events instead of mousedown and mouseup.
2. When I use click event for the main handler, the dialog closes if I start dragging outside of the dialog-box and then end dragging inside the dialog-box. I thought the only case the dialog closes should be when dragging both starts and ends outside the dialog box. So I used pointerup event instead of click.

This fixes #1290.