### PR TITLE
Fix #1041: Wrap long lines based on a settable maximum line width

### DIFF
--- a/src/fontra/views/editor/scene-controller.js
+++ b/src/fontra/views/editor/scene-controller.js
@@ -155,9 +155,14 @@ export class SceneController {
     this.sceneSettingsController.addKeyListener(
       ["selectedGlyph", "glyphLines"],
       (event) => {
+        const lines = this.sceneModel.positionedLines.map((line) => {
+          return line.glyphs.map((g) => ({
+            glyphName: g.glyphName,
+          }));
+        });
         this.sceneSettings.selectedGlyphName = getSelectedGlyphName(
           this.sceneSettings.selectedGlyph,
-          this.sceneSettings.glyphLines
+          lines
         );
       },
       true
@@ -330,6 +335,7 @@ export class SceneController {
       case "editBegin":
         {
           const glyphController = this.sceneModel.getSelectedPositionedGlyph().glyph;
+
           this.sceneModel.ghostPath = glyphController.flattenedPath2d;
         }
         break;
@@ -829,6 +835,7 @@ export class SceneController {
       return;
     }
     const glyphName = this.sceneModel.getSelectedGlyphName();
+
     const varGlyph = await this.fontController.getGlyph(glyphName);
     const baseChangePath = ["glyphs", glyphName];
 

--- a/src/fontra/views/editor/scene-controller.js
+++ b/src/fontra/views/editor/scene-controller.js
@@ -156,8 +156,10 @@ export class SceneController {
       ["selectedGlyph", "glyphLines"],
       (event) => {
         const lines = this.sceneModel.positionedLines.map((line) => {
-          return line.glyphs.map((g) => ({
-            glyphName: g.glyphName,
+          return line.glyphs.map((glyph) => ({
+            character: glyph.character,
+            glyphName: glyph.glyphName,
+            isUndefined: glyph.isUndefined,
           }));
         });
         this.sceneSettings.selectedGlyphName = getSelectedGlyphName(

--- a/src/fontra/views/editor/scene-model.js
+++ b/src/fontra/views/editor/scene-model.js
@@ -91,17 +91,32 @@ export class SceneModel {
     if (!glyphSelection) {
       return undefined;
     }
+
     return this.positionedLines[glyphSelection.lineIndex]?.glyphs[
       glyphSelection.glyphIndex
     ];
   }
 
   getSelectedGlyphInfo() {
-    return getSelectedGlyphInfo(this.selectedGlyph, this.glyphLines);
+    const lines = this.positionedLines.map((line) => {
+      return line.glyphs.map((glyph) => ({
+        character: glyph.character,
+        glyphName: glyph.glyphName,
+        isUndefined: glyph.isUndefined,
+      }));
+    });
+    return getSelectedGlyphInfo(this.selectedGlyph, lines);
   }
 
   getSelectedGlyphName() {
-    return getSelectedGlyphName(this.selectedGlyph, this.glyphLines);
+    const lines = this.positionedLines.map((line) => {
+      return line.glyphs.map((glyph) => ({
+        character: glyph.character,
+        glyphName: glyph.glyphName,
+        isUndefined: glyph.isUndefined,
+      }));
+    });
+    return getSelectedGlyphName(this.selectedGlyph, lines);
   }
 
   isSelectedGlyphLocked() {
@@ -349,7 +364,7 @@ export class SceneModel {
       glyphIndex: selectedGlyphIndex,
       isEditing: selectedGlyphIsEditing,
     } = this.selectedGlyph || {};
-    console.log(selectedLineIndex);
+
     const editLayerName = this.sceneSettings.editLayerName;
 
     let y = 0;
@@ -407,7 +422,6 @@ export class SceneModel {
             glyphInfo.glyphName
           );
         }
-        console.log(x + glyphInstance.xAdvance, maxLineLength);
         if (x + glyphInstance.xAdvance > maxLineLength) {
           stack.push(glyphLine.slice(glyphIndex));
           break;

--- a/src/fontra/views/editor/scene-model.js
+++ b/src/fontra/views/editor/scene-model.js
@@ -349,10 +349,12 @@ export class SceneModel {
       glyphIndex: selectedGlyphIndex,
       isEditing: selectedGlyphIsEditing,
     } = this.selectedGlyph || {};
+    console.log(selectedLineIndex);
     const editLayerName = this.sceneSettings.editLayerName;
 
     let y = 0;
     const lineDistance = 1.1 * fontController.unitsPerEm; // TODO make factor user-configurable
+    const maxLineLength = 12 * fontController.unitsPerEm; // TODO make factor user-configurable
     const positionedLines = [];
     let longestLineLength = 0;
 
@@ -374,7 +376,12 @@ export class SceneModel {
       return;
     }
 
-    for (const [lineIndex, glyphLine] of enumerate(glyphLines)) {
+    const stack = [...glyphLines].reverse();
+
+    let lineIndex = -1;
+    while (stack.length > 0) {
+      lineIndex += 1;
+      const glyphLine = stack.pop();
       const positionedLine = { glyphs: [] };
       let x = 0;
       for (const [glyphIndex, glyphInfo] of enumerate(glyphLine)) {
@@ -400,6 +407,12 @@ export class SceneModel {
             glyphInfo.glyphName
           );
         }
+        console.log(x + glyphInstance.xAdvance, maxLineLength);
+        if (x + glyphInstance.xAdvance > maxLineLength) {
+          stack.push(glyphLine.slice(glyphIndex));
+          break;
+        }
+
         positionedLine.glyphs.push({
           x: x,
           y: y,
@@ -413,7 +426,6 @@ export class SceneModel {
         });
         x += glyphInstance.xAdvance;
       }
-
       longestLineLength = Math.max(longestLineLength, x);
 
       let offset = 0;


### PR DESCRIPTION
Previously, rendering glyphs in the scene depended solely on `glyphLines` property, which originates from text entry of side panel.

And I recognized that to handle alignments, advance width of glyphs and total line lengths were already being tracked.

By using stack and pushing the "remaining line" on the top of the stack when the line length exceeds certain threshold, it was possible to implement the line wrapping algorithm.

--

But the problem is that currently "selection API" depends on "indices", and various codes accessing the current selected glyphs use these line and glyph indices to get glyph info out of `glyphLines` property.

This leads to a bug:
- the text I used is:
```
abcdeabcdeabcdeabcdeabcdeabcde
cdefg
```
- it gets wrapped as:
```
abcdeabcdeabcdeabcde
abcdeabcde
cdefg
```

when I select `b` from the "wrapped second line", and edit it, `d` gets edited because it is the second glyph of the second line, with respect to `glyphLines`

Therefore I handled this case by changing related codes to use `positionedLines` instead of `glyphLines`. Since type signatures of two data differs, some transforming is done. This is what second commit is about.

But it feels too much "ad hoc" for me, so any suggestions or reviews will be very helpful