### PR TITLE
[wip] [avar2] Redesign designspace navigation panel, rework internal font location vs glyph location

### DIFF
--- a/src/fontra/client/core/glyph-controller.js
+++ b/src/fontra/client/core/glyph-controller.js
@@ -470,7 +470,7 @@ export class VariableGlyphController {
     });
   }
 
-  findNearestSourceFromGlobalLocation(location, skipInactive = false) {
+  findNearestSourceFromUserLocation(location, skipInactive = false) {
     location = this.mapLocationGlobalToLocal(location);
     const splitLoc = splitDiscreteLocation(location, this.discreteAxes);
 

--- a/src/fontra/client/core/html-utils.js
+++ b/src/fontra/client/core/html-utils.js
@@ -164,4 +164,6 @@ export const link = createDomElement.bind(null, "link");
 export const select = createDomElement.bind(null, "select");
 export const option = createDomElement.bind(null, "option");
 export const style = createDomElement.bind(null, "style");
+export const details = createDomElement.bind(null, "details");
+export const summary = createDomElement.bind(null, "summary");
 // Let's add more once needed

--- a/src/fontra/client/tabler-icons/chevron-up.svg
+++ b/src/fontra/client/tabler-icons/chevron-up.svg
@@ -1,0 +1,1 @@
+<svg  xmlns="http://www.w3.org/2000/svg"  width="24"  height="24"  viewBox="0 0 24 24"  fill="none"  stroke="currentColor"  stroke-width="2"  stroke-linecap="round"  stroke-linejoin="round"  class="icon icon-tabler icons-tabler-outline icon-tabler-chevron-up"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M6 15l6 -6l6 6" /></svg>

--- a/src/fontra/client/web-components/icon-button.js
+++ b/src/fontra/client/web-components/icon-button.js
@@ -60,7 +60,13 @@ export class IconButton extends UnlitElement {
 
   render() {
     this._button = html.button(
-      { onclick: this._buttonOnClick, disabled: this._buttonDisabled },
+      {
+        onclick: (event) => {
+          this._buttonOnClick?.(event);
+          event.stopImmediatePropagation();
+        },
+        disabled: this._buttonDisabled,
+      },
       [html.createDomElement("inline-svg", { src: this.src })]
     );
     return this._button;

--- a/src/fontra/client/web-components/ui-accordion.js
+++ b/src/fontra/client/web-components/ui-accordion.js
@@ -9,7 +9,6 @@ export class Accordion extends UnlitElement {
     display: grid;
     grid-template-rows: auto;
     align-content: start;
-    align-items: start;
     gap: 0.5em;
     text-wrap: wrap;
     width: 100%;

--- a/src/fontra/client/web-components/ui-accordion.js
+++ b/src/fontra/client/web-components/ui-accordion.js
@@ -54,7 +54,6 @@ export class Accordion extends UnlitElement {
 
   .ui-accordion-item-content {
     display: block;
-    // min-height: 0;
     box-sizing: border-box;
     overflow: hidden;
   }

--- a/src/fontra/client/web-components/ui-accordion.js
+++ b/src/fontra/client/web-components/ui-accordion.js
@@ -80,6 +80,9 @@ export class Accordion extends UnlitElement {
           item.label,
         ]
       );
+      if (item.auxiliaryHeaderElement) {
+        headerElement.appendChild(item.auxiliaryHeaderElement);
+      }
 
       const contentElement = html.div(
         { class: "ui-accordion-item-content", hidden: !item.open },

--- a/src/fontra/client/web-components/ui-accordion.js
+++ b/src/fontra/client/web-components/ui-accordion.js
@@ -107,8 +107,8 @@ export class Accordion extends UnlitElement {
     ];
   }
 
-  getItemElement(itemID) {
-    return this.shadowRoot.querySelector(`#${itemID}`);
+  querySelector(selector) {
+    return this.shadowRoot.querySelector(selector);
   }
 
   _toggleItem(itemElement) {

--- a/src/fontra/client/web-components/ui-accordion.js
+++ b/src/fontra/client/web-components/ui-accordion.js
@@ -21,6 +21,7 @@ export class Accordion extends UnlitElement {
     grid-template-rows: auto 1fr;
     gap: 0.2em;
     min-height: 0;
+    box-sizing: border-box;
   }
 
   .ui-accordion-item[hidden] {
@@ -34,6 +35,7 @@ export class Accordion extends UnlitElement {
     align-items: center;
     font-weight: bold;
     cursor: pointer;
+    box-sizing: border-box;
   }
 
   .ui-accordion-item .open-close-icon {
@@ -54,7 +56,7 @@ export class Accordion extends UnlitElement {
     display: block;
     // min-height: 0;
     box-sizing: border-box;
-    overflow: auto;
+    overflow: hidden;
   }
   `;
 

--- a/src/fontra/client/web-components/ui-accordion.js
+++ b/src/fontra/client/web-components/ui-accordion.js
@@ -100,7 +100,10 @@ export class Accordion extends UnlitElement {
 
       itemElements.push(itemElement);
     }
-    return html.div({ class: "ui-accordion-contents" }, itemElements);
+    return [
+      html.link({ href: "/css/tooltip.css", rel: "stylesheet" }),
+      html.div({ class: "ui-accordion-contents" }, itemElements),
+    ];
   }
 
   getItemElement(itemID) {

--- a/src/fontra/client/web-components/ui-accordion.js
+++ b/src/fontra/client/web-components/ui-accordion.js
@@ -40,12 +40,11 @@ export class Accordion extends UnlitElement {
   .ui-accordion-item .open-close-icon {
     height: 1.5em;
     width: 1.5em;
-    transform: rotate(180deg);
     transition: 120ms;
   }
 
   .ui-accordion-item.ui-accordion-item-closed .open-close-icon {
-    transform: rotate(0deg);
+    transform: rotate(180deg);
   }
 
   .ui-accordion-item.ui-accordion-item-closed .ui-accordion-item-content {

--- a/src/fontra/client/web-components/ui-accordion.js
+++ b/src/fontra/client/web-components/ui-accordion.js
@@ -1,0 +1,114 @@
+import * as html from "/core/html-utils.js";
+import { UnlitElement } from "/core/html-utils.js";
+import { enumerate } from "/core/utils.js";
+
+export class Accordion extends UnlitElement {
+  static styles = `
+  .ui-accordion-contents {
+    padding: 1em;
+    display: grid;
+    grid-template-rows: auto;
+    align-content: start;
+    align-items: start;
+    gap: 0.5em;
+    text-wrap: wrap;
+    width: 100%;
+    height: 100%;
+    box-sizing: border-box;
+  }
+
+  .ui-accordion-item {
+    display: grid;
+    grid-template-rows: auto 1fr;
+    gap: 0.2em;
+    min-height: 0;
+  }
+
+  .ui-accordion-item[hidden] {
+    display: none;
+  }
+
+  .ui-accordion-item-header {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    justify-content: start;
+    align-items: center;
+    font-weight: bold;
+    cursor: pointer;
+  }
+
+  .ui-accordion-item .open-close-icon {
+    height: 1.5em;
+    width: 1.5em;
+    transform: rotate(180deg);
+    transition: 120ms;
+  }
+
+  .ui-accordion-item.ui-accordion-item-closed .open-close-icon {
+    transform: rotate(0deg);
+  }
+
+  .ui-accordion-item.ui-accordion-item-closed .ui-accordion-item-content {
+    display: none;
+  }
+
+  .ui-accordion-item-content {
+    display: block;
+    // min-height: 0;
+    box-sizing: border-box;
+    overflow: auto;
+  }
+  `;
+
+  static properties = {
+    items: { type: Array },
+  };
+
+  render() {
+    const itemElements = [];
+    for (const [index, item] of enumerate(this.items || [])) {
+      const id = item.id || `ui-accordion-item-${index}`;
+
+      const headerElement = html.div(
+        {
+          class: "ui-accordion-item-header",
+          onclick: (event) => this._toggleItem(itemElement),
+        },
+        [
+          html.createDomElement("inline-svg", {
+            class: "open-close-icon",
+            src: "/tabler-icons/chevron-up.svg",
+          }),
+          item.label,
+        ]
+      );
+
+      const contentElement = html.div(
+        { class: "ui-accordion-item-content", hidden: !item.open },
+        [item.content]
+      );
+
+      const itemElement = html.div(
+        { class: "ui-accordion-item", id: id, hidden: !!item.hidden },
+        [headerElement, contentElement]
+      );
+
+      if (!item.open) {
+        itemElement.classList.add("ui-accordion-item-closed");
+      }
+
+      itemElements.push(itemElement);
+    }
+    return html.div({ class: "ui-accordion-contents" }, itemElements);
+  }
+
+  getItemElement(itemID) {
+    return this.shadowRoot.querySelector(`#${itemID}`);
+  }
+
+  _toggleItem(itemElement) {
+    itemElement.classList.toggle("ui-accordion-item-closed");
+  }
+}
+
+customElements.define("ui-accordion", Accordion);

--- a/src/fontra/views/editor/cjk-design-frame.js
+++ b/src/fontra/views/editor/cjk-design-frame.js
@@ -14,9 +14,12 @@ export class CJKDesignFrame {
       this.updateCJKDesignFrame(cjkDesignFrameGlyphName)
     );
 
-    editor.sceneSettingsController.addKeyListener("location", (event) => {
-      this.updateCJKDesignFrame(cjkDesignFrameGlyphName);
-    });
+    editor.sceneSettingsController.addKeyListener(
+      ["location", "glyphLocation"],
+      (event) => {
+        this.updateCJKDesignFrame(cjkDesignFrameGlyphName);
+      }
+    );
 
     registerVisualizationLayerDefinition({
       identifier: "fontra.cjk.design.frame",

--- a/src/fontra/views/editor/edit-tools-power-ruler.js
+++ b/src/fontra/views/editor/edit-tools-power-ruler.js
@@ -51,7 +51,7 @@ export class PowerRulerTool extends BaseTool {
     this.active = editor.visualizationLayersSettings.model[POWER_RULER_IDENTIFIER];
 
     editor.sceneSettingsController.addKeyListener(
-      "location",
+      ["location", "glyphLocation"],
       throttleCalls(() => setTimeout(() => this.locationChanged(), 0), 20)
     );
 

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -622,7 +622,7 @@ export class EditorController {
       case "goToNearestSource":
         const glyphController =
           await this.sceneModel.getSelectedVariableGlyphController();
-        const nearestSourceIndex = glyphController.findNearestSourceFromGlobalLocation(
+        const nearestSourceIndex = glyphController.findNearestSourceFromUserLocation(
           { ...this.sceneSettings.location, ...this.sceneSettings.glyphLocation },
           true
         );
@@ -2113,7 +2113,7 @@ export class EditorController {
     const sourceIndex = this.sceneSettings.selectedSourceIndex;
     let newSourceIndex;
     if (sourceIndex === undefined) {
-      newSourceIndex = varGlyphController.findNearestSourceFromGlobalLocation({
+      newSourceIndex = varGlyphController.findNearestSourceFromUserLocation({
         ...this.sceneSettings.location,
         ...this.sceneSettings.glyphLocation,
       });

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -2396,7 +2396,7 @@ export class EditorController {
     if (this.sceneSettings.selectedGlyph) {
       viewInfo["selectedGlyph"] = this.sceneSettings.selectedGlyph;
     }
-    viewInfo["location"] = this.sceneController.getGlobalLocation();
+    viewInfo["location"] = this.sceneSettings.location;
     const localLocations = this.sceneController.getLocalLocations(true);
     if (Object.keys(localLocations).length) {
       viewInfo["localLocations"] = localLocations;

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -137,7 +137,15 @@ export class EditorController {
     this.sceneModel = this.sceneController.sceneModel;
 
     this.sceneSettingsController.addKeyListener(
-      ["align", "location", "selectedGlyph", "selection", "text", "viewBox"],
+      [
+        "align",
+        "location",
+        "glyphLocation",
+        "selectedGlyph",
+        "selection",
+        "text",
+        "viewBox",
+      ],
       (event) => {
         if (event.senderInfo?.senderID !== this && !event.senderInfo?.adjustViewBox) {
           this.updateWindowLocation(); // scheduled with delay
@@ -615,7 +623,7 @@ export class EditorController {
         const glyphController =
           await this.sceneModel.getSelectedVariableGlyphController();
         const nearestSourceIndex = glyphController.findNearestSourceFromGlobalLocation(
-          this.sceneSettings.location,
+          { ...this.sceneSettings.location, ...this.sceneSettings.glyphLocation },
           true
         );
         this.sceneSettings.selectedSourceIndex = nearestSourceIndex;
@@ -1583,6 +1591,7 @@ export class EditorController {
       // Force sync between location and selectedSourceIndex, as the glyph's
       // source list may have changed
       this.sceneSettings.location = { ...this.sceneSettings.location };
+      this.sceneSettings.glyphLocation = { ...this.sceneSettings.glyphLocation };
     } else {
       await this._pasteLayerGlyphs(pasteLayerGlyphs);
     }
@@ -2104,9 +2113,10 @@ export class EditorController {
     const sourceIndex = this.sceneSettings.selectedSourceIndex;
     let newSourceIndex;
     if (sourceIndex === undefined) {
-      newSourceIndex = varGlyphController.findNearestSourceFromGlobalLocation(
-        this.sceneSettings.location
-      );
+      newSourceIndex = varGlyphController.findNearestSourceFromGlobalLocation({
+        ...this.sceneSettings.location,
+        ...this.sceneSettings.glyphLocation,
+      });
     } else {
       const numSources = varGlyphController.sources.length;
       newSourceIndex =
@@ -2271,6 +2281,7 @@ export class EditorController {
     // Force sync between location and selectedSourceIndex, as the glyph's
     // source list may have changed
     this.sceneSettings.location = { ...this.sceneSettings.location };
+    this.sceneSettings.glyphLocation = { ...this.sceneSettings.glyphLocation };
     await this.sceneModel.updateScene();
     this.canvasController.requestUpdate();
   }

--- a/src/fontra/views/editor/panel-designspace-navigation.js
+++ b/src/fontra/views/editor/panel-designspace-navigation.js
@@ -630,7 +630,7 @@ export default class DesignspaceNavigationPanel extends Panel {
     this.sourcesList.setItems(sourceItems, false, true);
     this.sourcesList.setSelectedItemIndex(this.sceneSettings.selectedSourceIndex);
 
-    this.glyphSourcesDetails.hidden = !sourceItems.length;
+    this.glyphSourcesDetails.hidden = !varGlyphController;
 
     this._updateRemoveSourceButtonState();
     this._updateEditingStatus();

--- a/src/fontra/views/editor/panel-designspace-navigation.js
+++ b/src/fontra/views/editor/panel-designspace-navigation.js
@@ -497,7 +497,7 @@ export default class DesignspaceNavigationPanel extends Panel {
       return;
     }
     const interpolationContributions = varGlyphController.getInterpolationContributions(
-      this.sceneSettings.location
+      { ...this.sceneSettings.location, ...this.sceneSettings.glyphLocation }
     );
     for (const [index, sourceItem] of enumerate(this.sourcesList.items)) {
       sourceItem.interpolationContribution =
@@ -532,8 +532,10 @@ export default class DesignspaceNavigationPanel extends Panel {
     const sourceInterpolationStatus =
       varGlyphController?.sourceInterpolationStatus || [];
     const interpolationContributions =
-      varGlyphController?.getInterpolationContributions(this.sceneSettings.location) ||
-      [];
+      varGlyphController?.getInterpolationContributions({
+        ...this.sceneSettings.location,
+        ...this.sceneSettings.glyphLocation,
+      }) || [];
     let backgroundLayers = { ...this.sceneController.backgroundLayers };
     let editingLayers = { ...this.sceneController.editingLayers };
 
@@ -692,6 +694,7 @@ export default class DesignspaceNavigationPanel extends Panel {
     const glyph = glyphController.glyph;
 
     const location = glyphController.mapLocationGlobalToLocal(
+      // TODO: FIX for glyphLocation
       this.sceneSettings.location
     );
 

--- a/src/fontra/views/editor/panel-designspace-navigation.js
+++ b/src/fontra/views/editor/panel-designspace-navigation.js
@@ -105,7 +105,10 @@ export default class DesignspaceNavigationPanel extends Panel {
         label: "Glyph sources",
         open: true,
         content: html.div(
-          { id: "sources-list-container", class: "accordion-item-contents" },
+          {
+            style:
+              "display: grid; grid-template-rows: 1fr auto auto; height: 100%; box-sizing: border-box;",
+          },
           [
             html.createDomElement("ui-list", { id: "sources-list" }),
             html.createDomElement("add-remove-buttons", {

--- a/src/fontra/views/editor/panel-designspace-navigation.js
+++ b/src/fontra/views/editor/panel-designspace-navigation.js
@@ -39,105 +39,10 @@ export default class DesignspaceNavigationPanel extends Panel {
   iconPath = "/images/sliders.svg";
 
   static styles = `
-    ui-accordion {
-      display: block;
-      height: 100%;
-    }
-
-    /* ---------------------------------------------------- */
-
-    #designspace-navigation {
-      height: 100%;
-      width: 100%;
-      padding: 1em;
-      display: grid;
-      grid-template-rows: auto;
-      align-content: start;
-      gap: 0.4em;
-      box-sizing: border-box;
-    }
-
-    /* this is to counteract the undesired interaction between button.hidden
-       and display: block */
-    [hidden] {
-      display: none !important;
-    }
-
-    .accordion-item {
-      display: grid;
-      grid-template-rows: auto 1fr;
-      min-height: 0;
-    }
-
-    .accordion-item[hidden] {
-      display: none;
-    }
-
-    icon-button {
-      display: block;
-      width: 1.5em;
-      height: 1.5em;
-    }
-
-    #sources-list-container {
-      display: grid;
-      gap: 0.2em;
-    }
-
-    .accordion-item-close #sources-list-container {
-      display: none;
-    }
-
-    .accordion-item-contents {
-      display: block;
-      box-sizing: border-box;
-      // height: calc(100% - 3em);
-      overflow: auto;
-      // min-height: 5em;
-    }
-
-    #sources-list {
-      min-height: 100px;
-      flex-shrink: 1000;
-    }
-
-    #interpolation-error-info {
-      text-wrap: wrap;
-    }
-
-    inline-svg {
-      display: inline-block;
-      height: 1.35em;
-      width: 1.35em;
-      color: var(--fontra-light-red-color);
-      transform: translate(0, 0.3em);
-      margin-right: 0.25em;
-    }
-
-    .accordion-header {
-      display: grid;
-      grid-template-columns: 1.2em 1fr 1.2em 1.2em;
-      align-items: center;
-      gap: 0.2em;
-      justify-content: space-between;
-      font-weight: bold;
-      cursor: pointer;
-    }
-
-    .accordion-header-button {
-      width: 1.3em ;
-    }
-
-    .accordion-item-close .accordion-item-contents {
-      display: none;
-    }
-
-    .accordion-chevron {
-      transition: 120ms;
-    }
-    .accordion-item-close .accordion-chevron {
-      transform: rotate(180deg);
-    }
+    // ui-accordion {
+    //   display: block;
+    //   height: 100%;
+    // }
   `;
 
   constructor(editorController) {
@@ -158,14 +63,6 @@ export default class DesignspaceNavigationPanel extends Panel {
   }
 
   getContentElement() {
-    if (true) {
-      return this.getContentElement_inline();
-    } else {
-      return this.getContentElement_accordion();
-    }
-  }
-
-  getContentElement_accordion() {
     const accordion = new Accordion();
     accordion.items = [
       {
@@ -173,6 +70,19 @@ export default class DesignspaceNavigationPanel extends Panel {
         label: "Font axes",
         open: true,
         content: html.createDomElement("designspace-location", { id: "font-axes" }, []),
+        auxiliaryHeaderElement: groupAccordionHeaderButtons([
+          makeAccordionHeaderButton({
+            icon: "tool",
+            tooltip: "Edit font axes",
+            // onclick: (event) => console.log("edit font axes"),
+          }),
+          makeAccordionHeaderButton({
+            icon: "refresh",
+            id: "reset-font-axes-button",
+            tooltip: "Reset font axes",
+            onclick: (event) => this.resetFontAxesToDefault(),
+          }),
+        ]),
       },
       {
         id: "glyph-axes-accordion-item",
@@ -183,6 +93,19 @@ export default class DesignspaceNavigationPanel extends Panel {
           { id: "glyph-axes" },
           []
         ),
+        auxiliaryHeaderElement: groupAccordionHeaderButtons([
+          makeAccordionHeaderButton({
+            icon: "tool",
+            tooltip: "Edit glyph axes",
+            onclick: (event) => this.editGlyphAxes(),
+          }),
+          makeAccordionHeaderButton({
+            icon: "refresh",
+            id: "reset-glyph-axes-button",
+            tooltip: "Reset glyph axes",
+            onclick: (event) => this.resetFontAxesToDefault(),
+          }),
+        ]),
       },
       {
         id: "glyph-sources-accordion-item",
@@ -206,129 +129,6 @@ export default class DesignspaceNavigationPanel extends Panel {
 
     this.qs = accordion.shadowRoot.querySelector.bind(accordion.shadowRoot);
     return accordion;
-  }
-
-  getContentElement_inline() {
-    const toggleItem = (event) => {
-      let el = event.target;
-      for (const i of range(3)) {
-        if (el.classList.contains("accordion-item")) {
-          break;
-        }
-        el = el.parentElement;
-      }
-      el.classList.toggle("accordion-item-close");
-    };
-
-    const contentElement = html.div(
-      {
-        id: "designspace-navigation",
-      },
-      [
-        html.link({ href: "/css/tooltip.css", rel: "stylesheet" }),
-        html.div(
-          {
-            class: "accordion-item",
-            id: "font-axes-accordion-item",
-            open: true,
-            // ontoggle: (event) => console.log("toggle", event.target.open),
-          },
-          [
-            html.div({ class: "accordion-header", onclick: toggleItem }, [
-              html.createDomElement("icon-button", {
-                src: `/tabler-icons/chevron-up.svg`,
-                class: "accordion-header-button accordion-chevron",
-              }),
-              "Font axes",
-              html.createDomElement("icon-button", {
-                "src": `/tabler-icons/tool.svg`,
-                "class": "accordion-header-button",
-                "data-tooltip": "Edit font axes",
-                "data-tooltipposition": "bottom",
-              }),
-              html.createDomElement("icon-button", {
-                "id": "reset-font-axes-button",
-                "src": `/tabler-icons/refresh.svg`,
-                "class": "accordion-header-button",
-                "onclick": (event) => this.resetFontAxesToDefault(event),
-                "data-tooltip": "Reset font axes",
-                "data-tooltipposition": "bottom",
-              }),
-            ]),
-            html.div({ class: "accordion-item-contents" }, [
-              html.createDomElement("designspace-location", { id: "font-axes" }, []),
-            ]),
-          ]
-        ),
-        html.div(
-          {
-            class: "accordion-item",
-            id: "glyph-axes-accordion-item",
-            open: true,
-            // ontoggle: (event) => console.log("toggle", event.target.open),
-          },
-          [
-            html.div({ class: "accordion-header", onclick: toggleItem }, [
-              html.createDomElement("icon-button", {
-                src: `/tabler-icons/chevron-up.svg`,
-                class: "accordion-header-button accordion-chevron",
-              }),
-              "Glyph axes",
-              html.createDomElement("icon-button", {
-                "src": `/tabler-icons/tool.svg`,
-                "class": "accordion-header-button",
-                "onclick": (event) => this.editGlyphAxes(event),
-                "data-tooltip": "Edit glyph axes",
-                "data-tooltipposition": "bottom",
-              }),
-              html.createDomElement("icon-button", {
-                "id": "reset-glyph-axes-button",
-                "src": `/tabler-icons/refresh.svg`,
-                "class": "accordion-header-button",
-                "onclick": (event) => this.resetGlyphAxesToDefault(event),
-                "data-tooltip": "Reset glyph axes",
-                "data-tooltipposition": "bottom",
-              }),
-            ]),
-            html.div({ class: "accordion-item-contents" }, [
-              html.createDomElement("designspace-location", { id: "glyph-axes" }, []),
-            ]),
-          ]
-        ),
-        html.div(
-          {
-            class: "accordion-item",
-            id: "glyph-sources-accordion-item",
-            open: true,
-          },
-          [
-            html.div({ class: "accordion-header", onclick: toggleItem }, [
-              html.createDomElement("icon-button", {
-                src: `/tabler-icons/chevron-up.svg`,
-                class: "accordion-header-button accordion-chevron",
-              }),
-              "Glyph sources",
-            ]),
-            html.div(
-              { id: "sources-list-container", class: "accordion-item-contents" },
-              [
-                html.createDomElement("ui-list", { id: "sources-list" }),
-                html.createDomElement("add-remove-buttons", {
-                  style: "padding: 0.5em 0 0 0;",
-                  id: "sources-list-add-remove-buttons",
-                }),
-                html.createDomElement("div", {
-                  id: "interpolation-error-info",
-                }),
-              ]
-            ),
-          ]
-        ),
-      ]
-    );
-
-    this.qs = contentElement.querySelector.bind(contentElement);
-    return contentElement;
   }
 
   get fontAxesElement() {
@@ -595,7 +395,7 @@ export default class DesignspaceNavigationPanel extends Panel {
       }
     }
     const button = this.qs("#reset-font-axes-button");
-    // button.disabled = locationEmpty;
+    button.disabled = locationEmpty;
   }
 
   async onVisibilityHeaderClick(event) {
@@ -1438,6 +1238,32 @@ function makeClickableIconHeader(iconPath, onClick) {
       }),
     ]
   );
+}
+
+function groupAccordionHeaderButtons(buttons) {
+  return html.div(
+    { style: `display: grid; grid-template-columns: repeat(${buttons.length}, auto)` },
+    buttons
+  );
+}
+
+function makeAccordionHeaderButton(button) {
+  const options = {
+    style: "width: 1.4em; height: 1.4em;",
+    src: `/tabler-icons/${button.icon}.svg`,
+    onclick: button.onclick,
+  };
+
+  if (button.id) {
+    options.id = button.id;
+  }
+
+  if (button.tooltip) {
+    options["data-tooltip"] = button.tooltip;
+    options["data-tooltipposition"] = "bottom";
+  }
+
+  return html.createDomElement("icon-button", options);
 }
 
 customElements.define("panel-designspace-navigation", DesignspaceNavigationPanel);

--- a/src/fontra/views/editor/panel-designspace-navigation.js
+++ b/src/fontra/views/editor/panel-designspace-navigation.js
@@ -44,7 +44,7 @@ export default class DesignspaceNavigationPanel extends Panel {
       padding: 1em;
       display: flex;
       flex-direction: column;
-      gap: 0.1em;
+      gap: 0.4em;
       box-sizing: border-box;
     }
 

--- a/src/fontra/views/editor/panel-designspace-navigation.js
+++ b/src/fontra/views/editor/panel-designspace-navigation.js
@@ -1161,6 +1161,7 @@ function roundComponentOrigins(components) {
 }
 
 function getAxisInfoFromGlyph(glyph) {
+  // Fold NLI axes into single axes
   const axisInfo = {};
   for (const axis of glyph?.axes || []) {
     const baseName = getAxisBaseName(axis.name);

--- a/src/fontra/views/editor/panel-designspace-navigation.js
+++ b/src/fontra/views/editor/panel-designspace-navigation.js
@@ -174,7 +174,7 @@ export default class DesignspaceNavigationPanel extends Panel {
             html.createDomElement(
               "designspace-location",
               {
-                id: "designspace-location",
+                id: "font-location",
               },
               []
             ),
@@ -226,12 +226,10 @@ export default class DesignspaceNavigationPanel extends Panel {
   }
 
   setup() {
-    this.designspaceLocation = this.contentElement.querySelector(
-      "#designspace-location"
-    );
-    this.designspaceLocation.values = this.sceneSettings.location;
+    this.fontLocationElement = this.contentElement.querySelector("#font-location");
+    this.fontLocationElement.values = this.sceneSettings.location;
 
-    this.designspaceLocation.addEventListener(
+    this.fontLocationElement.addEventListener(
       "locationChanged",
       scheduleCalls(async (event) => {
         this.sceneController.scrollAdjustBehavior = "pin-glyph-center";
@@ -239,7 +237,7 @@ export default class DesignspaceNavigationPanel extends Panel {
 
         this.sceneSettingsController.setItem(
           "location",
-          { ...this.designspaceLocation.values },
+          { ...this.fontLocationElement.values },
           { senderID: this }
         );
       })
@@ -270,7 +268,7 @@ export default class DesignspaceNavigationPanel extends Panel {
           // Sent by us, ignore
           return;
         }
-        this.designspaceLocation.values = event.newValue;
+        this.fontLocationElement.values = event.newValue;
       },
       true
     );
@@ -466,7 +464,7 @@ export default class DesignspaceNavigationPanel extends Panel {
   _updateResetAllAxesButtonState() {
     const location = this.sceneSettings.location;
     let locationEmpty = true;
-    for (const axis of this.designspaceLocation.axes) {
+    for (const axis of this.fontLocationElement.axes) {
       if (
         axis.name &&
         axis.name in location &&
@@ -478,7 +476,7 @@ export default class DesignspaceNavigationPanel extends Panel {
     }
     const button = this.contentElement.querySelector("#reset-font-axes-button");
     button.disabled = locationEmpty;
-    button.hidden = !this.designspaceLocation.axes.length;
+    button.hidden = !this.fontLocationElement.axes.length;
   }
 
   async onVisibilityHeaderClick(event) {
@@ -556,7 +554,7 @@ export default class DesignspaceNavigationPanel extends Panel {
         axes.push(...localAxes);
       }
     }
-    this.designspaceLocation.axes = axes;
+    this.fontLocationElement.axes = axes;
 
     this._updateResetAllAxesButtonState();
   }
@@ -629,7 +627,7 @@ export default class DesignspaceNavigationPanel extends Panel {
     this.sourcesList.setSelectedItemIndex(this.sceneSettings.selectedSourceIndex);
     this.addRemoveSourceButtons.hidden = !sourceItems.length;
     this.addRemoveSourceButtons.disableAddButton =
-      !this.designspaceLocation.axes.length;
+      !this.fontLocationElement.axes.length;
 
     this._updateRemoveSourceButtonState();
     this._updateEditingStatus();

--- a/src/fontra/views/editor/panel-designspace-navigation.js
+++ b/src/fontra/views/editor/panel-designspace-navigation.js
@@ -100,7 +100,7 @@ export default class DesignspaceNavigationPanel extends Panel {
             icon: "refresh",
             id: "reset-glyph-axes-button",
             tooltip: "Reset glyph axes",
-            onclick: (event) => this.resetFontAxesToDefault(),
+            onclick: (event) => this.resetGlyphAxesToDefault(),
           }),
         ]),
       },
@@ -149,8 +149,7 @@ export default class DesignspaceNavigationPanel extends Panel {
 
   setup() {
     this.fontAxesElement.values = this.sceneSettings.location;
-
-    // this.glyphAxesElement.values = this.sceneSettings.location;
+    this.glyphAxesElement.values = this.sceneSettings.glyphLocation;
 
     this.fontAxesElement.addEventListener(
       "locationChanged",
@@ -161,6 +160,19 @@ export default class DesignspaceNavigationPanel extends Panel {
         this.sceneSettingsController.setItem(
           "location",
           { ...this.fontAxesElement.values },
+          { senderID: this }
+        );
+      })
+    );
+
+    this.glyphAxesElement.addEventListener(
+      "locationChanged",
+      scheduleCalls(async (event) => {
+        this.sceneController.scrollAdjustBehavior = "pin-glyph-center";
+        this.sceneController.autoViewBox = false;
+        this.sceneSettingsController.setItem(
+          "glyphLocation",
+          { ...this.glyphAxesElement.values },
           { senderID: this }
         );
       })
@@ -181,7 +193,7 @@ export default class DesignspaceNavigationPanel extends Panel {
     );
 
     this.sceneSettingsController.addKeyListener(
-      "location",
+      ["location", "glyphLocation"],
       (event) => {
         this.sceneSettings.editLayerName = null;
         this.updateResetAllAxesButtonState();
@@ -191,7 +203,12 @@ export default class DesignspaceNavigationPanel extends Panel {
           // Sent by us, ignore
           return;
         }
-        this.fontAxesElement.values = event.newValue;
+        if (event.key === "location") {
+          this.fontAxesElement.values = event.newValue;
+        } else {
+          // (event.key === "glyphLocation")
+          this.glyphAxesElement.values = event.newValue;
+        }
       },
       true
     );
@@ -399,7 +416,7 @@ export default class DesignspaceNavigationPanel extends Panel {
   }
 
   resetGlyphAxesToDefault(event) {
-    // TODO: implement
+    this.sceneSettings.glyphLocation = {};
   }
 
   _updateResetAllAxesButtonState() {

--- a/src/fontra/views/editor/panel-designspace-navigation.js
+++ b/src/fontra/views/editor/panel-designspace-navigation.js
@@ -476,7 +476,6 @@ export default class DesignspaceNavigationPanel extends Panel {
     }
     const button = this.contentElement.querySelector("#reset-font-axes-button");
     button.disabled = locationEmpty;
-    button.hidden = !this.fontLocationElement.axes.length;
   }
 
   async onVisibilityHeaderClick(event) {

--- a/src/fontra/views/editor/panel-designspace-navigation.js
+++ b/src/fontra/views/editor/panel-designspace-navigation.js
@@ -142,24 +142,23 @@ export default class DesignspaceNavigationPanel extends Panel {
       },
     ];
 
-    this.qs = accordion.shadowRoot.querySelector.bind(accordion.shadowRoot);
     return accordion;
   }
 
   get fontAxesElement() {
-    return this.qs("#font-axes");
+    return this.contentElement.querySelector("#font-axes");
   }
 
   get glyphAxesElement() {
-    return this.qs("#glyph-axes");
+    return this.contentElement.querySelector("#glyph-axes");
   }
 
   get glyphAxesAccordionItem() {
-    return this.qs("#glyph-axes-accordion-item");
+    return this.contentElement.querySelector("#glyph-axes-accordion-item");
   }
 
   get glyphSourcesAccordionItem() {
-    return this.qs("#glyph-sources-accordion-item");
+    return this.contentElement.querySelector("#glyph-sources-accordion-item");
   }
 
   setup() {
@@ -353,7 +352,7 @@ export default class DesignspaceNavigationPanel extends Panel {
       width: "1.2em",
     });
 
-    this.sourcesList = this.qs("#sources-list");
+    this.sourcesList = this.contentElement.querySelector("#sources-list");
     this.sourcesList.appendStyle(`
       .clickable-icon-header {
         transition: 150ms;
@@ -368,7 +367,9 @@ export default class DesignspaceNavigationPanel extends Panel {
     this.sourcesList.showHeader = true;
     this.sourcesList.columnDescriptions = columnDescriptions;
 
-    this.addRemoveSourceButtons = this.qs("#sources-list-add-remove-buttons");
+    this.addRemoveSourceButtons = this.contentElement.querySelector(
+      "#sources-list-add-remove-buttons"
+    );
 
     this.addRemoveSourceButtons.addButtonCallback = () => this.addSource();
     this.addRemoveSourceButtons.removeButtonCallback = () => this.removeSource();
@@ -454,7 +455,7 @@ export default class DesignspaceNavigationPanel extends Panel {
           break;
         }
       }
-      const button = this.qs(`#${buttonID}`);
+      const button = this.contentElement.querySelector(`#${buttonID}`);
       button.disabled = locationEmpty;
     }
   }
@@ -1078,7 +1079,7 @@ export default class DesignspaceNavigationPanel extends Panel {
   }
 
   async _updateInterpolationErrorInfo() {
-    const infoElement = this.qs("#interpolation-error-info");
+    const infoElement = this.contentElement.querySelector("#interpolation-error-info");
     const varGlyphController =
       await this.sceneModel.getSelectedVariableGlyphController();
     const glyphController = await this.sceneModel.getSelectedStaticGlyphController();

--- a/src/fontra/views/editor/panel-designspace-navigation.js
+++ b/src/fontra/views/editor/panel-designspace-navigation.js
@@ -578,7 +578,7 @@ export default class DesignspaceNavigationPanel extends Panel {
       ? getAxisInfoFromGlyph(varGlyphController)
       : [];
     this.glyphAxesElement.axes = localAxes;
-    this.glyphAxesAccordionItem.hidden = !localAxes.length;
+    this.glyphAxesAccordionItem.hidden = !varGlyphController;
 
     this._updateResetAllAxesButtonState();
   }

--- a/src/fontra/views/editor/panel-designspace-navigation.js
+++ b/src/fontra/views/editor/panel-designspace-navigation.js
@@ -425,20 +425,28 @@ export default class DesignspaceNavigationPanel extends Panel {
   }
 
   _updateResetAllAxesButtonState() {
-    const location = this.sceneSettings.location;
-    let locationEmpty = true;
-    for (const axis of this.fontAxesElement.axes) {
-      if (
-        axis.name &&
-        axis.name in location &&
-        location[axis.name] !== axis.defaultValue
-      ) {
-        locationEmpty = false;
-        break;
+    for (const [location, axesElement, buttonID] of [
+      [this.sceneSettings.location, this.fontAxesElement, "reset-font-axes-button"],
+      [
+        this.sceneSettings.glyphLocation,
+        this.glyphAxesElement,
+        "reset-glyph-axes-button",
+      ],
+    ]) {
+      let locationEmpty = true;
+      for (const axis of axesElement.axes) {
+        if (
+          axis.name &&
+          axis.name in location &&
+          location[axis.name] !== axis.defaultValue
+        ) {
+          locationEmpty = false;
+          break;
+        }
       }
+      const button = this.qs(`#${buttonID}`);
+      button.disabled = locationEmpty;
     }
-    const button = this.qs("#reset-font-axes-button");
-    button.disabled = locationEmpty;
   }
 
   async onVisibilityHeaderClick(event) {

--- a/src/fontra/views/editor/panel-designspace-navigation.js
+++ b/src/fontra/views/editor/panel-designspace-navigation.js
@@ -196,7 +196,7 @@ export default class DesignspaceNavigationPanel extends Panel {
                 html.createDomElement("icon-button", {
                   "src": `/tabler-icons/tool.svg`,
                   "class": "section-header-button",
-                  "onclick": (event) => this.editLocalAxes(event),
+                  "onclick": (event) => this.editGlyphAxes(event),
                   "data-tooltip": "Edit glyph axes",
                   "data-tooltipposition": "bottom",
                 }),
@@ -1011,13 +1011,13 @@ export default class DesignspaceNavigationPanel extends Panel {
     return { contentElement, warningElement };
   }
 
-  async editLocalAxes() {
+  async editGlyphAxes() {
     const varGlyphController =
       await this.sceneModel.getSelectedVariableGlyphController();
     if (!varGlyphController) {
       return;
     }
-    const dialog = await dialogSetup("Edit local axes", null, [
+    const dialog = await dialogSetup("Edit glyph axes", null, [
       { title: "Cancel", isCancelButton: true },
       { title: "Okay", isDefaultButton: true, result: "ok" },
     ]);

--- a/src/fontra/views/editor/panel-designspace-navigation.js
+++ b/src/fontra/views/editor/panel-designspace-navigation.js
@@ -38,13 +38,6 @@ export default class DesignspaceNavigationPanel extends Panel {
   identifier = "designspace-navigation";
   iconPath = "/images/sliders.svg";
 
-  static styles = `
-    // ui-accordion {
-    //   display: block;
-    //   height: 100%;
-    // }
-  `;
-
   constructor(editorController) {
     super(editorController);
     this.fontController = this.editorController.fontController;

--- a/src/fontra/views/editor/panel-designspace-navigation.js
+++ b/src/fontra/views/editor/panel-designspace-navigation.js
@@ -71,7 +71,12 @@ export default class DesignspaceNavigationPanel extends Panel {
           makeAccordionHeaderButton({
             icon: "tool",
             tooltip: "Edit font axes",
-            // onclick: (event) => console.log("edit font axes"),
+            onclick: (event) => {
+              const url = new URL(window.location);
+              url.pathname = url.pathname.replace("/editor/", "/fontinfo/");
+              url.hash = "#axes-panel";
+              window.open(url.toString());
+            },
           }),
           makeAccordionHeaderButton({
             icon: "refresh",

--- a/src/fontra/views/editor/panel-designspace-navigation.js
+++ b/src/fontra/views/editor/panel-designspace-navigation.js
@@ -42,8 +42,9 @@ export default class DesignspaceNavigationPanel extends Panel {
       height: 100%;
       width: 100%;
       padding: 1em;
-      display: flex;
-      flex-direction: column;
+      display: grid;
+      grid-template-rows: auto;
+      align-content: start;
       gap: 0.4em;
       box-sizing: border-box;
     }
@@ -58,6 +59,17 @@ export default class DesignspaceNavigationPanel extends Panel {
       display: block;
       width: 1.5em;
       height: 1.5em;
+    }
+
+    #sources-list-container {
+      display: grid;
+      gap: 0.0em;
+    }
+
+    .details-contents-container {
+      // height: 100%;
+      // overflow: hidden;
+      min-height: 0;
     }
 
     #sources-list {
@@ -79,8 +91,10 @@ export default class DesignspaceNavigationPanel extends Panel {
     }
 
     details {
-      display: flex;
+      // display: grid;
       outline: none;
+      // overflow-y: auto;
+      min-height: 0;
     }
 
     summary:focus {
@@ -99,6 +113,18 @@ export default class DesignspaceNavigationPanel extends Panel {
       cursor: pointer;
       font-weight: bold;
       margin-bottom: 0.2em;
+    }
+
+    details > designspace-location {
+      // height: 100%;
+      min-height: 0;
+      overflow-y: hidden;
+      // height: fit-content;
+    }
+
+    details > source-list {
+      // min-height: 0;
+      // height: 100%;
     }
 
     .section-summary {
@@ -180,7 +206,9 @@ export default class DesignspaceNavigationPanel extends Panel {
                 }),
               ]),
             ]),
-            html.createDomElement("designspace-location", { id: "font-axes" }, []),
+            html.div({ class: "details-contents-container" }, [
+              html.createDomElement("designspace-location", { id: "font-axes" }, []),
+            ]),
           ]
         ),
         html.details(
@@ -210,21 +238,26 @@ export default class DesignspaceNavigationPanel extends Panel {
                 }),
               ]),
             ]),
-            html.createDomElement("designspace-location", { id: "glyph-axes" }, []),
+            html.div({ class: "details-contents-container" }, [
+              html.createDomElement("designspace-location", { id: "glyph-axes" }, []),
+            ]),
           ]
         ),
         html.details({ id: "glyph-sources-details", open: true }, [
           html.summary({}, [html.div({ class: "section-summary" }, ["Glyph sources"])]),
-          html.createDomElement("ui-list", {
-            id: "sources-list",
-          }),
-          html.createDomElement("add-remove-buttons", {
-            style: "padding: 0.5em 0 0 0;",
-            id: "sources-list-add-remove-buttons",
-          }),
-          html.createDomElement("div", {
-            id: "interpolation-error-info",
-          }),
+          html.div(
+            { id: "sources-list-container", class: "details-contents-container" },
+            [
+              html.createDomElement("ui-list", { id: "sources-list" }),
+              html.createDomElement("add-remove-buttons", {
+                style: "padding: 0.5em 0 0 0;",
+                id: "sources-list-add-remove-buttons",
+              }),
+              html.createDomElement("div", {
+                id: "interpolation-error-info",
+              }),
+            ]
+          ),
         ]),
       ]
     );

--- a/src/fontra/views/editor/panel-designspace-navigation.js
+++ b/src/fontra/views/editor/panel-designspace-navigation.js
@@ -58,7 +58,7 @@ export default class DesignspaceNavigationPanel extends Panel {
   getContentElement() {
     const accordion = new Accordion();
     accordion.appendStyle(`
-      inline-svg {
+      .interpolation-error-icon {
         display: inline-block;
         height: 1.35em;
         width: 1.35em;
@@ -1111,7 +1111,12 @@ export default class DesignspaceNavigationPanel extends Panel {
               .join(" ") + ": "
           : "";
       const msg = `${nestedGlyphs}${error.message}`;
-      infoElement.appendChild(new InlineSVG(`/tabler-icons/${icon}.svg`));
+      infoElement.appendChild(
+        html.createDomElement("inline-svg", {
+          class: "interpolation-error-icon",
+          src: `/tabler-icons/${icon}.svg`,
+        })
+      );
       infoElement.append(msg);
       infoElement.appendChild(html.br());
     }

--- a/src/fontra/views/editor/panel-designspace-navigation.js
+++ b/src/fontra/views/editor/panel-designspace-navigation.js
@@ -62,7 +62,11 @@ export default class DesignspaceNavigationPanel extends Panel {
         id: "font-axes-accordion-item",
         label: "Font axes",
         open: true,
-        content: html.createDomElement("designspace-location", { id: "font-axes" }, []),
+        content: html.createDomElement(
+          "designspace-location",
+          { id: "font-axes", style: "height: 100%;" },
+          []
+        ),
         auxiliaryHeaderElement: groupAccordionHeaderButtons([
           makeAccordionHeaderButton({
             icon: "tool",
@@ -83,7 +87,7 @@ export default class DesignspaceNavigationPanel extends Panel {
         open: true,
         content: html.createDomElement(
           "designspace-location",
-          { id: "glyph-axes" },
+          { id: "glyph-axes", style: "height: 100%;" },
           []
         ),
         auxiliaryHeaderElement: groupAccordionHeaderButtons([

--- a/src/fontra/views/editor/panel-designspace-navigation.js
+++ b/src/fontra/views/editor/panel-designspace-navigation.js
@@ -703,10 +703,10 @@ export default class DesignspaceNavigationPanel extends Panel {
     const glyphController = await this.sceneModel.getSelectedVariableGlyphController();
     const glyph = glyphController.glyph;
 
-    const location = glyphController.mapLocationGlobalToLocal(
-      // TODO: FIX for glyphLocation
-      this.sceneSettings.location
-    );
+    const location = glyphController.mapLocationGlobalToLocal({
+      ...this.sceneSettings.location,
+      ...this.sceneSettings.glyphLocation,
+    });
 
     const {
       location: newLocation,
@@ -897,7 +897,7 @@ export default class DesignspaceNavigationPanel extends Panel {
     dialog.setContent(contentElement);
 
     setTimeout(
-      () => contentElement.shadowRoot.querySelector("#source-name-text-input")?.focus(),
+      () => contentElement.querySelector("#source-name-text-input")?.focus(),
       0
     );
 

--- a/src/fontra/views/editor/panel-designspace-navigation.js
+++ b/src/fontra/views/editor/panel-designspace-navigation.js
@@ -69,6 +69,10 @@ export default class DesignspaceNavigationPanel extends Panel {
       min-height: 0;
     }
 
+    .accordion-item[hidden] {
+      display: none;
+    }
+
     icon-button {
       display: block;
       width: 1.5em;
@@ -77,10 +81,14 @@ export default class DesignspaceNavigationPanel extends Panel {
 
     #sources-list-container {
       display: grid;
-      gap: 0.0em;
+      gap: 0.2em;
     }
 
-    .according-item-contents {
+    .accordion-item-close #sources-list-container {
+      display: none;
+    }
+
+    .accordion-item-contents {
       display: block;
       box-sizing: border-box;
       // height: calc(100% - 3em);
@@ -118,6 +126,17 @@ export default class DesignspaceNavigationPanel extends Panel {
 
     .accordion-header-button {
       width: 1.3em ;
+    }
+
+    .accordion-item-close .accordion-item-contents {
+      display: none;
+    }
+
+    .accordion-chevron {
+      transition: 120ms;
+    }
+    .accordion-item-close .accordion-chevron {
+      transform: rotate(180deg);
     }
   `;
 
@@ -170,7 +189,7 @@ export default class DesignspaceNavigationPanel extends Panel {
         label: "Glyph sources",
         open: true,
         content: html.div(
-          { id: "sources-list-container", class: "according-item-contents" },
+          { id: "sources-list-container", class: "accordion-item-contents" },
           [
             html.createDomElement("ui-list", { id: "sources-list" }),
             html.createDomElement("add-remove-buttons", {
@@ -190,6 +209,17 @@ export default class DesignspaceNavigationPanel extends Panel {
   }
 
   getContentElement_inline() {
+    const toggleItem = (event) => {
+      let el = event.target;
+      for (const i of range(3)) {
+        if (el.classList.contains("accordion-item")) {
+          break;
+        }
+        el = el.parentElement;
+      }
+      el.classList.toggle("accordion-item-close");
+    };
+
     const contentElement = html.div(
       {
         id: "designspace-navigation",
@@ -204,10 +234,10 @@ export default class DesignspaceNavigationPanel extends Panel {
             // ontoggle: (event) => console.log("toggle", event.target.open),
           },
           [
-            html.div({ class: "accordion-header" }, [
+            html.div({ class: "accordion-header", onclick: toggleItem }, [
               html.createDomElement("icon-button", {
                 src: `/tabler-icons/chevron-up.svg`,
-                class: "accordion-header-button",
+                class: "accordion-header-button accordion-chevron",
               }),
               "Font axes",
               html.createDomElement("icon-button", {
@@ -225,7 +255,7 @@ export default class DesignspaceNavigationPanel extends Panel {
                 "data-tooltipposition": "bottom",
               }),
             ]),
-            html.div({ class: "according-item-contents" }, [
+            html.div({ class: "accordion-item-contents" }, [
               html.createDomElement("designspace-location", { id: "font-axes" }, []),
             ]),
           ]
@@ -238,10 +268,10 @@ export default class DesignspaceNavigationPanel extends Panel {
             // ontoggle: (event) => console.log("toggle", event.target.open),
           },
           [
-            html.div({ class: "accordion-header" }, [
+            html.div({ class: "accordion-header", onclick: toggleItem }, [
               html.createDomElement("icon-button", {
                 src: `/tabler-icons/chevron-up.svg`,
-                class: "accordion-header-button",
+                class: "accordion-header-button accordion-chevron",
               }),
               "Glyph axes",
               html.createDomElement("icon-button", {
@@ -260,7 +290,7 @@ export default class DesignspaceNavigationPanel extends Panel {
                 "data-tooltipposition": "bottom",
               }),
             ]),
-            html.div({ class: "according-item-contents" }, [
+            html.div({ class: "accordion-item-contents" }, [
               html.createDomElement("designspace-location", { id: "glyph-axes" }, []),
             ]),
           ]
@@ -272,15 +302,15 @@ export default class DesignspaceNavigationPanel extends Panel {
             open: true,
           },
           [
-            html.div({ class: "accordion-header" }, [
+            html.div({ class: "accordion-header", onclick: toggleItem }, [
               html.createDomElement("icon-button", {
                 src: `/tabler-icons/chevron-up.svg`,
-                class: "accordion-header-button",
+                class: "accordion-header-button accordion-chevron",
               }),
               "Glyph sources",
             ]),
             html.div(
-              { id: "sources-list-container", class: "according-item-contents" },
+              { id: "sources-list-container", class: "accordion-item-contents" },
               [
                 html.createDomElement("ui-list", { id: "sources-list" }),
                 html.createDomElement("add-remove-buttons", {

--- a/src/fontra/views/editor/panel-designspace-navigation.js
+++ b/src/fontra/views/editor/panel-designspace-navigation.js
@@ -149,7 +149,7 @@ export default class DesignspaceNavigationPanel extends Panel {
         html.link({ href: "/css/tooltip.css", rel: "stylesheet" }),
         html.details(
           {
-            class: "font-axes",
+            id: "font-axes-details",
             open: true,
             // ontoggle: (event) => console.log("toggle", event.target.open),
           },
@@ -176,7 +176,7 @@ export default class DesignspaceNavigationPanel extends Panel {
         ),
         html.details(
           {
-            class: "glyph-axes",
+            id: "glyph-axes-details",
             open: true,
             // ontoggle: (event) => console.log("toggle", event.target.open),
           },
@@ -199,10 +199,10 @@ export default class DesignspaceNavigationPanel extends Panel {
                 "data-tooltipposition": "bottom",
               }),
             ]),
-            html.createDomElement("designspace-location", { id: "glyph-location" }, []),
+            html.createDomElement("designspace-location", { id: "glyph-axes" }, []),
           ]
         ),
-        html.details({ open: true }, [
+        html.details({ id: "glyph-sources-details", open: true }, [
           html.summary({ class: "section-header" }, ["Glyph sources"]),
           html.createDomElement("ui-list", {
             id: "sources-list",
@@ -219,11 +219,25 @@ export default class DesignspaceNavigationPanel extends Panel {
     );
   }
 
+  get fontAxesElement() {
+    return this.contentElement.querySelector("#font-axes");
+  }
+
+  get glyphAxesElement() {
+    return this.contentElement.querySelector("#glyph-axes");
+  }
+
+  get glyphAxesDetails() {
+    return this.contentElement.querySelector("#glyph-axes-details");
+  }
+
+  get glyphSourcesDetails() {
+    return this.contentElement.querySelector("#glyph-sources-details");
+  }
+
   setup() {
-    this.fontAxesElement = this.contentElement.querySelector("#font-axes");
     this.fontAxesElement.values = this.sceneSettings.location;
 
-    this.glyphAxesElement = this.contentElement.querySelector("#glyph-location");
     // this.glyphAxesElement.values = this.sceneSettings.location;
 
     this.fontAxesElement.addEventListener(
@@ -413,7 +427,6 @@ export default class DesignspaceNavigationPanel extends Panel {
     this.addRemoveSourceButtons.addButtonCallback = () => this.addSource();
     this.addRemoveSourceButtons.removeButtonCallback = () =>
       this.removeSource(this.sourcesList.getSelectedItemIndex());
-    this.addRemoveSourceButtons.hidden = true;
 
     this.sourcesList.addEventListener("listSelectionChanged", async (event) => {
       this.sceneController.scrollAdjustBehavior = "pin-glyph-center";
@@ -540,12 +553,12 @@ export default class DesignspaceNavigationPanel extends Panel {
 
     const varGlyphController =
       await this.sceneModel.getSelectedVariableGlyphController();
-    if (varGlyphController) {
-      const localAxes = getAxisInfoFromGlyph(varGlyphController);
-      this.glyphAxesElement.axes = localAxes;
-    } else {
-      this.glyphAxesElement.axes = [];
-    }
+
+    const localAxes = varGlyphController
+      ? getAxisInfoFromGlyph(varGlyphController)
+      : [];
+    this.glyphAxesElement.axes = localAxes;
+    this.glyphAxesDetails.hidden = !localAxes.length;
 
     this._updateResetAllAxesButtonState();
   }
@@ -616,8 +629,8 @@ export default class DesignspaceNavigationPanel extends Panel {
     }
     this.sourcesList.setItems(sourceItems, false, true);
     this.sourcesList.setSelectedItemIndex(this.sceneSettings.selectedSourceIndex);
-    this.addRemoveSourceButtons.hidden = !sourceItems.length;
-    this.addRemoveSourceButtons.disableAddButton = !this.fontAxesElement.axes.length;
+
+    this.glyphSourcesDetails.hidden = !sourceItems.length;
 
     this._updateRemoveSourceButtonState();
     this._updateEditingStatus();

--- a/src/fontra/views/editor/panel-designspace-navigation.js
+++ b/src/fontra/views/editor/panel-designspace-navigation.js
@@ -91,6 +91,42 @@ export default class DesignspaceNavigationPanel extends Panel {
       transform: translate(0, 0.3em);
       margin-right: 0.25em;
     }
+
+    details {
+      display: flex;
+    }
+
+    details > summary {
+      user-select: none;
+      cursor: pointer;
+      align-items: center;
+      font-weight: bold;
+      display: grid;
+      grid-template-columns: 1.5em 1fr 1.2em 1.2em;
+      gap: 0.2em;
+      justify-content: space-between;
+      margin-bottom: 0.4em;
+    }
+
+    details > summary::before {
+      content: "";
+      background-image: url("/tabler-icons/chevron-up.svg");
+      background-size: 100% 100%;
+      width: 1.6em;
+      height: 1.6em;
+      transition: 120ms;
+    }
+
+    details[open] > summary::before {
+      transform: rotate(180deg);
+    }
+
+    details[open] > summary {
+    }
+
+    .section-header-button {
+      width: 1.3em ;
+    }
   `;
 
   constructor(editorController) {
@@ -117,12 +153,53 @@ export default class DesignspaceNavigationPanel extends Panel {
       },
       [
         html.link({ href: "/css/tooltip.css", rel: "stylesheet" }),
-        html.createDomElement(
-          "designspace-location",
+        html.details(
           {
-            id: "designspace-location",
+            class: "font-axes",
+            open: true,
+            ontoggle: (event) => console.log("toggle", event.target.open),
           },
-          []
+          [
+            html.summary({ class: "section-header" }, [
+              "Font axes",
+              html.createDomElement("icon-button", {
+                src: `/tabler-icons/tool.svg`,
+                class: "section-header-button",
+              }),
+              html.createDomElement("icon-button", {
+                src: `/tabler-icons/refresh.svg`,
+                class: "section-header-button",
+              }),
+            ]),
+            html.createDomElement(
+              "designspace-location",
+              {
+                id: "designspace-location",
+              },
+              []
+            ),
+          ]
+        ),
+        html.details(
+          {
+            class: "glyph-axes",
+            open: true,
+            ontoggle: (event) => console.log("toggle", event.target.open),
+          },
+          [
+            html.summary({ class: "section-header" }, [
+              "Glyph axes",
+              html.createDomElement("icon-button", {
+                src: `/tabler-icons/tool.svg`,
+                class: "section-header-button",
+              }),
+              html.createDomElement("icon-button", {
+                src: `/tabler-icons/refresh.svg`,
+                class: "section-header-button",
+              }),
+            ]),
+            html.div({}, "Glyph axes content"),
+          ]
         ),
         html.div({ class: "axis-buttons-container" }, [
           html.createDomElement("icon-button", {
@@ -143,16 +220,19 @@ export default class DesignspaceNavigationPanel extends Panel {
           }),
         ]),
         html.hr(),
-        html.createDomElement("ui-list", {
-          id: "sources-list",
-        }),
-        html.createDomElement("add-remove-buttons", {
-          style: "padding: 0.5em 0 0 0;",
-          id: "sources-list-add-remove-buttons",
-        }),
-        html.createDomElement("div", {
-          id: "interpolation-error-info",
-        }),
+        html.details({ open: true }, [
+          html.summary({ class: "section-header" }, ["Glyph sources"]),
+          html.createDomElement("ui-list", {
+            id: "sources-list",
+          }),
+          html.createDomElement("add-remove-buttons", {
+            style: "padding: 0.5em 0 0 0;",
+            id: "sources-list-add-remove-buttons",
+          }),
+          html.createDomElement("div", {
+            id: "interpolation-error-info",
+          }),
+        ]),
       ]
     );
   }

--- a/src/fontra/views/editor/panel-designspace-navigation.js
+++ b/src/fontra/views/editor/panel-designspace-navigation.js
@@ -26,6 +26,7 @@ import { IconButton } from "/web-components/icon-button.js";
 import { InlineSVG } from "/web-components/inline-svg.js";
 import { showMenu } from "/web-components/menu-panel.js";
 import { dialog, dialogSetup, message } from "/web-components/modal-dialog.js";
+import { Accordion } from "/web-components/ui-accordion.js";
 
 import Panel from "./panel.js";
 import { NumberFormatter } from "/core/ui-utils.js";
@@ -38,6 +39,13 @@ export default class DesignspaceNavigationPanel extends Panel {
   iconPath = "/images/sliders.svg";
 
   static styles = `
+    ui-accordion {
+      display: block;
+      height: 100%;
+    }
+
+    /* ---------------------------------------------------- */
+
     #designspace-navigation {
       height: 100%;
       width: 100%;
@@ -131,7 +139,58 @@ export default class DesignspaceNavigationPanel extends Panel {
   }
 
   getContentElement() {
-    return html.div(
+    if (true) {
+      return this.getContentElement_inline();
+    } else {
+      return this.getContentElement_accordion();
+    }
+  }
+
+  getContentElement_accordion() {
+    const accordion = new Accordion();
+    accordion.items = [
+      {
+        id: "font-axes-accordion-item",
+        label: "Font axes",
+        open: true,
+        content: html.createDomElement("designspace-location", { id: "font-axes" }, []),
+      },
+      {
+        id: "glyph-axes-accordion-item",
+        label: "Glyph axes",
+        open: true,
+        content: html.createDomElement(
+          "designspace-location",
+          { id: "glyph-axes" },
+          []
+        ),
+      },
+      {
+        id: "glyph-sources-accordion-item",
+        label: "Glyph sources",
+        open: true,
+        content: html.div(
+          { id: "sources-list-container", class: "according-item-contents" },
+          [
+            html.createDomElement("ui-list", { id: "sources-list" }),
+            html.createDomElement("add-remove-buttons", {
+              style: "padding: 0.5em 0 0 0;",
+              id: "sources-list-add-remove-buttons",
+            }),
+            html.createDomElement("div", {
+              id: "interpolation-error-info",
+            }),
+          ]
+        ),
+      },
+    ];
+
+    this.qs = accordion.shadowRoot.querySelector.bind(accordion.shadowRoot);
+    return accordion;
+  }
+
+  getContentElement_inline() {
+    const contentElement = html.div(
       {
         id: "designspace-navigation",
       },
@@ -237,22 +296,25 @@ export default class DesignspaceNavigationPanel extends Panel {
         ),
       ]
     );
+
+    this.qs = contentElement.querySelector.bind(contentElement);
+    return contentElement;
   }
 
   get fontAxesElement() {
-    return this.contentElement.querySelector("#font-axes");
+    return this.qs("#font-axes");
   }
 
   get glyphAxesElement() {
-    return this.contentElement.querySelector("#glyph-axes");
+    return this.qs("#glyph-axes");
   }
 
   get glyphAxesAccordionItem() {
-    return this.contentElement.querySelector("#glyph-axes-accordion-item");
+    return this.qs("#glyph-axes-accordion-item");
   }
 
   get glyphSourcesAccordionItem() {
-    return this.contentElement.querySelector("#glyph-sources-accordion-item");
+    return this.qs("#glyph-sources-accordion-item");
   }
 
   setup() {
@@ -425,7 +487,7 @@ export default class DesignspaceNavigationPanel extends Panel {
       width: "1.2em",
     });
 
-    this.sourcesList = this.contentElement.querySelector("#sources-list");
+    this.sourcesList = this.qs("#sources-list");
     this.sourcesList.appendStyle(`
       .clickable-icon-header {
         transition: 150ms;
@@ -440,9 +502,7 @@ export default class DesignspaceNavigationPanel extends Panel {
     this.sourcesList.showHeader = true;
     this.sourcesList.columnDescriptions = columnDescriptions;
 
-    this.addRemoveSourceButtons = this.contentElement.querySelector(
-      "#sources-list-add-remove-buttons"
-    );
+    this.addRemoveSourceButtons = this.qs("#sources-list-add-remove-buttons");
 
     this.addRemoveSourceButtons.addButtonCallback = () => this.addSource();
     this.addRemoveSourceButtons.removeButtonCallback = () =>
@@ -504,8 +564,8 @@ export default class DesignspaceNavigationPanel extends Panel {
         break;
       }
     }
-    const button = this.contentElement.querySelector("#reset-font-axes-button");
-    button.disabled = locationEmpty;
+    const button = this.qs("#reset-font-axes-button");
+    // button.disabled = locationEmpty;
   }
 
   async onVisibilityHeaderClick(event) {
@@ -937,7 +997,7 @@ export default class DesignspaceNavigationPanel extends Panel {
     dialog.setContent(contentElement);
 
     setTimeout(
-      () => contentElement.querySelector("#source-name-text-input")?.focus(),
+      () => contentElement.shadowRoot.querySelector("#source-name-text-input")?.focus(),
       0
     );
 
@@ -1118,7 +1178,7 @@ export default class DesignspaceNavigationPanel extends Panel {
   }
 
   async _updateInterpolationErrorInfo() {
-    const infoElement = this.contentElement.querySelector("#interpolation-error-info");
+    const infoElement = this.qs("#interpolation-error-info");
     const varGlyphController =
       await this.sceneModel.getSelectedVariableGlyphController();
     const glyphController = await this.sceneModel.getSelectedStaticGlyphController();

--- a/src/fontra/views/editor/panel-designspace-navigation.js
+++ b/src/fontra/views/editor/panel-designspace-navigation.js
@@ -48,12 +48,6 @@ export default class DesignspaceNavigationPanel extends Panel {
       box-sizing: border-box;
     }
 
-    .axis-buttons-container {
-      display: flex;
-      flex-direction: row;
-      gap: 0.2em;
-    }
-
     /* this is to counteract the undesired interaction between button.hidden
        and display: block */
     [hidden] {
@@ -157,18 +151,24 @@ export default class DesignspaceNavigationPanel extends Panel {
           {
             class: "font-axes",
             open: true,
-            ontoggle: (event) => console.log("toggle", event.target.open),
+            // ontoggle: (event) => console.log("toggle", event.target.open),
           },
           [
             html.summary({ class: "section-header" }, [
               "Font axes",
               html.createDomElement("icon-button", {
-                src: `/tabler-icons/tool.svg`,
-                class: "section-header-button",
+                "src": `/tabler-icons/tool.svg`,
+                "class": "section-header-button",
+                "data-tooltip": "Edit font axes",
+                "data-tooltipposition": "bottom",
               }),
               html.createDomElement("icon-button", {
-                src: `/tabler-icons/refresh.svg`,
-                class: "section-header-button",
+                "id": "reset-font-axes-button",
+                "src": `/tabler-icons/refresh.svg`,
+                "class": "section-header-button",
+                "onclick": (event) => this.resetFontAxesToDefault(event),
+                "data-tooltip": "Reset font axes",
+                "data-tooltipposition": "bottom",
               }),
             ]),
             html.createDomElement(
@@ -184,41 +184,30 @@ export default class DesignspaceNavigationPanel extends Panel {
           {
             class: "glyph-axes",
             open: true,
-            ontoggle: (event) => console.log("toggle", event.target.open),
+            // ontoggle: (event) => console.log("toggle", event.target.open),
           },
           [
             html.summary({ class: "section-header" }, [
               "Glyph axes",
               html.createDomElement("icon-button", {
-                src: `/tabler-icons/tool.svg`,
-                class: "section-header-button",
+                "src": `/tabler-icons/tool.svg`,
+                "class": "section-header-button",
+                "onclick": (event) => this.editLocalAxes(event),
+                "data-tooltip": "Edit glyph axes",
+                "data-tooltipposition": "bottom",
               }),
               html.createDomElement("icon-button", {
-                src: `/tabler-icons/refresh.svg`,
-                class: "section-header-button",
+                "id": "reset-glyph-axes-button",
+                "src": `/tabler-icons/refresh.svg`,
+                "class": "section-header-button",
+                "onclick": (event) => this.resetGlyphAxesToDefault(event),
+                "data-tooltip": "Reset glyph axes",
+                "data-tooltipposition": "bottom",
               }),
             ]),
             html.div({}, "Glyph axes content"),
           ]
         ),
-        html.div({ class: "axis-buttons-container" }, [
-          html.createDomElement("icon-button", {
-            "id": "reset-axes-button",
-            "src": "/tabler-icons/refresh.svg",
-            "onclick": (event) => this.resetAllAxesToDefault(event),
-            "disabled": false,
-            "hidden": true,
-            "data-tooltip": "Reset all axes",
-            "data-tooltipposition": "bottom-left",
-          }),
-          html.createDomElement("icon-button", {
-            "id": "edit-local-axes-button",
-            "src": "/tabler-icons/tool.svg",
-            "onclick": (event) => this.editLocalAxes(event),
-            "data-tooltip": "Edit local axes",
-            "data-tooltipposition": "bottom-left",
-          }),
-        ]),
         html.details({ open: true }, [
           html.summary({ class: "section-header" }, ["Glyph sources"]),
           html.createDomElement("ui-list", {
@@ -259,7 +248,6 @@ export default class DesignspaceNavigationPanel extends Panel {
     this.sceneSettingsController.addKeyListener("selectedGlyphName", (event) => {
       this._updateAxes();
       this._updateSources();
-      this._updateEditLocalAxesButtonState();
       this._updateInterpolationErrorInfo();
     });
 
@@ -467,8 +455,12 @@ export default class DesignspaceNavigationPanel extends Panel {
     this._updateSources();
   }
 
-  resetAllAxesToDefault(event) {
+  resetFontAxesToDefault(event) {
     this.sceneSettings.location = {};
+  }
+
+  resetGlyphAxesToDefault(event) {
+    // TODO: implement
   }
 
   _updateResetAllAxesButtonState() {
@@ -484,7 +476,7 @@ export default class DesignspaceNavigationPanel extends Panel {
         break;
       }
     }
-    const button = this.contentElement.querySelector("#reset-axes-button");
+    const button = this.contentElement.querySelector("#reset-font-axes-button");
     button.disabled = locationEmpty;
     button.hidden = !this.designspaceLocation.axes.length;
   }
@@ -1005,11 +997,6 @@ export default class DesignspaceNavigationPanel extends Panel {
       ]
     );
     return { contentElement, warningElement };
-  }
-
-  _updateEditLocalAxesButtonState() {
-    const button = this.contentElement.querySelector("#edit-local-axes-button");
-    button.disabled = !this.sceneModel.selectedGlyph;
   }
 
   async editLocalAxes() {

--- a/src/fontra/views/editor/panel-designspace-navigation.js
+++ b/src/fontra/views/editor/panel-designspace-navigation.js
@@ -60,14 +60,6 @@ export default class DesignspaceNavigationPanel extends Panel {
       height: 1.5em;
     }
 
-    hr {
-      border: none;
-      border-top: 1px solid var(--horizontal-rule-color);
-      width: 100%;
-      height: 1px;
-      grid-column: 1 / -1;
-    }
-
     #sources-list {
       min-height: 100px;
       flex-shrink: 1000;

--- a/src/fontra/views/editor/panel-designspace-navigation.js
+++ b/src/fontra/views/editor/panel-designspace-navigation.js
@@ -219,7 +219,6 @@ export default class DesignspaceNavigationPanel extends Panel {
             "data-tooltipposition": "bottom-left",
           }),
         ]),
-        html.hr(),
         html.details({ open: true }, [
           html.summary({ class: "section-header" }, ["Glyph sources"]),
           html.createDomElement("ui-list", {

--- a/src/fontra/views/editor/panel-designspace-navigation.js
+++ b/src/fontra/views/editor/panel-designspace-navigation.js
@@ -55,6 +55,12 @@ export default class DesignspaceNavigationPanel extends Panel {
       display: none !important;
     }
 
+    .accordion-item {
+      display: grid;
+      grid-template-rows: auto 1fr;
+      min-height: 0;
+    }
+
     icon-button {
       display: block;
       width: 1.5em;
@@ -66,10 +72,12 @@ export default class DesignspaceNavigationPanel extends Panel {
       gap: 0.0em;
     }
 
-    .details-contents-container {
-      // height: 100%;
-      // overflow: hidden;
-      min-height: 0;
+    .according-item-contents {
+      display: block;
+      box-sizing: border-box;
+      // height: calc(100% - 3em);
+      overflow: auto;
+      // min-height: 5em;
     }
 
     #sources-list {
@@ -90,68 +98,17 @@ export default class DesignspaceNavigationPanel extends Panel {
       margin-right: 0.25em;
     }
 
-    details {
-      // display: grid;
-      outline: none;
-      // overflow-y: auto;
-      min-height: 0;
-    }
-
-    summary:focus {
-        outline: none;
-    }
-
-    details summary::-webkit-details-marker {
-      display: none;
-    }
-
-    details > summary {
-      list-style: none;
+    .accordion-header {
       display: grid;
-      grid-template-columns: 1.6em 1fr;
-      user-select: none;
-      cursor: pointer;
-      font-weight: bold;
-      margin-bottom: 0.2em;
-    }
-
-    details > designspace-location {
-      // height: 100%;
-      min-height: 0;
-      overflow-y: hidden;
-      // height: fit-content;
-    }
-
-    details > source-list {
-      // min-height: 0;
-      // height: 100%;
-    }
-
-    .section-summary {
-      display: grid;
-      grid-template-columns: 1fr 1.2em 1.2em;
+      grid-template-columns: 1.2em 1fr 1.2em 1.2em;
       align-items: center;
       gap: 0.2em;
       justify-content: space-between;
+      font-weight: bold;
+      cursor: pointer;
     }
 
-    details > summary::before {
-      content: "";
-      background-image: url("/tabler-icons/chevron-up.svg");
-      background-size: 100% 100%;
-      width: 1.6em;
-      height: 1.6em;
-      transition: 120ms;
-    }
-
-    details[open] > summary::before {
-      transform: rotate(180deg);
-    }
-
-    details[open] > summary {
-    }
-
-    .section-header-button {
+    .accordion-header-button {
       width: 1.3em ;
     }
   `;
@@ -180,85 +137,104 @@ export default class DesignspaceNavigationPanel extends Panel {
       },
       [
         html.link({ href: "/css/tooltip.css", rel: "stylesheet" }),
-        html.details(
+        html.div(
           {
-            id: "font-axes-details",
+            class: "accordion-item",
+            id: "font-axes-accordion-item",
             open: true,
             // ontoggle: (event) => console.log("toggle", event.target.open),
           },
           [
-            html.summary({}, [
-              html.div({ class: "section-summary" }, [
-                "Font axes",
-                html.createDomElement("icon-button", {
-                  "src": `/tabler-icons/tool.svg`,
-                  "class": "section-header-button",
-                  "data-tooltip": "Edit font axes",
-                  "data-tooltipposition": "bottom",
-                }),
-                html.createDomElement("icon-button", {
-                  "id": "reset-font-axes-button",
-                  "src": `/tabler-icons/refresh.svg`,
-                  "class": "section-header-button",
-                  "onclick": (event) => this.resetFontAxesToDefault(event),
-                  "data-tooltip": "Reset font axes",
-                  "data-tooltipposition": "bottom",
-                }),
-              ]),
+            html.div({ class: "accordion-header" }, [
+              html.createDomElement("icon-button", {
+                src: `/tabler-icons/chevron-up.svg`,
+                class: "accordion-header-button",
+              }),
+              "Font axes",
+              html.createDomElement("icon-button", {
+                "src": `/tabler-icons/tool.svg`,
+                "class": "accordion-header-button",
+                "data-tooltip": "Edit font axes",
+                "data-tooltipposition": "bottom",
+              }),
+              html.createDomElement("icon-button", {
+                "id": "reset-font-axes-button",
+                "src": `/tabler-icons/refresh.svg`,
+                "class": "accordion-header-button",
+                "onclick": (event) => this.resetFontAxesToDefault(event),
+                "data-tooltip": "Reset font axes",
+                "data-tooltipposition": "bottom",
+              }),
             ]),
-            html.div({ class: "details-contents-container" }, [
+            html.div({ class: "according-item-contents" }, [
               html.createDomElement("designspace-location", { id: "font-axes" }, []),
             ]),
           ]
         ),
-        html.details(
+        html.div(
           {
-            id: "glyph-axes-details",
+            class: "accordion-item",
+            id: "glyph-axes-accordion-item",
             open: true,
             // ontoggle: (event) => console.log("toggle", event.target.open),
           },
           [
-            html.summary({}, [
-              html.div({ class: "section-summary" }, [
-                "Glyph axes",
-                html.createDomElement("icon-button", {
-                  "src": `/tabler-icons/tool.svg`,
-                  "class": "section-header-button",
-                  "onclick": (event) => this.editGlyphAxes(event),
-                  "data-tooltip": "Edit glyph axes",
-                  "data-tooltipposition": "bottom",
-                }),
-                html.createDomElement("icon-button", {
-                  "id": "reset-glyph-axes-button",
-                  "src": `/tabler-icons/refresh.svg`,
-                  "class": "section-header-button",
-                  "onclick": (event) => this.resetGlyphAxesToDefault(event),
-                  "data-tooltip": "Reset glyph axes",
-                  "data-tooltipposition": "bottom",
-                }),
-              ]),
+            html.div({ class: "accordion-header" }, [
+              html.createDomElement("icon-button", {
+                src: `/tabler-icons/chevron-up.svg`,
+                class: "accordion-header-button",
+              }),
+              "Glyph axes",
+              html.createDomElement("icon-button", {
+                "src": `/tabler-icons/tool.svg`,
+                "class": "accordion-header-button",
+                "onclick": (event) => this.editGlyphAxes(event),
+                "data-tooltip": "Edit glyph axes",
+                "data-tooltipposition": "bottom",
+              }),
+              html.createDomElement("icon-button", {
+                "id": "reset-glyph-axes-button",
+                "src": `/tabler-icons/refresh.svg`,
+                "class": "accordion-header-button",
+                "onclick": (event) => this.resetGlyphAxesToDefault(event),
+                "data-tooltip": "Reset glyph axes",
+                "data-tooltipposition": "bottom",
+              }),
             ]),
-            html.div({ class: "details-contents-container" }, [
+            html.div({ class: "according-item-contents" }, [
               html.createDomElement("designspace-location", { id: "glyph-axes" }, []),
             ]),
           ]
         ),
-        html.details({ id: "glyph-sources-details", open: true }, [
-          html.summary({}, [html.div({ class: "section-summary" }, ["Glyph sources"])]),
-          html.div(
-            { id: "sources-list-container", class: "details-contents-container" },
-            [
-              html.createDomElement("ui-list", { id: "sources-list" }),
-              html.createDomElement("add-remove-buttons", {
-                style: "padding: 0.5em 0 0 0;",
-                id: "sources-list-add-remove-buttons",
+        html.div(
+          {
+            class: "accordion-item",
+            id: "glyph-sources-accordion-item",
+            open: true,
+          },
+          [
+            html.div({ class: "accordion-header" }, [
+              html.createDomElement("icon-button", {
+                src: `/tabler-icons/chevron-up.svg`,
+                class: "accordion-header-button",
               }),
-              html.createDomElement("div", {
-                id: "interpolation-error-info",
-              }),
-            ]
-          ),
-        ]),
+              "Glyph sources",
+            ]),
+            html.div(
+              { id: "sources-list-container", class: "according-item-contents" },
+              [
+                html.createDomElement("ui-list", { id: "sources-list" }),
+                html.createDomElement("add-remove-buttons", {
+                  style: "padding: 0.5em 0 0 0;",
+                  id: "sources-list-add-remove-buttons",
+                }),
+                html.createDomElement("div", {
+                  id: "interpolation-error-info",
+                }),
+              ]
+            ),
+          ]
+        ),
       ]
     );
   }
@@ -271,12 +247,12 @@ export default class DesignspaceNavigationPanel extends Panel {
     return this.contentElement.querySelector("#glyph-axes");
   }
 
-  get glyphAxesDetails() {
-    return this.contentElement.querySelector("#glyph-axes-details");
+  get glyphAxesAccordionItem() {
+    return this.contentElement.querySelector("#glyph-axes-accordion-item");
   }
 
-  get glyphSourcesDetails() {
-    return this.contentElement.querySelector("#glyph-sources-details");
+  get glyphSourcesAccordionItem() {
+    return this.contentElement.querySelector("#glyph-sources-accordion-item");
   }
 
   setup() {
@@ -602,7 +578,7 @@ export default class DesignspaceNavigationPanel extends Panel {
       ? getAxisInfoFromGlyph(varGlyphController)
       : [];
     this.glyphAxesElement.axes = localAxes;
-    this.glyphAxesDetails.hidden = !localAxes.length;
+    this.glyphAxesAccordionItem.hidden = !localAxes.length;
 
     this._updateResetAllAxesButtonState();
   }
@@ -674,7 +650,7 @@ export default class DesignspaceNavigationPanel extends Panel {
     this.sourcesList.setItems(sourceItems, false, true);
     this.sourcesList.setSelectedItemIndex(this.sceneSettings.selectedSourceIndex);
 
-    this.glyphSourcesDetails.hidden = !varGlyphController;
+    this.glyphSourcesAccordionItem.hidden = !varGlyphController;
 
     this._updateRemoveSourceButtonState();
     this._updateEditingStatus();

--- a/src/fontra/views/editor/panel-designspace-navigation.js
+++ b/src/fontra/views/editor/panel-designspace-navigation.js
@@ -57,6 +57,16 @@ export default class DesignspaceNavigationPanel extends Panel {
 
   getContentElement() {
     const accordion = new Accordion();
+    accordion.appendStyle(`
+      inline-svg {
+        display: inline-block;
+        height: 1.35em;
+        width: 1.35em;
+        color: var(--fontra-light-red-color);
+        transform: translate(0, 0.3em);
+        margin-right: 0.25em;
+      }
+    `);
     accordion.items = [
       {
         id: "font-axes-accordion-item",

--- a/src/fontra/views/editor/panel-designspace-navigation.js
+++ b/src/fontra/views/editor/panel-designspace-navigation.js
@@ -88,18 +88,33 @@ export default class DesignspaceNavigationPanel extends Panel {
 
     details {
       display: flex;
+      outline: none;
+    }
+
+    summary:focus {
+        outline: none;
+    }
+
+    details summary::-webkit-details-marker {
+      display: none;
     }
 
     details > summary {
+      list-style: none;
+      display: grid;
+      grid-template-columns: 1.6em 1fr;
       user-select: none;
       cursor: pointer;
-      align-items: center;
       font-weight: bold;
+      margin-bottom: 0.2em;
+    }
+
+    .section-summary {
       display: grid;
-      grid-template-columns: 1.5em 1fr 1.2em 1.2em;
+      grid-template-columns: 1fr 1.2em 1.2em;
+      align-items: center;
       gap: 0.2em;
       justify-content: space-between;
-      margin-bottom: 0.4em;
     }
 
     details > summary::before {
@@ -154,22 +169,24 @@ export default class DesignspaceNavigationPanel extends Panel {
             // ontoggle: (event) => console.log("toggle", event.target.open),
           },
           [
-            html.summary({ class: "section-header" }, [
-              "Font axes",
-              html.createDomElement("icon-button", {
-                "src": `/tabler-icons/tool.svg`,
-                "class": "section-header-button",
-                "data-tooltip": "Edit font axes",
-                "data-tooltipposition": "bottom",
-              }),
-              html.createDomElement("icon-button", {
-                "id": "reset-font-axes-button",
-                "src": `/tabler-icons/refresh.svg`,
-                "class": "section-header-button",
-                "onclick": (event) => this.resetFontAxesToDefault(event),
-                "data-tooltip": "Reset font axes",
-                "data-tooltipposition": "bottom",
-              }),
+            html.summary({}, [
+              html.div({ class: "section-summary" }, [
+                "Font axes",
+                html.createDomElement("icon-button", {
+                  "src": `/tabler-icons/tool.svg`,
+                  "class": "section-header-button",
+                  "data-tooltip": "Edit font axes",
+                  "data-tooltipposition": "bottom",
+                }),
+                html.createDomElement("icon-button", {
+                  "id": "reset-font-axes-button",
+                  "src": `/tabler-icons/refresh.svg`,
+                  "class": "section-header-button",
+                  "onclick": (event) => this.resetFontAxesToDefault(event),
+                  "data-tooltip": "Reset font axes",
+                  "data-tooltipposition": "bottom",
+                }),
+              ]),
             ]),
             html.createDomElement("designspace-location", { id: "font-axes" }, []),
           ]
@@ -181,29 +198,31 @@ export default class DesignspaceNavigationPanel extends Panel {
             // ontoggle: (event) => console.log("toggle", event.target.open),
           },
           [
-            html.summary({ class: "section-header" }, [
-              "Glyph axes",
-              html.createDomElement("icon-button", {
-                "src": `/tabler-icons/tool.svg`,
-                "class": "section-header-button",
-                "onclick": (event) => this.editLocalAxes(event),
-                "data-tooltip": "Edit glyph axes",
-                "data-tooltipposition": "bottom",
-              }),
-              html.createDomElement("icon-button", {
-                "id": "reset-glyph-axes-button",
-                "src": `/tabler-icons/refresh.svg`,
-                "class": "section-header-button",
-                "onclick": (event) => this.resetGlyphAxesToDefault(event),
-                "data-tooltip": "Reset glyph axes",
-                "data-tooltipposition": "bottom",
-              }),
+            html.summary({}, [
+              html.div({ class: "section-summary" }, [
+                "Glyph axes",
+                html.createDomElement("icon-button", {
+                  "src": `/tabler-icons/tool.svg`,
+                  "class": "section-header-button",
+                  "onclick": (event) => this.editLocalAxes(event),
+                  "data-tooltip": "Edit glyph axes",
+                  "data-tooltipposition": "bottom",
+                }),
+                html.createDomElement("icon-button", {
+                  "id": "reset-glyph-axes-button",
+                  "src": `/tabler-icons/refresh.svg`,
+                  "class": "section-header-button",
+                  "onclick": (event) => this.resetGlyphAxesToDefault(event),
+                  "data-tooltip": "Reset glyph axes",
+                  "data-tooltipposition": "bottom",
+                }),
+              ]),
             ]),
             html.createDomElement("designspace-location", { id: "glyph-axes" }, []),
           ]
         ),
         html.details({ id: "glyph-sources-details", open: true }, [
-          html.summary({ class: "section-header" }, ["Glyph sources"]),
+          html.summary({}, [html.div({ class: "section-summary" }, ["Glyph sources"])]),
           html.createDomElement("ui-list", {
             id: "sources-list",
           }),

--- a/src/fontra/views/editor/panel-selection-info.js
+++ b/src/fontra/views/editor/panel-selection-info.js
@@ -49,7 +49,7 @@ export default class SelectionInfoPanel extends Panel {
     this.sceneController = this.editorController.sceneController;
 
     this.sceneController.sceneSettingsController.addKeyListener(
-      ["selectedGlyphName", "selection", "location"],
+      ["selectedGlyphName", "selection", "location", "glyphLocation"],
       (event) => this.throttledUpdate()
     );
 

--- a/src/fontra/views/editor/scene-controller.js
+++ b/src/fontra/views/editor/scene-controller.js
@@ -152,10 +152,19 @@ export class SceneController {
         const varGlyphController =
           await this.sceneModel.getSelectedVariableGlyphController();
 
-        // TODO: FIX for glyphLocation
         const location = varGlyphController.mapSourceLocationToGlobal(sourceIndex);
 
-        this.sceneSettingsController.setItem("location", location, { senderID: this });
+        const { fontLocation, glyphLocation } = splitLocation(
+          location,
+          varGlyphController.axes
+        );
+
+        this.sceneSettingsController.setItem("location", fontLocation, {
+          senderID: this,
+        });
+        this.sceneSettingsController.setItem("glyphLocation", glyphLocation, {
+          senderID: this,
+        });
       },
       true
     );
@@ -1198,4 +1207,21 @@ export function equalGlyphSelection(glyphSelectionA, glyphSelectionB) {
     glyphSelectionA?.lineIndex === glyphSelectionB?.lineIndex &&
     glyphSelectionA?.glyphIndex === glyphSelectionB?.glyphIndex
   );
+}
+
+function splitLocation(location, glyphAxes) {
+  const glyphAxisNames = new Set(glyphAxes.map((axis) => axis.name));
+
+  const fontLocation = {};
+  const glyphLocation = {};
+
+  for (const [axisName, axisValue] of Object.entries(location)) {
+    if (glyphAxisNames.has(axisName)) {
+      glyphLocation[axisName] = axisValue;
+    } else {
+      fontLocation[axisName] = axisValue;
+    }
+  }
+
+  return { fontLocation, glyphLocation };
 }

--- a/src/fontra/views/editor/scene-controller.js
+++ b/src/fontra/views/editor/scene-controller.js
@@ -63,6 +63,7 @@ export class SceneController {
       editLayerName: null,
       glyphLines: [],
       location: {},
+      glyphLocation: {},
       selectedGlyph: null,
       selectedGlyphName: null,
       selectedSourceIndex: null,

--- a/src/fontra/views/editor/scene-controller.js
+++ b/src/fontra/views/editor/scene-controller.js
@@ -121,17 +121,20 @@ export class SceneController {
     );
 
     // Set up the mutual dependencies between location and selectedSourceIndex
-    this.sceneSettingsController.addKeyListener("location", async (event) => {
-      if (event.senderInfo?.senderID === this) {
-        return;
+    this.sceneSettingsController.addKeyListener(
+      ["location", "glyphLocation"],
+      async (event) => {
+        if (event.senderInfo?.senderID === this) {
+          return;
+        }
+        const varGlyphController =
+          await this.sceneModel.getSelectedVariableGlyphController();
+        const sourceIndex = varGlyphController?.getSourceIndex(event.newValue);
+        this.sceneSettingsController.setItem("selectedSourceIndex", sourceIndex, {
+          senderID: this,
+        });
       }
-      const varGlyphController =
-        await this.sceneModel.getSelectedVariableGlyphController();
-      const sourceIndex = varGlyphController?.getSourceIndex(event.newValue);
-      this.sceneSettingsController.setItem("selectedSourceIndex", sourceIndex, {
-        senderID: this,
-      });
-    });
+    );
 
     this.sceneSettingsController.addKeyListener(
       "selectedSourceIndex",

--- a/src/fontra/views/editor/scene-controller.js
+++ b/src/fontra/views/editor/scene-controller.js
@@ -700,10 +700,6 @@ export class SceneController {
     return layerNames;
   }
 
-  getGlobalLocation() {
-    return this.sceneModel.getGlobalLocation();
-  }
-
   getLocalLocations(filterShownGlyphs = false) {
     return this.sceneModel.getLocalLocations(filterShownGlyphs);
   }

--- a/src/fontra/views/editor/scene-controller.js
+++ b/src/fontra/views/editor/scene-controller.js
@@ -129,7 +129,10 @@ export class SceneController {
         }
         const varGlyphController =
           await this.sceneModel.getSelectedVariableGlyphController();
-        const sourceIndex = varGlyphController?.getSourceIndex(event.newValue);
+        const sourceIndex = varGlyphController?.getSourceIndex({
+          ...this.sceneSettings.location,
+          ...this.sceneSettings.glyphLocation,
+        });
         this.sceneSettingsController.setItem("selectedSourceIndex", sourceIndex, {
           senderID: this,
         });
@@ -148,6 +151,8 @@ export class SceneController {
         }
         const varGlyphController =
           await this.sceneModel.getSelectedVariableGlyphController();
+
+        // TODO: FIX for glyphLocation
         const location = varGlyphController.mapSourceLocationToGlobal(sourceIndex);
 
         this.sceneSettingsController.setItem("location", location, { senderID: this });

--- a/src/fontra/views/editor/scene-model.js
+++ b/src/fontra/views/editor/scene-model.js
@@ -129,8 +129,7 @@ export class SceneModel {
   }
 
   getGlobalLocation() {
-    const { globalLocation } = this._getSplitLocation();
-    return globalLocation;
+    return this.sceneSettings.location;
   }
 
   getLocalLocations(filterShownGlyphs = false) {
@@ -157,31 +156,13 @@ export class SceneModel {
     return localLocations;
   }
 
-  _getSplitLocation() {
-    const location = this.sceneSettings.location;
-
-    const globalAxisNames = Object.fromEntries(
-      this.fontController.globalAxes.map((axis) => [axis.name])
-    );
-    const globalLocation = {};
-    const localLocation = {};
-    for (const [name, value] of Object.entries(location)) {
-      if (name in globalAxisNames) {
-        globalLocation[name] = value;
-      } else {
-        localLocation[name] = value;
-      }
-    }
-    return { globalLocation, localLocation };
-  }
-
   _syncLocalLocations() {
-    const { globalLocation, localLocation } = this._getSplitLocation();
+    const glyphLocation = this.sceneSettings.glyphLocation;
 
     const glyphName = this.sceneSettings.selectedGlyphName;
     if (glyphName !== undefined) {
-      if (Object.keys(localLocation).length) {
-        this._localLocations[glyphName] = localLocation;
+      if (Object.keys(glyphLocation).length) {
+        this._localLocations[glyphName] = glyphLocation;
       } else {
         delete this._localLocations[glyphName];
       }
@@ -189,13 +170,8 @@ export class SceneModel {
   }
 
   _syncLocationFromGlyphName() {
-    const { globalLocation } = this._getSplitLocation();
-
     const glyphName = this.sceneSettings.selectedGlyphName;
-    this.sceneSettings.location = {
-      ...globalLocation,
-      ...this._localLocations[glyphName],
-    };
+    this.sceneSettings.glyphLocation = { ...this._localLocations[glyphName] };
   }
 
   setLocalLocations(localLocations) {

--- a/src/fontra/views/editor/scene-model.js
+++ b/src/fontra/views/editor/scene-model.js
@@ -36,10 +36,13 @@ export class SceneModel {
       }
     );
 
-    this.sceneSettingsController.addKeyListener("location", (event) => {
-      this._syncLocalLocations();
-      this.updateScene();
-    });
+    this.sceneSettingsController.addKeyListener(
+      ["location", "glyphLocation"],
+      (event) => {
+        this._syncLocalLocations();
+        this.updateScene();
+      }
+    );
 
     this.sceneSettingsController.addKeyListener(
       "selectedGlyphName",
@@ -443,8 +446,8 @@ export class SceneModel {
 
   async getGlyphInstance(glyphName, layerName) {
     const location = {
-      ...this._localLocations[glyphName],
       ...this.getGlobalLocation(),
+      ...this._localLocations[glyphName],
     };
     return await this.fontController.getGlyphInstance(glyphName, location, layerName);
   }

--- a/src/fontra/views/editor/scene-model.js
+++ b/src/fontra/views/editor/scene-model.js
@@ -131,10 +131,6 @@ export class SceneModel {
     );
   }
 
-  getGlobalLocation() {
-    return this.sceneSettings.location;
-  }
-
   getLocalLocations(filterShownGlyphs = false) {
     let localLocations;
     if (filterShownGlyphs) {
@@ -446,7 +442,7 @@ export class SceneModel {
 
   async getGlyphInstance(glyphName, layerName) {
     const location = {
-      ...this.getGlobalLocation(),
+      ...this.sceneSettings.location,
       ...this._localLocations[glyphName],
     };
     return await this.fontController.getGlyphInstance(glyphName, location, layerName);


### PR DESCRIPTION
- Redesign the designspace navigation panel to clearly separate font axes from glyph axes
- Use new ui-accordion web component, so we have three collapsable sections:
  - font axes
  - glyph axes
  - glyph sources

Todo:
- [x] fix interpolation errors section styling
- [x] internally separate font location vs glyph location
- [x] hook up the glyph axes