### PR TITLE
Add isEditing boolean property to positionedGlyph

### DIFF
--- a/src/fontra/views/editor/scene-model.js
+++ b/src/fontra/views/editor/scene-model.js
@@ -331,8 +331,11 @@ export class SceneModel {
     const fontController = this.fontController;
     const glyphLines = this.glyphLines;
     const align = this.sceneSettings.align;
-    const { lineIndex: selectedLineIndex, glyphIndex: selectedGlyphIndex } =
-      this.selectedGlyph || {};
+    const {
+      lineIndex: selectedLineIndex,
+      glyphIndex: selectedGlyphIndex,
+      isEditing: selectedGlyphIsEditing,
+    } = this.selectedGlyph || {};
     const editLayerName = this.sceneSettings.editLayerName;
 
     let y = 0;
@@ -358,12 +361,11 @@ export class SceneModel {
       const positionedLine = { glyphs: [] };
       let x = 0;
       for (const [glyphIndex, glyphInfo] of enumerate(glyphLine)) {
+        const isSelectedGlyph =
+          lineIndex == selectedLineIndex && glyphIndex == selectedGlyphIndex;
+
         const thisGlyphEditLayerName =
-          editLayerName &&
-          lineIndex == selectedLineIndex &&
-          glyphIndex == selectedGlyphIndex
-            ? editLayerName
-            : undefined;
+          editLayerName && isSelectedGlyph ? editLayerName : undefined;
 
         const varGlyph = await this.fontController.getGlyph(glyphInfo.glyphName);
         let glyphInstance = await this.getGlyphInstance(
@@ -384,6 +386,7 @@ export class SceneModel {
           glyphName: glyphInfo.glyphName,
           character: glyphInfo.character,
           isUndefined: isUndefined,
+          isEditing: !!(isSelectedGlyph && selectedGlyphIsEditing),
         });
         x += glyphInstance.xAdvance;
       }


### PR DESCRIPTION
Add isEditing boolean property to positionedGlyph, so visualization layers can switch behavior if needed.

This is handy for #1342.