### PR TITLE
Fix #1315: decompose component should include anchors

### DIFF
--- a/src/fontra/client/core/glyph-controller.js
+++ b/src/fontra/client/core/glyph-controller.js
@@ -923,12 +923,11 @@ export async function decomposeComponents(
       });
     }
     for (const anchor of compoInstance.anchors) {
-      const { name, x, y } = anchor;
-      const [newX, newY] = t.transformPoint(x, y);
+      const [x, y] = t.transformPoint(anchor.x, anchor.y);
       newAnchors.push({
-        name,
-        x: newX,
-        y: newY,
+        name: anchor.name,
+        x,
+        y,
       });
     }
   }

--- a/src/fontra/client/core/glyph-controller.js
+++ b/src/fontra/client/core/glyph-controller.js
@@ -895,6 +895,7 @@ export async function decomposeComponents(
 
   const newPaths = [];
   const newComponents = [];
+  const newAnchors = [];
   for (const index of componentIndices) {
     const component = components[index];
     const baseGlyph = await getGlyphFunc(component.name);
@@ -921,9 +922,18 @@ export async function decomposeComponents(
         location: { ...nestedCompo.location },
       });
     }
+    for (const anchor of compoInstance.anchors) {
+      const { name, x, y } = anchor;
+      const [newX, newY] = t.transformPoint(x, y);
+      newAnchors.push({
+        name,
+        x: newX,
+        y: newY,
+      });
+    }
   }
   const newPath = joinPaths(newPaths);
-  return { path: newPath, components: newComponents };
+  return { path: newPath, components: newComponents, anchors: newAnchors };
 }
 
 function makeAxisMapFunc(axis) {

--- a/src/fontra/views/editor/scene-controller.js
+++ b/src/fontra/views/editor/scene-controller.js
@@ -1060,6 +1060,7 @@ export class SceneController {
         const decomposeInfo = decomposed[layerName];
         const path = layerGlyph.path;
         const components = layerGlyph.components;
+        const anchors = layerGlyph.anchors;
 
         for (const contour of decomposeInfo.path.iterContours()) {
           // Hm, rounding should be optional
@@ -1067,6 +1068,13 @@ export class SceneController {
           path.appendContour(contour);
         }
         components.push(...decomposeInfo.components);
+        for (const anchor of decomposeInfo.anchors) {
+          // preserve existing anchors
+          const exists = anchors.some((a) => a.name === anchor.name);
+          if (!exists) {
+            anchors.push(anchor);
+          }
+        }
 
         // Next, delete the components we decomposed
         for (const componentIndex of reversed(componentSelection)) {


### PR DESCRIPTION
First, I tried to match the style with previous component and path decomposing codes.

The case I paid extra attention is when the glyph and its component have anchors with same names;
For example, if somehow the parent glyph had a `top` anchor, and a compoment has a `top` anchor, only one of either anchors should remain, not both.

I chose to preserve anchors from the parent glyph. 

And as I was reading the code, decomposing supports decomposing multiple components at the same time. In that case, anchors from a component with a preceding order have priority.

This fixes #1315