### PR TITLE
Adding option selectOnFocus for textInput

### DIFF
--- a/src/fontra/client/core/ui-utils.js
+++ b/src/fontra/client/core/ui-utils.js
@@ -136,9 +136,6 @@ export function textInput(controller, key, options) {
   if (options?.class) {
     inputElement.className = options.class;
   }
-  if (options?.selectOnFocus) {
-    inputElement.onFocus = () => inputElement.select();
-  }
   inputElement.value = formatter.toString(controller.model[key]);
   inputElement[options.continuous ? "oninput" : "onchange"] = () => {
     const { value, error } = formatter.fromString(inputElement.value);

--- a/src/fontra/client/core/ui-utils.js
+++ b/src/fontra/client/core/ui-utils.js
@@ -136,6 +136,9 @@ export function textInput(controller, key, options) {
   if (options?.class) {
     inputElement.className = options.class;
   }
+  if (options?.selectOnFocus) {
+    inputElement.onFocus = () => inputElement.select();
+  }
   inputElement.value = formatter.toString(controller.model[key]);
   inputElement[options.continuous ? "oninput" : "onchange"] = () => {
     const { value, error } = formatter.fromString(inputElement.value);

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -2120,7 +2120,7 @@ export class EditorController {
     dialog.setContent(contentElement);
 
     setTimeout(
-      () => contentElement.querySelector("#anchor-name-text-input")?.focus(),
+      () => contentElement.querySelector("#anchor-name-text-input")?.select(),
       0
     );
 
@@ -2161,7 +2161,6 @@ export class EditorController {
         ...labeledTextInput("Name:", controller, "anchorName", {
           placeholderKey: "suggestedAnchorName",
           id: "anchor-name-text-input",
-          selectOnFocus: true,
         }),
         ...labeledTextInput("x:", controller, "anchorX", {
           placeholderKey: "suggestedAnchorX",

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -2161,6 +2161,7 @@ export class EditorController {
         ...labeledTextInput("Name:", controller, "anchorName", {
           placeholderKey: "suggestedAnchorName",
           id: "anchor-name-text-input",
+          selectOnFocus: true,
         }),
         ...labeledTextInput("x:", controller, "anchorX", {
           placeholderKey: "suggestedAnchorX",

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -2119,10 +2119,11 @@ export class EditorController {
 
     dialog.setContent(contentElement);
 
-    setTimeout(
-      () => contentElement.querySelector("#anchor-name-text-input")?.select(),
-      0
-    );
+    setTimeout(() => {
+      const inputName = contentElement.querySelector("#anchor-name-text-input");
+      inputName.focus();
+      inputName.select();
+    }, 0);
 
     validateInput();
 

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -2120,9 +2120,9 @@ export class EditorController {
     dialog.setContent(contentElement);
 
     setTimeout(() => {
-      const inputName = contentElement.querySelector("#anchor-name-text-input");
-      inputName.focus();
-      inputName.select();
+      const inputNameElement = contentElement.querySelector("#anchor-name-text-input");
+      inputNameElement.focus();
+      inputNameElement.select();
     }, 0);
 
     validateInput();


### PR DESCRIPTION
Fixes #1339

I added a new option called selectOnFocus for textInput. This way we can have control over the textInput if it should be selected on focus or not. 

For reference:

https://github.com/googlefonts/fontra/assets/21055547/d75af2fc-b3bc-4dd6-8361-2193b09e19d2


