### PR TITLE
Don't handle space up when the active element is typable

### DIFF
--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -2210,6 +2210,9 @@ export class EditorController {
   }
 
   spaceKeyUpHandler(event) {
+    if (isActiveElementTypeable()) {
+      return;
+    }
     this.canvasController.sceneView = this.defaultSceneView;
     this.canvasController.requestUpdate();
     for (const overlay of document.querySelectorAll(".cleanable-overlay")) {


### PR DESCRIPTION
This fixes #1328.