### PR TITLE
Fix point selection: prefer items that are already selected

### DIFF
--- a/src/fontra/client/core/var-path.js
+++ b/src/fontra/client/core/var-path.js
@@ -2,7 +2,7 @@ import { Bezier } from "../third-party/bezier-js.js";
 import { convexHull } from "./convex-hull.js";
 import { VariationError } from "./errors.js";
 import { centeredRect, pointInRect, rectFromPoints, updateRect } from "./rectangle.js";
-import { arrayExtend, enumerate, range } from "./utils.js";
+import { arrayExtend, enumerate, range, reversed } from "./utils.js";
 import VarArray from "./var-array.js";
 
 export const POINT_TYPE_OFF_CURVE_QUAD = "quad";
@@ -448,12 +448,13 @@ export class VarPackedPath {
 
   pointIndexNearPointFromPointIndices(point, margin, pointIndices) {
     //
-    // Given `point` and a `margin` and an array of `pointIndices`, return
-    // the index of the first point contained in `pointIndices` that is within
-    // `margin` of `point`. Return undefined if no such point was found.
+    // Given `point` and a `margin` and an array of `pointIndices`, return the
+    // index of the first point that is within `margin` of `point`, searching
+    // from the *end* of the `pointIndices` list. Return undefined if no such
+    // point was found.
     //
     const rect = centeredRect(point.x, point.y, margin);
-    for (const pointIndex of pointIndices) {
+    for (const pointIndex of reversed(pointIndices)) {
       const point = this.getPoint(pointIndex);
       if (point && pointInRect(point.x, point.y, rect)) {
         return pointIndex;

--- a/src/fontra/client/core/var-path.js
+++ b/src/fontra/client/core/var-path.js
@@ -446,6 +446,21 @@ export class VarPackedPath {
     }
   }
 
+  pointIndexNearPointFromPointIndices(point, margin, pointIndices) {
+    //
+    // Given `point` and a `margin` and an array of `pointIndices`, return
+    // the index of the first point contained in `pointIndices` that is within
+    // `margin` of `point`. Return undefined if no such point was found.
+    //
+    const rect = centeredRect(point.x, point.y, margin);
+    for (const pointIndex of pointIndices) {
+      const point = this.getPoint(pointIndex);
+      if (point && pointInRect(point.x, point.y, rect)) {
+        return pointIndex;
+      }
+    }
+  }
+
   *iterPoints() {
     yield* this._iterPointsFromTo(0, this.pointTypes.length - 1);
   }

--- a/src/fontra/views/editor/edit-tools-pointer.js
+++ b/src/fontra/views/editor/edit-tools-pointer.js
@@ -24,7 +24,8 @@ export class PointerTool extends BaseTool {
     const { selection, pathHit } = this.sceneModel.selectionAtPoint(
       point,
       size,
-      union(sceneController.selection, sceneController.hoverSelection),
+      sceneController.selection,
+      sceneController.hoverSelection,
       event.altKey
     );
     sceneController.hoverSelection = selection;
@@ -56,7 +57,8 @@ export class PointerTool extends BaseTool {
     const { selection, pathHit } = this.sceneModel.selectionAtPoint(
       point,
       size,
-      union(sceneController.selection, sceneController.hoverSelection),
+      sceneController.selection,
+      sceneController.hoverSelection,
       initialEvent.altKey
     );
     let initialClickedPointIndex;

--- a/src/fontra/views/editor/scene-model.js
+++ b/src/fontra/views/editor/scene-model.js
@@ -550,23 +550,18 @@ export class SceneModel {
       y: point.y - positionedGlyph.y,
     };
 
+    let pointIndex;
     if (parsedCurrentSelection) {
-      const pointIndex = positionedGlyph.glyph.path.pointIndexNearPointFromPointIndices(
+      pointIndex = positionedGlyph.glyph.path.pointIndexNearPointFromPointIndices(
         glyphPoint,
         size,
         parsedCurrentSelection.point || []
       );
-      if (pointIndex !== undefined) {
-        return new Set([`point/${parsedCurrentSelection.point[0]}`]);
-      }
     } else {
-      const pointIndex = positionedGlyph.glyph.path.pointIndexNearPoint(
-        glyphPoint,
-        size
-      );
-      if (pointIndex !== undefined) {
-        return new Set([`point/${pointIndex}`]);
-      }
+      pointIndex = positionedGlyph.glyph.path.pointIndexNearPoint(glyphPoint, size);
+    }
+    if (pointIndex !== undefined) {
+      return new Set([`point/${pointIndex}`]);
     }
 
     return new Set();

--- a/src/fontra/views/editor/scene-model.js
+++ b/src/fontra/views/editor/scene-model.js
@@ -9,7 +9,7 @@ import {
   sectRect,
   unionRect,
 } from "../core/rectangle.js";
-import { difference, isEqualSet, updateSet } from "../core/set-ops.js";
+import { difference, isEqualSet, union, updateSet } from "../core/set-ops.js";
 import { consolidateCalls, enumerate, parseSelection } from "../core/utils.js";
 import * as vector from "../core/vector.js";
 import { loaderSpinner } from "/core/loader-spinner.js";
@@ -452,22 +452,44 @@ export class SceneModel {
     return await this.fontController.getGlyphInstance(glyphName, location, layerName);
   }
 
-  selectionAtPoint(point, size, currentSelection, preferTCenter) {
+  selectionAtPoint(
+    point,
+    size,
+    currentSelection,
+    currentHoverSelection,
+    preferTCenter
+  ) {
     if (!this.selectedGlyph?.isEditing) {
       return { selection: new Set() };
     }
 
-    const pointSelection = this.pointSelectionAtPoint(point, size);
+    const parsedCurrentSelection = currentSelection
+      ? parseSelection(currentSelection)
+      : undefined;
+
+    const pointSelection = this.pointSelectionAtPoint(
+      point,
+      size,
+      parsedCurrentSelection
+    );
     if (pointSelection.size) {
       return { selection: pointSelection };
     }
 
-    const anchorSelection = this.anchorSelectionAtPoint(point, size);
+    const anchorSelection = this.anchorSelectionAtPoint(
+      point,
+      size,
+      parsedCurrentSelection
+    );
     if (anchorSelection.size) {
       return { selection: anchorSelection };
     }
 
-    const guidelineSelection = this.guidelineSelectionAtPoint(point, size);
+    const guidelineSelection = this.guidelineSelectionAtPoint(
+      point,
+      size,
+      parsedCurrentSelection
+    );
     if (guidelineSelection.size) {
       return { selection: guidelineSelection };
     }
@@ -487,13 +509,13 @@ export class SceneModel {
     const componentSelection = this.componentSelectionAtPoint(
       point,
       size,
-      currentSelection,
+      currentSelection ? union(currentSelection, currentHoverSelection) : undefined,
       preferTCenter
     );
     return { selection: componentSelection };
   }
 
-  pointSelectionAtPoint(point, size) {
+  pointSelectionAtPoint(point, size, parsedCurrentSelection) {
     const positionedGlyph = this.getSelectedPositionedGlyph();
     if (!positionedGlyph) {
       return new Set();
@@ -503,6 +525,18 @@ export class SceneModel {
       x: point.x - positionedGlyph.x,
       y: point.y - positionedGlyph.y,
     };
+
+    if (parsedCurrentSelection?.point?.length) {
+      const pointIndex = positionedGlyph.glyph.path.pointIndexNearPointFromPointIndices(
+        glyphPoint,
+        size,
+        parsedCurrentSelection.point
+      );
+      if (pointIndex !== undefined) {
+        return new Set([`point/${parsedCurrentSelection.point[0]}`]);
+      }
+    }
+
     const pointIndex = positionedGlyph.glyph.path.pointIndexNearPoint(glyphPoint, size);
     if (pointIndex !== undefined) {
       return new Set([`point/${pointIndex}`]);

--- a/src/fontra/views/editor/scene-model.js
+++ b/src/fontra/views/editor/scene-model.js
@@ -10,7 +10,13 @@ import {
   unionRect,
 } from "../core/rectangle.js";
 import { difference, isEqualSet, union, updateSet } from "../core/set-ops.js";
-import { consolidateCalls, enumerate, parseSelection, range } from "../core/utils.js";
+import {
+  consolidateCalls,
+  enumerate,
+  parseSelection,
+  range,
+  reversed,
+} from "../core/utils.js";
 import * as vector from "../core/vector.js";
 import { loaderSpinner } from "/core/loader-spinner.js";
 
@@ -667,8 +673,8 @@ export class SceneModel {
     const selRect = centeredRect(x, y, size);
     const indices = parsedCurrentSelection
       ? parsedCurrentSelection.anchor || []
-      : range(anchors.length);
-    for (const i of indices) {
+      : [...range(anchors.length)];
+    for (const i of reversed(indices)) {
       const anchor = anchors[i];
       const anchorMatch = pointInRect(anchor.x, anchor.y, selRect);
       if (anchorMatch) {
@@ -690,8 +696,8 @@ export class SceneModel {
     const selRect = centeredRect(x, y, size);
     const indices = parsedCurrentSelection
       ? parsedCurrentSelection.guideline || []
-      : range(guidelines.length);
-    for (const i of indices) {
+      : [...range(guidelines.length)];
+    for (const i of reversed(indices)) {
       const guideline = guidelines[i];
       if (guideline && pointInRect(guideline.x, guideline.y, selRect)) {
         return new Set([`guideline/${i}`]);


### PR DESCRIPTION
This fixes #572.

This improves selection behavior when multiple items (usually points) are close together.