### PR TITLE
Separate source index from UI list index

### DIFF
--- a/src/fontra/client/web-components/ui-list.js
+++ b/src/fontra/client/web-components/ui-list.js
@@ -219,6 +219,10 @@ export class UIList extends UnlitElement {
   }
 
   setSelectedItem(item, shouldDispatchEvent = false) {
+    if (!item) {
+      this.setSelectedItemIndex(undefined, shouldDispatchEvent);
+      return;
+    }
     let index = -1;
     if (item && this.itemEqualFunc) {
       const itemEqualFunc = this.itemEqualFunc;

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -394,9 +394,7 @@ export class EditorController {
                 const designspaceNavigationPanel = this.getSidebarPanel(
                   "designspace-navigation"
                 );
-                designspaceNavigationPanel.removeSource(
-                  designspaceNavigationPanel.sourcesList.getSelectedItemIndex()
-                );
+                designspaceNavigationPanel.removeSource();
               },
             },
             {

--- a/src/fontra/views/editor/panel-designspace-navigation.js
+++ b/src/fontra/views/editor/panel-designspace-navigation.js
@@ -374,7 +374,9 @@ export default class DesignspaceNavigationPanel extends Panel {
     });
 
     this.sourcesList.addEventListener("rowDoubleClicked", (event) => {
-      this.editSourceProperties(event.detail.doubleClickedRowIndex);
+      const sourceIndex =
+        this.sourcesList.items[event.detail.doubleClickedRowIndex].sourceIndex;
+      this.editSourceProperties(sourceIndex);
     });
 
     this.fontController.addChangeListener(
@@ -472,7 +474,8 @@ export default class DesignspaceNavigationPanel extends Panel {
       this.sceneSettings.location
     );
     for (const [index, sourceItem] of enumerate(this.sourcesList.items)) {
-      sourceItem.interpolationContribution = interpolationContributions[index];
+      sourceItem.interpolationContribution =
+        interpolationContributions[sourceItem.sourceIndex];
     }
   }
 

--- a/src/fontra/views/editor/panel-designspace-navigation.js
+++ b/src/fontra/views/editor/panel-designspace-navigation.js
@@ -214,16 +214,19 @@ export default class DesignspaceNavigationPanel extends Panel {
         const varGlyphController =
           await this.sceneModel.getSelectedVariableGlyphController();
         let index = event.newValue;
+
+        let sourceListItem = this.sourceListGetSourceItem(index);
+
         if (
-          varGlyphController?.sources[index]?.layerName !==
-          this.sourcesList.items[index]?.layerName
+          varGlyphController?.sources[index]?.layerName !== sourceListItem?.layerName
         ) {
           // the selectedSourceIndex event may come at a time that the
           // sourcesList hasn't been updated yet, so could be out of
           // sync. Prevent setting it to a wrong value.
-          index = undefined;
+          sourceListItem = undefined;
         }
-        this.sourceListSetSelectedSource(index);
+
+        this.sourcesList.setSelectedItem(sourceListItem);
 
         this._updateRemoveSourceButtonState();
         this._updateEditingStatus();
@@ -391,11 +394,16 @@ export default class DesignspaceNavigationPanel extends Panel {
     this._updateSources();
   }
 
+  sourceListGetSourceItem(sourceIndex) {
+    if (sourceIndex == undefined) {
+      return undefined;
+    }
+    return this.sourcesList.items.find((item) => item.sourceIndex == sourceIndex);
+  }
+
   sourceListSetSelectedSource(sourceIndex) {
     if (sourceIndex != undefined) {
-      this.sourcesList.setSelectedItem(
-        this.sourcesList.items.find((item) => item.sourceIndex == sourceIndex)
-      );
+      this.sourcesList.setSelectedItem(this.sourceListGetSourceItem(sourceIndex));
     } else {
       this.sourcesList.setSelectedItemIndex(undefined);
     }
@@ -569,6 +577,7 @@ export default class DesignspaceNavigationPanel extends Panel {
       });
       sourceItems.push(sourceController.model);
     }
+
     this.sourcesList.setItems(sourceItems, false, true);
     this.sourceListSetSelectedSource(this.sceneSettings.selectedSourceIndex);
     this.addRemoveSourceButtons.hidden = !sourceItems.length;


### PR DESCRIPTION
To prepare for "virtual sources" and sorting of the glyph sources list, we need to make a clear distinction between the index into the glyph's sources list, and the index into the UI's representation of glyph sources.