### PR TITLE
UI editor for status color definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ The following list of features is not complete, but gives you a rough idea of wh
 - Edit variation axes ✅
 - Visualize and edit variation axis mapping (avar) ✅
 - Visualize and edit cross-axis variation axis mapping (avar-2)
+- Visualize and edit status field definitions ✅
 
 ### Multiple windows
 

--- a/src/fontra/client/core/utils.js
+++ b/src/fontra/client/core/utils.js
@@ -353,6 +353,48 @@ export function rgbaToCSS(rgba) {
   return `rgb(${channels.join(",")})`;
 }
 
+export function hexToRgbaList(hexColor) {
+  // TODO: for now this works,
+  // but need to be refactored: recude redundancies
+  let c;
+  if (/^#[A-Fa-f0-9]{8}$/.test(hexColor)) {
+    c = hexColor.substring(1).split("");
+    return [
+      parseInt(c[0] + c[1], 16),
+      parseInt(c[2] + c[3], 16),
+      parseInt(c[4] + c[5], 16),
+      round(parseInt(c[6] + c[7], 16) / 255, 2),
+    ];
+  } else if (/^#[A-Fa-f0-9]{6}$/.test(hexColor)) {
+    c = hexColor.substring(1).split("");
+    return [
+      parseInt(c[0] + c[1], 16),
+      parseInt(c[2] + c[3], 16),
+      parseInt(c[4] + c[5], 16),
+      1,
+    ];
+  } else if (/^#[A-Fa-f0-9]{4}$/.test(hexColor)) {
+    c = hexColor.substring(1).split("");
+    return [
+      parseInt(c[0] + c[0], 16),
+      parseInt(c[1] + c[1], 16),
+      parseInt(c[2] + c[2], 16),
+      round(parseInt(c[3] + c[3], 16) / 255, 2),
+    ];
+  } else if (/^#[A-Fa-f0-9]{3}$/.test(hexColor)) {
+    console.log("hexColor: ", hexColor);
+    c = hexColor.substring(1).split("");
+    return [
+      parseInt(c[0] + c[0], 16),
+      parseInt(c[1] + c[1], 16),
+      parseInt(c[2] + c[2], 16),
+      1,
+    ];
+  } else {
+    new Error("Bad hex color format. Should be #RRGGBB or #RRGGBBAA or #RGB or #RGBA");
+  }
+}
+
 export function clamp(number, min, max) {
   return Math.max(Math.min(number, max), min);
 }

--- a/src/fontra/client/core/utils.js
+++ b/src/fontra/client/core/utils.js
@@ -360,39 +360,59 @@ export function hexToRgbaList(hexColor) {
   if (/^#[A-Fa-f0-9]{8}$/.test(hexColor)) {
     c = hexColor.substring(1).split("");
     return [
-      parseInt(c[0] + c[1], 16),
-      parseInt(c[2] + c[3], 16),
-      parseInt(c[4] + c[5], 16),
+      round(parseInt(c[0] + c[1], 16) / 255, 2),
+      round(parseInt(c[2] + c[3], 16) / 255, 2),
+      round(parseInt(c[4] + c[5], 16) / 255, 2),
       round(parseInt(c[6] + c[7], 16) / 255, 2),
     ];
   } else if (/^#[A-Fa-f0-9]{6}$/.test(hexColor)) {
     c = hexColor.substring(1).split("");
     return [
-      parseInt(c[0] + c[1], 16),
-      parseInt(c[2] + c[3], 16),
-      parseInt(c[4] + c[5], 16),
+      round(parseInt(c[0] + c[1], 16) / 255, 2),
+      round(parseInt(c[2] + c[3], 16) / 255, 2),
+      round(parseInt(c[4] + c[5], 16) / 255, 2),
       1,
     ];
   } else if (/^#[A-Fa-f0-9]{4}$/.test(hexColor)) {
     c = hexColor.substring(1).split("");
     return [
-      parseInt(c[0] + c[0], 16),
-      parseInt(c[1] + c[1], 16),
-      parseInt(c[2] + c[2], 16),
+      round(parseInt(c[0] + c[0], 16) / 255, 2),
+      round(parseInt(c[1] + c[1], 16) / 255, 2),
+      round(parseInt(c[2] + c[2], 16) / 255, 2),
       round(parseInt(c[3] + c[3], 16) / 255, 2),
     ];
   } else if (/^#[A-Fa-f0-9]{3}$/.test(hexColor)) {
     console.log("hexColor: ", hexColor);
     c = hexColor.substring(1).split("");
     return [
-      parseInt(c[0] + c[0], 16),
-      parseInt(c[1] + c[1], 16),
-      parseInt(c[2] + c[2], 16),
+      round(parseInt(c[0] + c[0], 16) / 255, 2),
+      round(parseInt(c[1] + c[1], 16) / 255, 2),
+      round(parseInt(c[2] + c[2], 16) / 255, 2),
       1,
     ];
   } else {
     new Error("Bad hex color format. Should be #RRGGBB or #RRGGBBAA or #RGB or #RGBA");
   }
+}
+
+export function rgbaToHex(rgba) {
+  const [r, g, b, a] = rgba;
+  const red = Math.round(r * 255)
+    .toString(16)
+    .padStart(2, "0");
+  const green = Math.round(g * 255)
+    .toString(16)
+    .padStart(2, "0");
+  const blue = Math.round(b * 255)
+    .toString(16)
+    .padStart(2, "0");
+  const alpha = Math.round(a * 255)
+    .toString(16)
+    .padStart(2, "0");
+  if (alpha === "ff") {
+    return `#${red}${green}${blue}`;
+  }
+  return `#${red}${green}${blue}${alpha}`;
 }
 
 export function clamp(number, min, max) {

--- a/src/fontra/client/core/utils.js
+++ b/src/fontra/client/core/utils.js
@@ -353,66 +353,42 @@ export function rgbaToCSS(rgba) {
   return `rgb(${channels.join(",")})`;
 }
 
-export function hexToRgbaList(hexColor) {
-  // TODO: for now this works,
-  // but need to be refactored: recude redundancies
-  let c;
-  if (/^#[A-Fa-f0-9]{8}$/.test(hexColor)) {
-    c = hexColor.substring(1).split("");
-    return [
-      round(parseInt(c[0] + c[1], 16) / 255, 2),
-      round(parseInt(c[2] + c[3], 16) / 255, 2),
-      round(parseInt(c[4] + c[5], 16) / 255, 2),
-      round(parseInt(c[6] + c[7], 16) / 255, 2),
-    ];
-  } else if (/^#[A-Fa-f0-9]{6}$/.test(hexColor)) {
-    c = hexColor.substring(1).split("");
-    return [
-      round(parseInt(c[0] + c[1], 16) / 255, 2),
-      round(parseInt(c[2] + c[3], 16) / 255, 2),
-      round(parseInt(c[4] + c[5], 16) / 255, 2),
-      1,
-    ];
-  } else if (/^#[A-Fa-f0-9]{4}$/.test(hexColor)) {
-    c = hexColor.substring(1).split("");
-    return [
-      round(parseInt(c[0] + c[0], 16) / 255, 2),
-      round(parseInt(c[1] + c[1], 16) / 255, 2),
-      round(parseInt(c[2] + c[2], 16) / 255, 2),
-      round(parseInt(c[3] + c[3], 16) / 255, 2),
-    ];
-  } else if (/^#[A-Fa-f0-9]{3}$/.test(hexColor)) {
-    console.log("hexColor: ", hexColor);
-    c = hexColor.substring(1).split("");
-    return [
-      round(parseInt(c[0] + c[0], 16) / 255, 2),
-      round(parseInt(c[1] + c[1], 16) / 255, 2),
-      round(parseInt(c[2] + c[2], 16) / 255, 2),
-      1,
-    ];
+export function hexToRgba(hexColor) {
+  let c = hexColor.substring(1).split("");
+  let r = [];
+  if (/^#[A-Fa-f0-9]{8}$/.test(hexColor) || /^#[A-Fa-f0-9]{6}$/.test(hexColor)) {
+    for (const i of range(0, c.length, 2)) {
+      r.push(round(parseInt(c[i] + c[i + 1], 16) / 255, 2));
+    }
+  } else if (/^#[A-Fa-f0-9]{4}$/.test(hexColor) || /^#[A-Fa-f0-9]{3}$/.test(hexColor)) {
+    for (const i of range(c.length)) {
+      r.push(round(parseInt(c[i] + c[i], 16) / 255, 2));
+    }
   } else {
+    r = [1, 0, 0, 1];
     new Error("Bad hex color format. Should be #RRGGBB or #RRGGBBAA or #RGB or #RGBA");
   }
+  if (r.length === 3) {
+    r.push(1);
+  }
+  return r;
 }
 
 export function rgbaToHex(rgba) {
-  const [r, g, b, a] = rgba;
-  const red = Math.round(r * 255)
-    .toString(16)
-    .padStart(2, "0");
-  const green = Math.round(g * 255)
-    .toString(16)
-    .padStart(2, "0");
-  const blue = Math.round(b * 255)
-    .toString(16)
-    .padStart(2, "0");
-  const alpha = Math.round(a * 255)
-    .toString(16)
-    .padStart(2, "0");
-  if (alpha === "ff") {
-    return `#${red}${green}${blue}`;
+  const channels = rgba.slice(0, 3).map((channel) =>
+    Math.round(channel * 255)
+      .toString(16)
+      .padStart(2, "0")
+  );
+  const alpha = rgba[3];
+  if (alpha !== undefined && 0 <= alpha && alpha < 1) {
+    channels.push(
+      Math.round(alpha * 255)
+        .toString(16)
+        .padStart(2, "0")
+    );
   }
-  return `#${red}${green}${blue}${alpha}`;
+  return `#${channels.join("")}`;
 }
 
 export function clamp(number, min, max) {

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -378,18 +378,22 @@ export class EditorController {
         title: "Font",
         enabled: () => true,
         getItems: () => {
-          return [
-            {
-              title: "Edit Font Info, Axes and Sources",
-              enabled: () => true,
-              callback: () => {
-                const url = new URL(window.location);
-                url.pathname = url.pathname.replace("/editor/", "/fontinfo/");
-                url.hash = "";
-                window.open(url.toString());
-              },
-            },
+          const menuItems = [
+            ["Font Info", "#font-info-panel", true],
+            ["Axes", "#axes-panel", true],
+            ["Sources", "#sources-panel", false],
+            ["Status definitions", "#development-status-definitions-panel", true],
           ];
+          return menuItems.map(([title, panelID, enabled]) => ({
+            title,
+            enabled: () => enabled,
+            callback: () => {
+              const url = new URL(window.location);
+              url.pathname = url.pathname.replace("/editor/", "/fontinfo/");
+              url.hash = panelID;
+              window.open(url.toString());
+            },
+          }));
         },
       },
       {

--- a/src/fontra/views/fontinfo/fontinfo.js
+++ b/src/fontra/views/fontinfo/fontinfo.js
@@ -3,7 +3,7 @@ import * as html from "../core/html-utils.js";
 import { getRemoteProxy } from "../core/remote.js";
 import { makeDisplayPath } from "../core/view-utils.js";
 import { AxesPanel } from "./panel-axes.js";
-import { DevelopmentStatusDefinitions } from "./panel-development-status-definitions.js";
+import { DevelopmentStatusDefinitionsPanel } from "./panel-development-status-definitions.js";
 import { FontInfoPanel } from "./panel-font-info.js";
 import { SourcesPanel } from "./panel-sources.js";
 import { message } from "/web-components/modal-dialog.js";
@@ -48,7 +48,7 @@ export class FontInfoController {
       FontInfoPanel,
       AxesPanel,
       SourcesPanel,
-      DevelopmentStatusDefinitions,
+      DevelopmentStatusDefinitionsPanel,
     ]) {
       panelClass.fontAttributes.forEach((fontAttr) => {
         subscribePattern[fontAttr] = null;

--- a/src/fontra/views/fontinfo/fontinfo.js
+++ b/src/fontra/views/fontinfo/fontinfo.js
@@ -3,6 +3,7 @@ import * as html from "../core/html-utils.js";
 import { getRemoteProxy } from "../core/remote.js";
 import { makeDisplayPath } from "../core/view-utils.js";
 import { AxesPanel } from "./panel-axes.js";
+import { DevelopmentStatusDefinitions } from "./panel-development-status-definitions.js";
 import { FontInfoPanel } from "./panel-font-info.js";
 import { SourcesPanel } from "./panel-sources.js";
 import { message } from "/web-components/modal-dialog.js";
@@ -43,7 +44,12 @@ export class FontInfoController {
 
     const subscribePattern = {};
 
-    for (const panelClass of [FontInfoPanel, AxesPanel, SourcesPanel]) {
+    for (const panelClass of [
+      FontInfoPanel,
+      AxesPanel,
+      SourcesPanel,
+      DevelopmentStatusDefinitions,
+    ]) {
       panelClass.fontAttributes.forEach((fontAttr) => {
         subscribePattern[fontAttr] = null;
       });

--- a/src/fontra/views/fontinfo/panel-development-status-definitions.js
+++ b/src/fontra/views/fontinfo/panel-development-status-definitions.js
@@ -1,7 +1,11 @@
 import { recordChanges } from "../core/change-recorder.js";
 import * as html from "../core/html-utils.js";
 import { addStyleSheet } from "../core/html-utils.js";
+import { ObservableController } from "../core/observable-object.js";
+import { labeledTextInput } from "../core/ui-utils.js";
+import { enumerate, hexToRgbaList } from "../core/utils.js";
 import { BaseInfoPanel } from "./panel-base.js";
+import { dialogSetup } from "/web-components/modal-dialog.js";
 import { Form } from "/web-components/ui-form.js";
 
 const defaultStatusFieldDefinitions = {
@@ -45,18 +49,182 @@ addStyleSheet(`
 
 export class DevelopmentStatusDefinitionsPanel extends BaseInfoPanel {
   static title = "Status definitions";
-  static id = "development-status-sefinitions-panel";
-  static fontAttributes = ["fontInfo", "unitsPerEm"];
+  static id = "development-status-definitions-panel";
+  static fontAttributes = ["statusDefinitions"];
 
   async setupUI() {
-    const customData = await this.fontController.customData;
     const statusDefinitions = getStatusFieldDefinitions(this.fontController);
     console.log("statusDefinitions", statusDefinitions);
 
     // TODO: page content status color definitions
 
+    const container = html.div({
+      style: "display: grid; gap: 0.5em;",
+    });
+
+    for (const statusDef of statusDefinitions) {
+      console.log("statusDef", statusDef);
+      // container.appendChild(
+      //   new statusBox(axes, index, this.postChange.bind(this), this.deleteAxis.bind(this))
+      // );
+    }
+
+    //setupSortableList(container);
+
+    // container.addEventListener("reordered", (event) => {
+    //   const reorderedAxes = [];
+    //   for (const [index, axisBox] of enumerate(container.children)) {
+    //     reorderedAxes.push(axisBox.axis);
+    //     axisBox.axisIndex = index;
+    //   }
+    //   this.replaceAxes(reorderedAxes, "Reorder axes");
+    // });
+
     this.panelElement.innerHTML = "";
-    this.panelElement.appendChild(this.infoForm);
+    this.panelElement.style = `
+    gap: 1em;
+    `;
+    this.panelElement.appendChild(
+      html.input({
+        type: "button",
+        style: `justify-self: start;`,
+        value: "New status definition...",
+        onclick: (event) => this.newStatusDefinition(statusDefinitions),
+      })
+    );
+
+    //this.panelElement.innerHTML = "";
+    //this.panelElement.appendChild(this.infoForm);
+  }
+
+  async newStatusDefinition() {
+    const statusDefinitions =
+      this.fontController.customData["fontra.sourceStatusFieldDefinitions"];
+    const validateInput = () => {
+      const warnings = [];
+      const editedStatusDefName =
+        controller.model.statusDefName || controller.model.suggestedstatusDefName;
+      for (const n of ["Value"]) {
+        const value = controller.model[`statusDef${n}`];
+        if (isNaN(value)) {
+          if (value !== undefined) {
+            warnings.push(`⚠️ The ${n.toLowerCase()} value must be a number`);
+          }
+        }
+      }
+      if (
+        statusDefinitions &&
+        statusDefinitions.some((statusDef) => statusDef.name === editedStatusDefName)
+      ) {
+        warnings.push("⚠️ The statusDef name should be unique");
+      }
+      warningElement.innerText = warnings.length ? warnings.join("\n") : "";
+      dialog.defaultButton.classList.toggle("disabled", warnings.length);
+    };
+
+    const controller = new ObservableController({
+      statusDefName: "In Progress",
+      statusDefColor: 0,
+      statusDefValue: 0,
+      statusDefIsDefault: false,
+      placeholderKeyColor: "suggestedStatusDefColor",
+    });
+
+    controller.addKeyListener("statusDefName", (event) => {
+      validateInput();
+    });
+    controller.addKeyListener("statusDefColor", (event) => {
+      validateInput();
+    });
+    controller.addKeyListener("statusDefValue", (event) => {
+      validateInput();
+    });
+    controller.addKeyListener("statusDefIsDefault", (event) => {
+      validateInput();
+    });
+
+    const disable =
+      controller.model.statusDefName ||
+      controller.model.statusDefColor ||
+      controller.model.statusDefValue
+        ? false
+        : true;
+    const { contentElement, warningElement } =
+      this._statusDefPropertiesContentElement(controller);
+
+    const dialog = await dialogSetup("New status definition", null, [
+      { title: "Cancel", isCancelButton: true },
+      { title: "Add new status definition", isDefaultButton: true, disabled: disable },
+    ]);
+
+    dialog.setContent(contentElement);
+
+    setTimeout(
+      () => contentElement.querySelector("#statusDef-name-text-input")?.focus(),
+      0
+    );
+
+    validateInput();
+
+    if (!(await dialog.run())) {
+      // User cancelled
+      return {};
+    }
+
+    const newStatus = {
+      label: controller.model.statusDefName,
+      color: hexToRgbaList(controller.model.statusDefColor),
+      value: controller.model.statusDefValue,
+      isDefault: controller.model.statusDefIsDefault,
+    };
+    console.log("newStatus", newStatus);
+
+    const undoLabel = `add status definition '${newStatus.name}'`;
+    const root = {
+      customData: this.fontController.customData["fontra.sourceStatusFieldDefinitions"],
+    };
+    const changes = recordChanges(root, (root) => {
+      root.customData["fontra.sourceStatusFieldDefinitions"].push(newStatus);
+    });
+    if (changes.hasChange) {
+      this.postChange(changes.change, changes.rollbackChange, undoLabel);
+      this.setupUI();
+    }
+  }
+
+  _statusDefPropertiesContentElement(controller) {
+    const warningElement = html.div({
+      id: "warning-text-status-def",
+      style: `grid-column: 1 / -1; min-height: 1.5em;`,
+    });
+    const contentElement = html.div(
+      {
+        style: `overflow: hidden;
+          white-space: nowrap;
+          display: grid;
+          gap: 0.5em;
+          grid-template-columns: auto auto;
+          align-items: center;
+          height: 100%;
+          min-height: 0;
+        `,
+      },
+      [
+        ...labeledTextInput("Name:", controller, "statusDefName", {
+          id: "statusDef-name-text-input",
+        }),
+        ...labeledTextInput("Color:", controller, "statusDefColor", {
+          type: "color",
+          placeholderKeyColor: "suggestedStatusDefColor",
+        }),
+        ...labeledTextInput("Value:", controller, "statusDefValue", {}),
+        //html.div(),
+        //labeledCheckbox("default", controller, "statusDefIsDefault", {}),
+        html.br(),
+        warningElement,
+      ]
+    );
+    return { contentElement, warningElement };
   }
 }
 
@@ -66,5 +234,5 @@ function getStatusFieldDefinitions(fontController) {
   if (statusFieldDefinitions) {
     return statusFieldDefinitions;
   }
-  return defaultStatusFieldDefinitions;
+  return defaultStatusFieldDefinitions["fontra.sourceStatusFieldDefinitions"];
 }

--- a/src/fontra/views/fontinfo/panel-development-status-definitions.js
+++ b/src/fontra/views/fontinfo/panel-development-status-definitions.js
@@ -3,7 +3,7 @@ import * as html from "../core/html-utils.js";
 import { addStyleSheet } from "../core/html-utils.js";
 import { ObservableController } from "../core/observable-object.js";
 import { labeledTextInput } from "../core/ui-utils.js";
-import { enumerate, hexToRgbaList, rgbaToCSS } from "../core/utils.js";
+import { enumerate, hexToRgbaList, rgbaToCSS, rgbaToHex } from "../core/utils.js";
 import { BaseInfoPanel } from "./panel-base.js";
 import { dialogSetup } from "/web-components/modal-dialog.js";
 import { Form } from "/web-components/ui-form.js";
@@ -63,7 +63,7 @@ export class DevelopmentStatusDefinitionsPanel extends BaseInfoPanel {
         type: "button",
         style: `justify-self: start;`,
         value: "New status definition...",
-        onclick: (event) => this.newStatusDefinition(statusDefinitions),
+        onclick: (event) => this.newStatusDef(),
       })
     );
     for (const statusDef of statusDefinitions) {
@@ -94,40 +94,13 @@ export class DevelopmentStatusDefinitionsPanel extends BaseInfoPanel {
 
       const formContents = [];
 
-      // formContents.push({
-      //   type: "edit-number",
-      //   key: JSON.stringify(["color"]),
-      //   label: "Value",
-      //   value: statusDef.value,
-      //   minValue: 0,
-      //   integer: true,
-      // });
-      // formContents.push({
-      //   type: "edit-text",
-      //   key: JSON.stringify(["label"]),
-      //   label: "Label",
-      //   value: statusDef.label,
-      // });
-      // formContents.push({
-      //   type: "edit-text", // edit-color does not exist, yet
-      //   key: JSON.stringify(["color"]),
-      //   label: "Color",
-      //   value: rgbaToCSS(statusDef.color),
-      // });
-      // formContents.push({
-      //   type: "edit-text",
-      //   key: JSON.stringify(["isDefault"]),
-      //   label: "Is Default",
-      //   value: statusDef.isDefault,
-      // });
-
       formContents.push({
         type: "header",
         label: `Status Definition ${statusDef.value}`,
         auxiliaryElement: html.createDomElement("icon-button", {
           "style": `width: 1.3em;`,
           "src": "/tabler-icons/trash.svg",
-          //"onclick": (event) => this._resetTransformationForComponent(index),
+          "onclick": (event) => this.deleteStatusDef(statusDef.value),
           "data-tooltip": "Delete status definition",
           "data-tooltipposition": "left",
         }),
@@ -142,16 +115,33 @@ export class DevelopmentStatusDefinitionsPanel extends BaseInfoPanel {
           width: "6em",
         },
         field2: {
-          type: "edit-text",
+          type: "auxiliaryElement",
           key: "StatusLabel",
-          value: rgbaToCSS(statusDef.color),
-          width: "6em",
+          auxiliaryElement: html.input({
+            type: "color",
+            style: `margin: 0; padding: 0; outline: none;`,
+            value: rgbaToHex(statusDef.color),
+            onchange: (event) => {
+              console.log("event.target.value", event.target.value);
+              console.log("statusDef.color", statusDef.color);
+              console.log("rgbaToHex(statusDef.color)", rgbaToHex(statusDef.color));
+            },
+          }),
         },
         field3: {
-          type: "edit-text",
+          type: "auxiliaryElement",
           key: "StatusIsDefault",
-          value: statusDef.isDefault,
-          width: "6em",
+          auxiliaryElement: html.input({
+            "type": "checkbox",
+            "id": "statusDefIsDefault",
+            "style": `width: auto; margin: 0; padding: 0; outline: none;`,
+            "checked": statusDef.isDefault,
+            "onclick": (event) => {
+              console.log("StatusIsDefault", event.target.checked);
+            },
+            "data-tooltip": "Is Default",
+            "data-tooltipposition": "left",
+          }),
         },
       });
 
@@ -160,95 +150,197 @@ export class DevelopmentStatusDefinitionsPanel extends BaseInfoPanel {
     }
   }
 
-  async newStatusDefinition() {
-    const statusDefinitions =
+  // commented out for now
+  //   async newStatusDefinition() {
+  //     const statusDefinitions =
+  //       this.fontController.customData["fontra.sourceStatusFieldDefinitions"];
+  //     const validateInput = () => {
+  //       const warnings = [];
+  //       const editedStatusDefName =
+  //         controller.model.statusDefName || controller.model.suggestedstatusDefName;
+  //       for (const n of ["Value"]) {
+  //         const value = controller.model[`statusDef${n}`];
+  //         if (isNaN(value)) {
+  //           if (value !== undefined) {
+  //             warnings.push(`⚠️ The ${n.toLowerCase()} value must be a number`);
+  //           }
+  //         }
+  //       }
+  //       if (
+  //         statusDefinitions &&
+  //         statusDefinitions.some((statusDef) => statusDef.name === editedStatusDefName)
+  //       ) {
+  //         warnings.push("⚠️ The statusDef name should be unique");
+  //       }
+  //       warningElement.innerText = warnings.length ? warnings.join("\n") : "";
+  //       dialog.defaultButton.classList.toggle("disabled", warnings.length);
+  //     };
+
+  //     const controller = new ObservableController({
+  //       statusDefName: "In Progress",
+  //       statusDefColor: 0,
+  //       statusDefValue: 0,
+  //       statusDefIsDefault: false,
+  //       placeholderKeyColor: "suggestedStatusDefColor",
+  //     });
+
+  //     controller.addKeyListener("statusDefName", (event) => {
+  //       validateInput();
+  //     });
+  //     controller.addKeyListener("statusDefColor", (event) => {
+  //       validateInput();
+  //     });
+  //     controller.addKeyListener("statusDefValue", (event) => {
+  //       validateInput();
+  //     });
+  //     controller.addKeyListener("statusDefIsDefault", (event) => {
+  //       validateInput();
+  //     });
+
+  //     const disable =
+  //       controller.model.statusDefName ||
+  //       controller.model.statusDefColor ||
+  //       controller.model.statusDefValue
+  //         ? false
+  //         : true;
+  //     const { contentElement, warningElement } =
+  //       this._statusDefPropertiesContentElement(controller);
+
+  //     const dialog = await dialogSetup("New status definition", null, [
+  //       { title: "Cancel", isCancelButton: true },
+  //       { title: "Add new status definition", isDefaultButton: true, disabled: disable },
+  //     ]);
+
+  //     dialog.setContent(contentElement);
+
+  //     setTimeout(
+  //       () => contentElement.querySelector("#statusDef-name-text-input")?.focus(),
+  //       0
+  //     );
+
+  //     validateInput();
+
+  //     if (!(await dialog.run())) {
+  //       // User cancelled
+  //       return {};
+  //     }
+
+  //     const newStatus = {
+  //       label: controller.model.statusDefName,
+  //       color: hexToRgbaList(controller.model.statusDefColor),
+  //       value: controller.model.statusDefValue,
+  //       isDefault: controller.model.statusDefIsDefault,
+  //     };
+  //     console.log("newStatus", newStatus);
+
+  //     const undoLabel = `add status definition '${newStatus.name}'`;
+  //     console.log("undoLabel: ", undoLabel);
+  //     const root = {
+  //       customData: this.fontController.customData["fontra.sourceStatusFieldDefinitions"],
+  //     };
+  //     const changes = recordChanges(root, (root) => {
+  //       root.customData["fontra.sourceStatusFieldDefinitions"].push(newStatus);
+  //     });
+  //     if (changes.hasChange) {
+  //       this.postChange(changes.change, changes.rollbackChange, undoLabel);
+  //       this.setupUI();
+  //     }
+  //   }
+
+  //   _statusDefPropertiesContentElement(controller) {
+  //     const warningElement = html.div({
+  //       id: "warning-text-status-def",
+  //       style: `grid-column: 1 / -1; min-height: 1.5em;`,
+  //     });
+  //     const contentElement = html.div(
+  //       {
+  //         style: `overflow: hidden;
+  //           white-space: nowrap;
+  //           display: grid;
+  //           gap: 0.5em;
+  //           grid-template-columns: auto auto;
+  //           align-items: center;
+  //           height: 100%;
+  //           min-height: 0;
+  //         `,
+  //       },
+  //       [
+  //         ...labeledTextInput("Name:", controller, "statusDefName", {
+  //           id: "statusDef-name-text-input",
+  //         }),
+  //         ...labeledTextInput("Color:", controller, "statusDefColor", {
+  //           type: "color",
+  //           placeholderKeyColor: "suggestedStatusDefColor",
+  //         }),
+  //         ...labeledTextInput("Value:", controller, "statusDefValue", {}),
+  //         //html.div(),
+  //         //labeledCheckbox("default", controller, "statusDefIsDefault", {}),
+  //         html.br(),
+  //         warningElement,
+  //       ]
+  //     );
+  //     return { contentElement, warningElement };
+  //   }
+
+  async newStatusDef(statusDef = undefined) {
+    // TODO: check for duplicates
+    const statusFieldDefinitions =
       this.fontController.customData["fontra.sourceStatusFieldDefinitions"];
-    const validateInput = () => {
-      const warnings = [];
-      const editedStatusDefName =
-        controller.model.statusDefName || controller.model.suggestedstatusDefName;
-      for (const n of ["Value"]) {
-        const value = controller.model[`statusDef${n}`];
-        if (isNaN(value)) {
-          if (value !== undefined) {
-            warnings.push(`⚠️ The ${n.toLowerCase()} value must be a number`);
-          }
-        }
-      }
-      if (
-        statusDefinitions &&
-        statusDefinitions.some((statusDef) => statusDef.name === editedStatusDefName)
-      ) {
-        warnings.push("⚠️ The statusDef name should be unique");
-      }
-      warningElement.innerText = warnings.length ? warnings.join("\n") : "";
-      dialog.defaultButton.classList.toggle("disabled", warnings.length);
-    };
-
-    const controller = new ObservableController({
-      statusDefName: "In Progress",
-      statusDefColor: 0,
-      statusDefValue: 0,
-      statusDefIsDefault: false,
-      placeholderKeyColor: "suggestedStatusDefColor",
-    });
-
-    controller.addKeyListener("statusDefName", (event) => {
-      validateInput();
-    });
-    controller.addKeyListener("statusDefColor", (event) => {
-      validateInput();
-    });
-    controller.addKeyListener("statusDefValue", (event) => {
-      validateInput();
-    });
-    controller.addKeyListener("statusDefIsDefault", (event) => {
-      validateInput();
-    });
-
-    const disable =
-      controller.model.statusDefName ||
-      controller.model.statusDefColor ||
-      controller.model.statusDefValue
-        ? false
-        : true;
-    const { contentElement, warningElement } =
-      this._statusDefPropertiesContentElement(controller);
-
-    const dialog = await dialogSetup("New status definition", null, [
-      { title: "Cancel", isCancelButton: true },
-      { title: "Add new status definition", isDefaultButton: true, disabled: disable },
-    ]);
-
-    dialog.setContent(contentElement);
-
-    setTimeout(
-      () => contentElement.querySelector("#statusDef-name-text-input")?.focus(),
-      0
-    );
-
-    validateInput();
-
-    if (!(await dialog.run())) {
-      // User cancelled
-      return {};
+    if (!statusFieldDefinitions) {
+      this.fontController.customData["fontra.sourceStatusFieldDefinitions"] = [];
+    }
+    const nextStatusValue = !statusFieldDefinitions
+      ? 0
+      : statusFieldDefinitions
+          .map((statusDef) => statusDef.value)
+          .sort()
+          .pop() + 1;
+    console.log("nextStatusValue", nextStatusValue);
+    // fix duplicates and isDefault
+    if (
+      statusDef &&
+      statusFieldDefinitions.some((statusDef) => statusDef.value === statusDef.value)
+    ) {
+      console.info(
+        "Status definition with value already exists, changed value to next available value."
+      );
+      statusDef = {
+        ...statusDef,
+        value: nextStatusValue,
+      };
     }
 
-    const newStatus = {
-      label: controller.model.statusDefName,
-      color: hexToRgbaList(controller.model.statusDefColor),
-      value: controller.model.statusDefValue,
-      isDefault: controller.model.statusDefIsDefault,
-    };
-    console.log("newStatus", newStatus);
+    // fix isDefault
+    if (statusDef && statusFieldDefinitions.some((statusDef) => statusDef.isDefault)) {
+      console.info(
+        "Status definition with isDefault already exists, changed value to false."
+      );
+      delete statusDef["isDefault"];
+    }
 
-    const undoLabel = `add status definition '${newStatus.name}'`;
+    if (!statusDef) {
+      const defaultStatuses =
+        defaultStatusFieldDefinitions["fontra.sourceStatusFieldDefinitions"];
+      statusDef = defaultStatuses.find(
+        (statusDef) => statusDef.value == nextStatusValue
+      );
+    }
+
+    if (!statusDef) {
+      console.info("No status definition provided or found. Use default.");
+      statusDef = {
+        color: [1, 0, 0, 1],
+        label: "Status definition name",
+        value: nextStatusValue,
+      };
+    }
+    //fontController.customData["fontra.sourceStatusFieldDefinitions"].push(statusDef);
+
+    const undoLabel = `add status definition ${statusDef.value} '${statusDef.label}'`;
     console.log("undoLabel: ", undoLabel);
-    const root = {
-      customData: this.fontController.customData["fontra.sourceStatusFieldDefinitions"],
-    };
+    const root = { customData: this.fontController.customData };
     const changes = recordChanges(root, (root) => {
-      root.customData["fontra.sourceStatusFieldDefinitions"].push(newStatus);
+      root.customData["fontra.sourceStatusFieldDefinitions"].push(statusDef);
     });
     if (changes.hasChange) {
       this.postChange(changes.change, changes.rollbackChange, undoLabel);
@@ -256,39 +348,20 @@ export class DevelopmentStatusDefinitionsPanel extends BaseInfoPanel {
     }
   }
 
-  _statusDefPropertiesContentElement(controller) {
-    const warningElement = html.div({
-      id: "warning-text-status-def",
-      style: `grid-column: 1 / -1; min-height: 1.5em;`,
+  async deleteStatusDef(statusDefValue) {
+    const index = this.fontController.customData[
+      "fontra.sourceStatusFieldDefinitions"
+    ].findIndex((statusDef) => statusDef.value === statusDefValue);
+    const undoLabel = `delete status definition ${statusDefValue}`;
+    console.log("undoLabel: ", undoLabel);
+    const root = { customData: this.fontController.customData };
+    const changes = recordChanges(root, (root) => {
+      root.customData["fontra.sourceStatusFieldDefinitions"].splice(index, 1);
     });
-    const contentElement = html.div(
-      {
-        style: `overflow: hidden;
-          white-space: nowrap;
-          display: grid;
-          gap: 0.5em;
-          grid-template-columns: auto auto;
-          align-items: center;
-          height: 100%;
-          min-height: 0;
-        `,
-      },
-      [
-        ...labeledTextInput("Name:", controller, "statusDefName", {
-          id: "statusDef-name-text-input",
-        }),
-        ...labeledTextInput("Color:", controller, "statusDefColor", {
-          type: "color",
-          placeholderKeyColor: "suggestedStatusDefColor",
-        }),
-        ...labeledTextInput("Value:", controller, "statusDefValue", {}),
-        //html.div(),
-        //labeledCheckbox("default", controller, "statusDefIsDefault", {}),
-        html.br(),
-        warningElement,
-      ]
-    );
-    return { contentElement, warningElement };
+    if (changes.hasChange) {
+      this.postChange(changes.change, changes.rollbackChange, undoLabel);
+      this.setupUI();
+    }
   }
 }
 
@@ -298,5 +371,5 @@ function getStatusFieldDefinitions(fontController) {
   if (statusFieldDefinitions) {
     return statusFieldDefinitions;
   }
-  return defaultStatusFieldDefinitions["fontra.sourceStatusFieldDefinitions"];
+  return [];
 }

--- a/src/fontra/views/fontinfo/panel-development-status-definitions.js
+++ b/src/fontra/views/fontinfo/panel-development-status-definitions.js
@@ -56,13 +56,13 @@ export class DevelopmentStatusDefinitionsPanel extends BaseInfoPanel {
     const statusDefinitions = getStatusFieldDefinitions(this.fontController);
     this.panelElement.innerHTML = "";
     this.panelElement.style = `
-    gap: 1em;
+    gap: 0.5em;
     `;
     this.panelElement.appendChild(
       html.input({
         type: "button",
         style: `justify-self: start;`,
-        value: "New status definition...",
+        value: "New status definition",
         onclick: (event) => this.newStatusDef(),
       })
     );
@@ -170,138 +170,6 @@ export class DevelopmentStatusDefinitionsPanel extends BaseInfoPanel {
       this.panelElement.appendChild(this.infoForm);
     }
   }
-
-  // commented out for now
-  //   async newStatusDefinition() {
-  //     const statusDefinitions =
-  //       this.fontController.customData["fontra.sourceStatusFieldDefinitions"];
-  //     const validateInput = () => {
-  //       const warnings = [];
-  //       const editedStatusDefName =
-  //         controller.model.statusDefName || controller.model.suggestedstatusDefName;
-  //       for (const n of ["Value"]) {
-  //         const value = controller.model[`statusDef${n}`];
-  //         if (isNaN(value)) {
-  //           if (value !== undefined) {
-  //             warnings.push(`⚠️ The ${n.toLowerCase()} value must be a number`);
-  //           }
-  //         }
-  //       }
-  //       if (
-  //         statusDefinitions &&
-  //         statusDefinitions.some((statusDef) => statusDef.name === editedStatusDefName)
-  //       ) {
-  //         warnings.push("⚠️ The statusDef name should be unique");
-  //       }
-  //       warningElement.innerText = warnings.length ? warnings.join("\n") : "";
-  //       dialog.defaultButton.classList.toggle("disabled", warnings.length);
-  //     };
-
-  //     const controller = new ObservableController({
-  //       statusDefName: "In Progress",
-  //       statusDefColor: 0,
-  //       statusDefValue: 0,
-  //       statusDefIsDefault: false,
-  //       placeholderKeyColor: "suggestedStatusDefColor",
-  //     });
-
-  //     controller.addKeyListener("statusDefName", (event) => {
-  //       validateInput();
-  //     });
-  //     controller.addKeyListener("statusDefColor", (event) => {
-  //       validateInput();
-  //     });
-  //     controller.addKeyListener("statusDefValue", (event) => {
-  //       validateInput();
-  //     });
-  //     controller.addKeyListener("statusDefIsDefault", (event) => {
-  //       validateInput();
-  //     });
-
-  //     const disable =
-  //       controller.model.statusDefName ||
-  //       controller.model.statusDefColor ||
-  //       controller.model.statusDefValue
-  //         ? false
-  //         : true;
-  //     const { contentElement, warningElement } =
-  //       this._statusDefPropertiesContentElement(controller);
-
-  //     const dialog = await dialogSetup("New status definition", null, [
-  //       { title: "Cancel", isCancelButton: true },
-  //       { title: "Add new status definition", isDefaultButton: true, disabled: disable },
-  //     ]);
-
-  //     dialog.setContent(contentElement);
-
-  //     setTimeout(
-  //       () => contentElement.querySelector("#statusDef-name-text-input")?.focus(),
-  //       0
-  //     );
-
-  //     validateInput();
-
-  //     if (!(await dialog.run())) {
-  //       // User cancelled
-  //       return {};
-  //     }
-
-  //     const newStatus = {
-  //       label: controller.model.statusDefName,
-  //       color: hexToRgbaList(controller.model.statusDefColor),
-  //       value: controller.model.statusDefValue,
-  //       isDefault: controller.model.statusDefIsDefault,
-  //     };
-  //     console.log("newStatus", newStatus);
-
-  //     const undoLabel = `add status definition '${newStatus.name}'`;
-  //     console.log("undoLabel: ", undoLabel);
-  //     const root = {
-  //       customData: this.fontController.customData["fontra.sourceStatusFieldDefinitions"],
-  //     };
-  //     const changes = recordChanges(root, (root) => {
-  //       root.customData["fontra.sourceStatusFieldDefinitions"].push(newStatus);
-  //     });
-  //     if (changes.hasChange) {
-  //       this.postChange(changes.change, changes.rollbackChange, undoLabel);
-  //       this.setupUI();
-  //     }
-  //   }
-
-  //   _statusDefPropertiesContentElement(controller) {
-  //     const warningElement = html.div({
-  //       id: "warning-text-status-def",
-  //       style: `grid-column: 1 / -1; min-height: 1.5em;`,
-  //     });
-  //     const contentElement = html.div(
-  //       {
-  //         style: `overflow: hidden;
-  //           white-space: nowrap;
-  //           display: grid;
-  //           gap: 0.5em;
-  //           grid-template-columns: auto auto;
-  //           align-items: center;
-  //           height: 100%;
-  //           min-height: 0;
-  //         `,
-  //       },
-  //       [
-  //         ...labeledTextInput("Name:", controller, "statusDefName", {
-  //           id: "statusDef-name-text-input",
-  //         }),
-  //         ...labeledTextInput("Color:", controller, "statusDefColor", {
-  //           type: "color",
-  //           placeholderKeyColor: "suggestedStatusDefColor",
-  //         }),
-  //         ...labeledTextInput("Value:", controller, "statusDefValue", {}),
-  //         //html.div(),
-  //         //labeledCheckbox("default", controller, "statusDefIsDefault", {}),
-  //         html.br(),
-  //         warningElement,
-  //       ]
-  //     );
-  //     return { contentElement, warningElement };
-  //   }
 
   async newStatusDef(statusDef = undefined) {
     const statusFieldDefinitions =

--- a/src/fontra/views/fontinfo/panel-development-status-definitions.js
+++ b/src/fontra/views/fontinfo/panel-development-status-definitions.js
@@ -43,8 +43,8 @@ addStyleSheet(`
 }
 `);
 
-export class DevelopmentStatusDefinitions extends BaseInfoPanel {
-  static title = "Status Color Settings"; // Development Status Definitions -> too long
+export class DevelopmentStatusDefinitionsPanel extends BaseInfoPanel {
+  static title = "Status definitions";
   static id = "development-status-sefinitions-panel";
   static fontAttributes = ["fontInfo", "unitsPerEm"];
 

--- a/src/fontra/views/fontinfo/panel-development-status-definitions.js
+++ b/src/fontra/views/fontinfo/panel-development-status-definitions.js
@@ -1,7 +1,7 @@
 import { recordChanges } from "../core/change-recorder.js";
 import * as html from "../core/html-utils.js";
 import { addStyleSheet } from "../core/html-utils.js";
-import { enumerate, hexToRgbaList, range, rgbaToHex } from "../core/utils.js";
+import { enumerate, hexToRgba, range, rgbaToHex } from "../core/utils.js";
 import { BaseInfoPanel } from "./panel-base.js";
 
 const defaultStatusFieldDefinitions = {
@@ -264,7 +264,7 @@ class StatusDefBox extends HTMLElement {
         "onchange": (event) => {
           const updatedStatusDef = {
             ...statusDef,
-            color: hexToRgbaList(event.target.value),
+            color: hexToRgba(event.target.value),
           };
           this.replaceStatusDef(updatedStatusDef, "change status definition color");
         },

--- a/src/fontra/views/fontinfo/panel-development-status-definitions.js
+++ b/src/fontra/views/fontinfo/panel-development-status-definitions.js
@@ -170,12 +170,12 @@ addStyleSheet(`
 
 .fontra-ui-font-info-status-definitions-panel-status-def-box-delete {
   justify-self: end;
-  align-self: start;
+  /*align-self: start;*/
 }
 
 .fontra-ui-font-info-status-definitions-panel-status-def-box-color {
   width: 8em;
-  height: 1.6em;
+  /*height: 1.6em; without height: best compromise for all browsers*/
   margin: 0;
   padding: 0;
   outline: none;
@@ -287,7 +287,7 @@ class StatusDefBox extends HTMLElement {
     this.append(
       html.div(
         {
-          "style": "display: inline-flex; height: 1.6em;",
+          "style": "margin: auto;",
           "data-tooltip":
             "If set: This color will be used if a source status is not set.",
           "data-tooltipposition": "top",
@@ -302,7 +302,7 @@ class StatusDefBox extends HTMLElement {
           html.label(
             {
               for: checkBoxIdentifier,
-              style: "padding: 3px",
+              style: "margin: auto;/*padding: 3px*/",
             },
             ["Is Default"]
           ),

--- a/src/fontra/views/fontinfo/panel-development-status-definitions.js
+++ b/src/fontra/views/fontinfo/panel-development-status-definitions.js
@@ -1,0 +1,70 @@
+import { recordChanges } from "../core/change-recorder.js";
+import * as html from "../core/html-utils.js";
+import { addStyleSheet } from "../core/html-utils.js";
+import { BaseInfoPanel } from "./panel-base.js";
+import { Form } from "/web-components/ui-form.js";
+
+const defaultStatusFieldDefinitions = {
+  "fontra.sourceStatusFieldDefinitions": [
+    {
+      color: [1, 0, 0, 1],
+      isDefault: true,
+      label: "In progress",
+      value: 0,
+    },
+    {
+      color: [1, 0.5, 0, 1],
+      label: "Checking-1",
+      value: 1,
+    },
+    {
+      color: [1, 1, 0, 1],
+      label: "Checking-2",
+      value: 2,
+    },
+    {
+      color: [0, 0.5, 1, 1],
+      label: "Checking-3",
+      value: 3,
+    },
+    {
+      color: [0, 1, 0.5, 1],
+      label: "Validated",
+      value: 4,
+    },
+  ],
+};
+
+addStyleSheet(`
+.fontra-ui-font-info-axes-panel {
+  background-color: var(--ui-element-background-color);
+  border-radius: 0.5em;
+  padding: 1em;
+}
+`);
+
+export class DevelopmentStatusDefinitions extends BaseInfoPanel {
+  static title = "Status Color Settings"; // Development Status Definitions -> too long
+  static id = "development-status-sefinitions-panel";
+  static fontAttributes = ["fontInfo", "unitsPerEm"];
+
+  async setupUI() {
+    const customData = await this.fontController.customData;
+    const statusDefinitions = getStatusFieldDefinitions(this.fontController);
+    console.log("statusDefinitions", statusDefinitions);
+
+    // TODO: page content status color definitions
+
+    this.panelElement.innerHTML = "";
+    this.panelElement.appendChild(this.infoForm);
+  }
+}
+
+function getStatusFieldDefinitions(fontController) {
+  const statusFieldDefinitions =
+    fontController.customData["fontra.sourceStatusFieldDefinitions"];
+  if (statusFieldDefinitions) {
+    return statusFieldDefinitions;
+  }
+  return defaultStatusFieldDefinitions;
+}

--- a/src/fontra/views/fontinfo/panel-development-status-definitions.js
+++ b/src/fontra/views/fontinfo/panel-development-status-definitions.js
@@ -58,7 +58,6 @@ export class DevelopmentStatusDefinitionsPanel extends BaseInfoPanel {
       statusDefsContainer.appendChild(
         new StatusDefBox(
           this.fontController,
-          statusDefinitions,
           index,
           this.postChange.bind(this),
           this.setupUI.bind(this)
@@ -86,8 +85,8 @@ export class DevelopmentStatusDefinitionsPanel extends BaseInfoPanel {
     const statusFieldDefinitions =
       this.fontController.customData["fontra.sourceStatusFieldDefinitions"];
     if (!statusFieldDefinitions) {
-      // if not present, create default status definitions
-      // TODO: This does not work, if there is no "fontra.sourceStatusFieldDefinitions" set, yet.
+      // TODO: This does not work, yet.
+      // If there is no "fontra.sourceStatusFieldDefinitions" in customData.
       this.fontController.customData["fontra.sourceStatusFieldDefinitions"] = [];
     }
     const nextStatusValue = !statusFieldDefinitions
@@ -187,11 +186,10 @@ addStyleSheet(`
 `);
 
 class StatusDefBox extends HTMLElement {
-  constructor(fontController, statusDefs, statusIndex, postChange, setupUI) {
+  constructor(fontController, statusIndex, postChange, setupUI) {
     super();
     this.classList.add("fontra-ui-font-info-status-definitions-panel-status-def-box");
     this.fontController = fontController;
-    this.statusDefs = statusDefs;
     this.statusIndex = statusIndex;
     this.postChange = postChange;
     this.setupUI = setupUI;
@@ -199,7 +197,9 @@ class StatusDefBox extends HTMLElement {
   }
 
   get statusDef() {
-    return this.statusDefs[this.statusIndex];
+    return this.fontController.customData["fontra.sourceStatusFieldDefinitions"][
+      this.statusIndex
+    ];
   }
 
   replaceStatusDef(newStatusDef, undoLabel, statusIndex = this.statusIndex) {
@@ -215,11 +215,7 @@ class StatusDefBox extends HTMLElement {
   }
 
   deleteStatusDef(statusIndex) {
-    const statusDef =
-      this.fontController.customData["fontra.sourceStatusFieldDefinitions"][
-        statusIndex
-      ];
-    const undoLabel = `delete status def '${statusDef.name}'`;
+    const undoLabel = `delete status def '${this.statusDef.name}'`;
     const root = { customData: this.fontController.customData };
     const changes = recordChanges(root, (root) => {
       root.customData["fontra.sourceStatusFieldDefinitions"].splice(statusIndex, 1);

--- a/src/fontra/views/fontinfo/panel-development-status-definitions.js
+++ b/src/fontra/views/fontinfo/panel-development-status-definitions.js
@@ -123,10 +123,10 @@ export class DevelopmentStatusDefinitionsPanel extends BaseInfoPanel {
 
       formContents.push({
         type: "header",
-        label: "Transformation",
+        label: `Status Definition ${statusDef.value}`,
         auxiliaryElement: html.createDomElement("icon-button", {
           "style": `width: 1.3em;`,
-          "src": "/tabler-icons/refresh.svg",
+          "src": "/tabler-icons/trash.svg",
           //"onclick": (event) => this._resetTransformationForComponent(index),
           "data-tooltip": "Delete status definition",
           "data-tooltipposition": "left",
@@ -136,19 +136,22 @@ export class DevelopmentStatusDefinitionsPanel extends BaseInfoPanel {
       formContents.push({
         type: "universal-row",
         field1: {
-          type: "text",
-          key: `StatusDefinition${statusDef.value}`,
-          value: `Status Definition:`,
+          type: "edit-text",
+          key: "StatusLabel",
+          value: statusDef.label,
+          width: "6em",
         },
         field2: {
           type: "edit-text",
           key: "StatusLabel",
-          value: statusDef.label,
+          value: rgbaToCSS(statusDef.color),
+          width: "6em",
         },
         field3: {
           type: "edit-text",
-          key: "StatusLabel",
-          value: rgbaToCSS(statusDef.color),
+          key: "StatusIsDefault",
+          value: statusDef.isDefault,
+          width: "6em",
         },
       });
 

--- a/test-js/test-utils.js
+++ b/test-js/test-utils.js
@@ -11,7 +11,7 @@ import {
   fileNameExtension,
   getCharFromCodePoint,
   guessCharFromGlyphName,
-  hexToRgbaList,
+  hexToRgba,
   hyphenatedToCamelCase,
   hyphenatedToLabel,
   loadURLFragment,
@@ -373,22 +373,26 @@ describe("rgbaToCSS", () => {
   });
 });
 
-describe("hexToRgbaList", () => {
+describe("hexToRgba", () => {
   it("should convert a hex color string to rgba array of decimals", () => {
-    let array = hexToRgbaList("#FF0000");
+    let array = hexToRgba("#FF0000");
     expect(array).deep.equals([1, 0, 0, 1]); // red
   });
   it("should convert short hex color string to rgba array of decimals", () => {
-    const array = hexToRgbaList("#F00");
+    const array = hexToRgba("#F00");
     expect(array).deep.equals([1, 0, 0, 1]); // red
   });
   it("should convert a hex color string with opacity to rgba array of decimals", () => {
-    const array = hexToRgbaList("#FF000080");
+    const array = hexToRgba("#FF000080");
     expect(array).deep.equals([1, 0, 0, 0.5]); // red with 80% opacity
   });
   it("should convert short hex color string with opacity to rgba array of decimals", () => {
-    const array = hexToRgbaList("#F008");
+    const array = hexToRgba("#F008");
     expect(array).deep.equals([1, 0, 0, 0.53]); // red with 80% opacity
+  });
+  it("bad hex string -> Default value", () => {
+    const array = hexToRgba("#X008");
+    expect(array).deep.equals([1, 0, 0, 1]);
   });
 });
 

--- a/test-js/test-utils.js
+++ b/test-js/test-utils.js
@@ -11,6 +11,7 @@ import {
   fileNameExtension,
   getCharFromCodePoint,
   guessCharFromGlyphName,
+  hexToRgbaList,
   hyphenatedToCamelCase,
   hyphenatedToLabel,
   loadURLFragment,
@@ -368,6 +369,25 @@ describe("rgbaToCSS", () => {
   });
   it("should always create rgb if the opacity is 1", () => {
     expect(rgbaToCSS([0, 0, 0, 1])).to.be.equal("rgb(0,0,0)");
+  });
+});
+
+describe("hexToRgbaList", () => {
+  it("should convert a hex color string to rgba array of decimals", () => {
+    let array = hexToRgbaList("#FF0000");
+    expect(array).deep.equals([255, 0, 0, 1]); // red
+  });
+  it("should convert short hex color string to rgba array of decimals", () => {
+    const array = hexToRgbaList("#F00");
+    expect(array).deep.equals([255, 0, 0, 1]); // red
+  });
+  it("should convert a hex color string with opacity to rgba array of decimals", () => {
+    const array = hexToRgbaList("#FF000080");
+    expect(array).deep.equals([255, 0, 0, 0.5]); // red with 80% opacity
+  });
+  it("should convert short hex color string with opacity to rgba array of decimals", () => {
+    const array = hexToRgbaList("#F008");
+    expect(array).deep.equals([255, 0, 0, 0.53]); // red with 80% opacity
   });
 });
 

--- a/test-js/test-utils.js
+++ b/test-js/test-utils.js
@@ -26,6 +26,7 @@ import {
   reversed,
   reversedEnumerate,
   rgbaToCSS,
+  rgbaToHex,
   round,
   scheduleCalls,
   splitGlyphNameExtension,
@@ -375,19 +376,28 @@ describe("rgbaToCSS", () => {
 describe("hexToRgbaList", () => {
   it("should convert a hex color string to rgba array of decimals", () => {
     let array = hexToRgbaList("#FF0000");
-    expect(array).deep.equals([255, 0, 0, 1]); // red
+    expect(array).deep.equals([1, 0, 0, 1]); // red
   });
   it("should convert short hex color string to rgba array of decimals", () => {
     const array = hexToRgbaList("#F00");
-    expect(array).deep.equals([255, 0, 0, 1]); // red
+    expect(array).deep.equals([1, 0, 0, 1]); // red
   });
   it("should convert a hex color string with opacity to rgba array of decimals", () => {
     const array = hexToRgbaList("#FF000080");
-    expect(array).deep.equals([255, 0, 0, 0.5]); // red with 80% opacity
+    expect(array).deep.equals([1, 0, 0, 0.5]); // red with 80% opacity
   });
   it("should convert short hex color string with opacity to rgba array of decimals", () => {
     const array = hexToRgbaList("#F008");
-    expect(array).deep.equals([255, 0, 0, 0.53]); // red with 80% opacity
+    expect(array).deep.equals([1, 0, 0, 0.53]); // red with 80% opacity
+  });
+});
+
+describe("rgbaToHex", () => {
+  it("should convert rgba array of decimals to a hex color string", () => {
+    expect(rgbaToHex([1, 0, 0, 1])).deep.equals("#ff0000");
+  });
+  it("should convert rgba array of decimals to a hex color string with opacity ", () => {
+    expect(rgbaToHex([1, 0, 0, 0.5])).deep.equals("#ff000080");
   });
 });
 

--- a/test-py/data/mutatorsans/MutatorSansLightCondensed.ufo/glyphs/E_.glif
+++ b/test-py/data/mutatorsans/MutatorSansLightCondensed.ufo/glyphs/E_.glif
@@ -31,4 +31,10 @@
       <point x="80" y="370" type="line"/>
     </contour>
   </outline>
+  <lib>
+    <dict>
+      <key>public.markColor</key>
+      <string>1,0,0,1</string>
+    </dict>
+  </lib>
 </glyph>

--- a/test-py/test_backends_fontra.py
+++ b/test-py/test_backends_fontra.py
@@ -113,3 +113,26 @@ async def test_features(writableFontraFont):
 
     reopenedFont = getFileSystemBackend(writableFontraFont.path)
     assert await reopenedFont.getFeatures() == OpenTypeFeatures()
+
+
+async def test_statusFieldDefinitions(writableFontraFont):
+    customData = await writableFontraFont.getCustomData()
+    assert {} == customData
+
+    statusTestData = {
+        "fontra.sourceStatusFieldDefinitions": [
+            {
+                "color": [1, 0, 0, 1],
+                "isDefault": True,
+                "label": "In progress",
+                "value": 0,
+            },
+            {"color": [1, 0.5, 0, 1], "label": "Checking-1", "value": 1},
+            {"color": [1, 1, 0, 1], "label": "Checking-2", "value": 2},
+            {"color": [0, 0.5, 1, 1], "label": "Checking-3", "value": 3},
+            {"color": [0, 1, 0.5, 1], "label": "Validated", "value": 4},
+        ]
+    }
+    await writableFontraFont.putCustomData(statusTestData)
+
+    assert statusTestData == await writableFontraFont.getCustomData()


### PR DESCRIPTION
Fixes #1360 

I guess it's now in a stage for a first draft PR. 
As mentioned in todays meeting, there seems to be an issue with the backend or frontend (where I definitely need help with). When there is no "fontra.sourceStatusFieldDefinitions" in the customData it fails adding a it.
I added a unittest 'test_statusFieldDefinitions' which shows, that it's possible to read and write the status definitions. But somehow it fails when I try to do it via the frontend, and sadly I don't know how to fix it.

The terminal says:
```
  File "/Users/ollimeier/Documents/hithub_data/fontra/src/fontra/core/changes.py", line 102, in _applyChange
    subject = subject[pathElement]
              ~~~~~~~^^^^^^^^^^^^^
KeyError: 'fontra.sourceStatusFieldDefinitions'
```

Thanks a lot in advance :)