### PR TITLE
Create a way to communicate the OVERLAP_SIMPLE ttf flag via UFO

### DIFF
--- a/src/fontra/workflow/actions/glyph.py
+++ b/src/fontra/workflow/actions/glyph.py
@@ -300,3 +300,13 @@ def roundCoordinates(
         ]
 
     return replace(glyph, **newFields)
+
+
+@registerFilterAction("amend-glyph-custom-data")
+@dataclass(kw_only=True)
+class AmendGlyphCustomData(BaseFilter):
+    customData: dict[str, Any]
+
+    async def processGlyph(self, glyph: VariableGlyph) -> VariableGlyph:
+        newCustomData = {**glyph.customData, **self.customData}
+        return replace(glyph, customData=newCustomData)

--- a/test-py/data/mutatorsans/MutatorSansLightCondensed.ufo/glyphs/A_acute.glif
+++ b/test-py/data/mutatorsans/MutatorSansLightCondensed.ufo/glyphs/A_acute.glif
@@ -11,6 +11,8 @@
     <dict>
       <key>public.markColor</key>
       <string>0.6567,0.6903,1,1</string>
+      <key>public.truetype.overlap</key>
+      <true/>
     </dict>
   </lib>
 </glyph>

--- a/test-py/data/workflow/output-amend-glyph-custom-data.fontra/font-data.json
+++ b/test-py/data/workflow/output-amend-glyph-custom-data.fontra/font-data.json
@@ -1,0 +1,42 @@
+{
+"axes": {
+"axes": [
+{
+"name": "width",
+"label": "width",
+"tag": "wdth",
+"minValue": 0,
+"defaultValue": 0,
+"maxValue": 1000
+},
+{
+"name": "weight",
+"label": "weight",
+"tag": "wght",
+"minValue": 100,
+"defaultValue": 100,
+"maxValue": 900,
+"mapping": [
+[
+100,
+150
+],
+[
+900,
+850
+]
+]
+},
+{
+"name": "italic",
+"label": "italic",
+"tag": "ital",
+"values": [
+0,
+1
+],
+"defaultValue": 0
+}
+]
+}
+}

--- a/test-py/data/workflow/output-amend-glyph-custom-data.fontra/glyph-info.csv
+++ b/test-py/data/workflow/output-amend-glyph-custom-data.fontra/glyph-info.csv
@@ -1,0 +1,3 @@
+glyph name;code points
+A;U+0041,U+0061
+B;U+0042,U+0062

--- a/test-py/data/workflow/output-amend-glyph-custom-data.fontra/glyphs/A^1.json
+++ b/test-py/data/workflow/output-amend-glyph-custom-data.fontra/glyphs/A^1.json
@@ -1,0 +1,71 @@
+{
+"name": "A",
+"sources": [
+{
+"name": "LightCondensed",
+"layerName": "MutatorSansLightCondensed/foreground",
+"location": {
+"italic": 0,
+"weight": 150,
+"width": 0
+}
+},
+{
+"name": "BoldCondensed",
+"layerName": "MutatorSansBoldCondensed/foreground",
+"location": {
+"italic": 0,
+"weight": 850,
+"width": 0
+}
+},
+{
+"name": "LightWide",
+"layerName": "MutatorSansLightWide/foreground",
+"location": {
+"italic": 0,
+"weight": 150,
+"width": 1000
+}
+},
+{
+"name": "BoldWide",
+"layerName": "MutatorSansBoldWide/foreground",
+"location": {
+"italic": 0,
+"weight": 850,
+"width": 1000
+}
+}
+],
+"layers": {
+"MutatorSansBoldCondensed/foreground": {
+"glyph": {
+"xAdvance": 740
+}
+},
+"MutatorSansBoldWide/foreground": {
+"glyph": {
+"xAdvance": 1290
+}
+},
+"MutatorSansLightCondensed/foreground": {
+"glyph": {
+"xAdvance": 396
+}
+},
+"MutatorSansLightCondensed/support": {
+"glyph": {
+"xAdvance": 930
+}
+},
+"MutatorSansLightWide/foreground": {
+"glyph": {
+"xAdvance": 1190
+}
+}
+},
+"customData": {
+"public.truetype.overlap": true
+}
+}

--- a/test-py/data/workflow/output-amend-glyph-custom-data.fontra/glyphs/B^1.json
+++ b/test-py/data/workflow/output-amend-glyph-custom-data.fontra/glyphs/B^1.json
@@ -1,0 +1,80 @@
+{
+"name": "B",
+"sources": [
+{
+"name": "LightCondensed",
+"layerName": "MutatorSansLightCondensed/foreground",
+"location": {
+"italic": 0,
+"weight": 150,
+"width": 0
+}
+},
+{
+"name": "BoldCondensed",
+"layerName": "MutatorSansBoldCondensed/foreground",
+"location": {
+"italic": 0,
+"weight": 850,
+"width": 0
+}
+},
+{
+"name": "LightWide",
+"layerName": "MutatorSansLightWide/foreground",
+"location": {
+"italic": 0,
+"weight": 150,
+"width": 1000
+}
+},
+{
+"name": "BoldWide",
+"layerName": "MutatorSansBoldWide/foreground",
+"location": {
+"italic": 0,
+"weight": 850,
+"width": 1000
+}
+},
+{
+"name": "support.crossbar",
+"layerName": "MutatorSansLightCondensed/support.crossbar",
+"location": {
+"italic": 0,
+"weight": 595,
+"width": 0
+}
+}
+],
+"layers": {
+"MutatorSansBoldCondensed/foreground": {
+"glyph": {
+"xAdvance": 710
+}
+},
+"MutatorSansBoldWide/foreground": {
+"glyph": {
+"xAdvance": 1270
+}
+},
+"MutatorSansLightCondensed/foreground": {
+"glyph": {
+"xAdvance": 443
+}
+},
+"MutatorSansLightCondensed/support.crossbar": {
+"glyph": {
+"xAdvance": 645
+}
+},
+"MutatorSansLightWide/foreground": {
+"glyph": {
+"xAdvance": 1173
+}
+}
+},
+"customData": {
+"public.truetype.overlap": true
+}
+}

--- a/test-py/test_font.py
+++ b/test-py/test_font.py
@@ -101,6 +101,9 @@ getGlyphTestData = [
                     },
                 },
             },
+            "customData": {
+                "public.truetype.overlap": True,
+            },
         },
     ),
     (
@@ -373,6 +376,9 @@ getGlyphTestData = [
                         "xAdvance": 1290,
                     },
                 },
+            },
+            "customData": {
+                "public.truetype.overlap": True,
             },
         },
     ),

--- a/test-py/test_workflow.py
+++ b/test-py/test_workflow.py
@@ -1040,6 +1040,22 @@ def test_command(tmpdir, configYAMLSources):
             False,
             [],
         ),
+        (
+            "amend-glyph-custom-data",
+            """
+            steps:
+            - input: fontra-read
+              source: "test-py/data/workflow/input1-A.fontra"
+            - filter: drop-shapes
+            - filter: amend-glyph-custom-data
+              customData:
+                "public.truetype.overlap": true
+            - output: fontra-write
+              destination: "output-amend-glyph-custom-data.fontra"
+            """,
+            False,
+            [],
+        ),
     ],
 )
 async def test_workflow_actions(


### PR DESCRIPTION
This fixes #1450, by:
- Specifying a list of ufo glyph lib keys that belong to the default source, and should be kept in Fontra's glyph.customData
- Adding a fontra-workflow action that can add glyph.customData items