### PR TITLE
[fontra-copy] Better exceptions when trying to use unknown file types

### DIFF
--- a/src/fontra/backends/__init__.py
+++ b/src/fontra/backends/__init__.py
@@ -8,6 +8,10 @@ from ..core.protocols import ReadableFontBackend, WritableFontBackend
 logger = logging.getLogger(__name__)
 
 
+class UnknownFileType(Exception):
+    pass
+
+
 def getFileSystemBackend(path: PathLike) -> ReadableFontBackend:
     return _getFileSystemBackend(path, False)
 
@@ -27,7 +31,12 @@ def _getFileSystemBackend(path: PathLike, create: bool) -> WritableFontBackend:
     logger.info(f"{logVerb} project {path.name}...")
     fileType = path.suffix.lstrip(".").lower()
     backendEntryPoints = entry_points(group="fontra.filesystem.backends")
-    entryPoint = backendEntryPoints[fileType]
+    try:
+        entryPoint = backendEntryPoints[fileType]
+    except KeyError:
+        raise UnknownFileType(
+            f"Can't find backend for files with extension '.{fileType}'"
+        )
     backendClass = entryPoint.load()
 
     if create:

--- a/src/fontra/backends/copy.py
+++ b/src/fontra/backends/copy.py
@@ -161,7 +161,8 @@ async def mainAsync() -> None:
         glyphNames.extend(args.glyph_names_file.read().split())
 
     sourcePath = pathlib.Path(args.source)
-    assert sourcePath.exists()
+    if not sourcePath.exists():
+        raise FileNotFoundError(sourcePath)
     destPath = pathlib.Path(args.destination)
     if args:
         if destPath.is_dir():

--- a/test-py/test_backends_copy.py
+++ b/test-py/test_backends_copy.py
@@ -4,7 +4,7 @@ import subprocess
 import pytest
 from test_backends_designspace import fileNamesFromDir
 
-from fontra.backends import getFileSystemBackend, newFileSystemBackend
+from fontra.backends import UnknownFileType, getFileSystemBackend, newFileSystemBackend
 from fontra.backends.copy import copyFont
 
 mutatorDSPath = (
@@ -51,3 +51,10 @@ def test_fontra_copy(tmpdir):
         "MutatorCopy_LightWide.ufo",
         "MutatorCopy_Regular.ufo",
     ] == fileNamesFromDir(tmpdir)
+
+
+def test_newFileSystemBackend_unknown_filetype():
+    with pytest.raises(
+        UnknownFileType, match="Can't find backend for files with extension"
+    ):
+        _ = newFileSystemBackend("test.someunknownextension")


### PR DESCRIPTION
As well as a better error when the input font does not exist.