### PR TITLE
Use unfiltered fontAxes in Add source / Source properties dialog

### DIFF
--- a/src/fontra/views/editor/panel-designspace-navigation.js
+++ b/src/fontra/views/editor/panel-designspace-navigation.js
@@ -993,7 +993,7 @@ export default class DesignspaceNavigationPanel extends Panel {
     const glyphAxisNames = glyph.axes.map((axis) => axis.name);
     const fontAxes = mapAxesFromUserSpaceToSourceSpace(
       // Don't include font axes that also exist as glyph axes
-      this.fontAxes.filter((axis) => !glyphAxisNames.includes(axis.name))
+      this.fontController.fontAxes.filter((axis) => !glyphAxisNames.includes(axis.name))
     );
     return [
       ...fontAxes,


### PR DESCRIPTION
`this.fontAxes` has the hidden axes filtered out, which we still need here.

This fixes #1386.