### PR TITLE
[source list] Remove header icon for 'on' (active/inactive) source column

### DIFF
--- a/src/fontra/views/editor/panel-designspace-navigation.js
+++ b/src/fontra/views/editor/panel-designspace-navigation.js
@@ -359,7 +359,7 @@ export default class DesignspaceNavigationPanel extends Panel {
   _setupSourceListColumnDescriptions() {
     const columnDescriptions = [
       {
-        title: makeRegularIconHeader("/tabler-icons/circle-dot.svg"),
+        title: " ",
         key: "active",
         cellFactory: makeIconCellFactory(
           ["/tabler-icons/circle-dotted.svg", "/tabler-icons/circle-dot.svg"],
@@ -1382,20 +1382,6 @@ function makeClickableIconHeader(iconPath, onClick) {
       class: "clickable-icon-header",
       style: "height: 1.2em; width: 1.2em;",
       onclick: onClick,
-    },
-    [
-      html.createDomElement("inline-svg", {
-        src: iconPath,
-      }),
-    ]
-  );
-}
-
-function makeRegularIconHeader(iconPath) {
-  return html.div(
-    {
-      class: "icon",
-      style: "height: 1.2em; width: 1.2em;",
     },
     [
       html.createDomElement("inline-svg", {


### PR DESCRIPTION
Remove header icon for 'on' (active/inactive) source column, I find it distracting.