### PR TITLE
Optionally set the 'overlap simple' flag for every exported glyph

### DIFF
--- a/src/fontra/backends/designspace.py
+++ b/src/fontra/backends/designspace.py
@@ -127,6 +127,8 @@ class DesignspaceBackend:
         self.fileWatcherCallbacks: list[Callable[[Any], Awaitable[None]]] = []
         self._glyphDependenciesTask: asyncio.Task[GlyphDependencies] | None = None
         self._glyphDependencies: GlyphDependencies | None = None
+        # Set this to true to set "public.truetype.overlap" in each writte .glif's lib:
+        self.setOverlapSimpleFlag = False
         self._initialize(dsDoc)
 
     def _initialize(self, dsDoc: DesignSpaceDocument) -> None:
@@ -495,6 +497,8 @@ class DesignspaceBackend:
                 GLYPH_SOURCE_CUSTOM_DATA_LIB_KEY,
                 sourcesCustomData.get(ufoLayer.fontraLayerName),
             )
+            if self.setOverlapSimpleFlag:
+                layerGlyph.lib["public.truetype.overlap"] = True
 
             drawPointsFunc = populateUFOLayerGlyph(
                 layerGlyph, layer.glyph, hasVariableComponents


### PR DESCRIPTION
Another approach for fix #1450:

Add an optional flag to the DS backend that, when set to true, will set the overlap flag in all exported layer glyphs.