### PR TITLE
Fix #1388: Icon hover animation misbehaves on Safari

### DIFF
--- a/src/fontra/client/web-components/icon-button.js
+++ b/src/fontra/client/web-components/icon-button.js
@@ -14,6 +14,7 @@ export class IconButton extends UnlitElement {
       height: 100%;
       transition: 150ms;
       cursor: pointer;
+      will-change: transform;
     }
 
     button:hover {


### PR DESCRIPTION
After spending hours trying to solve the problem, I asked to chatGPT, and the first option it provided solved the problem.

I attach the solutions it suggested: https://chatgpt.com/share/68cc3cc6-7e15-4e8b-a29c-6fa3baba5c57

Since [Mozilla documentation](https://developer.mozilla.org/en-US/docs/Web/CSS/will-change) of `will-change` recommends not to use `will-change` so often because it may cause too much resource consumption, I tried all the other solutions(animating only inner svg component,`transform-origin`, `backface-visibility`, `transformZ(0)`). However they all failed.

Thus I suggest adding `will-change: transform` to the style of `IconButton`.

This fixes #1388 