### PR TITLE
Use LayoutHandling.CLOSURE for drop-unreachable-glyphs

### DIFF
--- a/src/fontra/workflow/actions/subset.py
+++ b/src/fontra/workflow/actions/subset.py
@@ -114,6 +114,7 @@ def filterGlyphMap(glyphMap, glyphNames):
 @dataclass(kw_only=True)
 class DropUnreachableGlyphs(BaseGlyphSubsetter):
     keepNotdef: bool = True
+    layoutHandling: str = LayoutHandling.CLOSURE
 
     async def _buildSubsettedGlyphSet(
         self, inputGlyphMap: dict[str, list[int]]
@@ -122,7 +123,7 @@ class DropUnreachableGlyphs(BaseGlyphSubsetter):
             glyphName for glyphName, codePoints in inputGlyphMap.items() if codePoints
         }
 
-        if self.keepNotdef:
+        if self.keepNotdef and ".notdef" in inputGlyphMap:
             reachableGlyphs.add(".notdef")
 
         return reachableGlyphs

--- a/test-py/data/workflow/input-drop-unreachable-glyphs.fontra/features.txt
+++ b/test-py/data/workflow/input-drop-unreachable-glyphs.fontra/features.txt
@@ -1,0 +1,3 @@
+feature calt {
+	sub A A' A by A.alt;
+} calt;

--- a/test-py/data/workflow/input-drop-unreachable-glyphs.fontra/glyph-info.csv
+++ b/test-py/data/workflow/input-drop-unreachable-glyphs.fontra/glyph-info.csv
@@ -1,5 +1,6 @@
 glyph name;code points
 A;U+0041,U+0061
+A.alt;
 Adieresis;U+00C4,U+00E4
 dieresis;
 dot;

--- a/test-py/data/workflow/input-drop-unreachable-glyphs.fontra/glyphs/A.alt^1.json
+++ b/test-py/data/workflow/input-drop-unreachable-glyphs.fontra/glyphs/A.alt^1.json
@@ -1,0 +1,420 @@
+{
+"name": "A.alt",
+"sources": [
+{
+"name": "LightCondensed",
+"layerName": "MutatorSansLightCondensed/foreground",
+"location": {
+"italic": 0,
+"weight": 150,
+"width": 0
+}
+},
+{
+"name": "BoldCondensed",
+"layerName": "MutatorSansBoldCondensed/foreground",
+"location": {
+"italic": 0,
+"weight": 850,
+"width": 0
+}
+},
+{
+"name": "LightWide",
+"layerName": "MutatorSansLightWide/foreground",
+"location": {
+"italic": 0,
+"weight": 150,
+"width": 1000
+}
+},
+{
+"name": "BoldWide",
+"layerName": "MutatorSansBoldWide/foreground",
+"location": {
+"italic": 0,
+"weight": 850,
+"width": 1000
+}
+}
+],
+"layers": {
+"MutatorSansBoldCondensed/foreground": {
+"glyph": {
+"path": {
+"contours": [
+{
+"points": [
+{
+"x": -10,
+"y": 0
+},
+{
+"x": 250,
+"y": 0
+},
+{
+"x": 334,
+"y": 800
+},
+{
+"x": 104,
+"y": 800
+}
+],
+"isClosed": true
+},
+{
+"points": [
+{
+"x": 110,
+"y": 120
+},
+{
+"x": 580,
+"y": 120
+},
+{
+"x": 580,
+"y": 330
+},
+{
+"x": 110,
+"y": 330
+}
+],
+"isClosed": true
+},
+{
+"points": [
+{
+"x": 390,
+"y": 0
+},
+{
+"x": 730,
+"y": 0
+},
+{
+"x": 614,
+"y": 800
+},
+{
+"x": 294,
+"y": 800
+}
+],
+"isClosed": true
+},
+{
+"points": [
+{
+"x": 204,
+"y": 540
+},
+{
+"x": 474,
+"y": 540
+},
+{
+"x": 474,
+"y": 800
+},
+{
+"x": 204,
+"y": 800
+}
+],
+"isClosed": true
+}
+]
+},
+"xAdvance": 740
+}
+},
+"MutatorSansBoldWide/foreground": {
+"glyph": {
+"path": {
+"contours": [
+{
+"points": [
+{
+"x": 20,
+"y": 0
+},
+{
+"x": 350,
+"y": 0
+},
+{
+"x": 640,
+"y": 800
+},
+{
+"x": 360,
+"y": 800
+}
+],
+"isClosed": true
+},
+{
+"points": [
+{
+"x": 210,
+"y": 120
+},
+{
+"x": 940,
+"y": 120
+},
+{
+"x": 940,
+"y": 340
+},
+{
+"x": 210,
+"y": 340
+}
+],
+"isClosed": true
+},
+{
+"points": [
+{
+"x": 800,
+"y": 0
+},
+{
+"x": 1270,
+"y": 0
+},
+{
+"x": 930,
+"y": 800
+},
+{
+"x": 480,
+"y": 800
+}
+],
+"isClosed": true
+},
+{
+"points": [
+{
+"x": 410,
+"y": 540
+},
+{
+"x": 830,
+"y": 540
+},
+{
+"x": 830,
+"y": 800
+},
+{
+"x": 410,
+"y": 800
+}
+],
+"isClosed": true
+}
+]
+},
+"xAdvance": 1290
+}
+},
+"MutatorSansLightCondensed/foreground": {
+"glyph": {
+"path": {
+"contours": [
+{
+"points": [
+{
+"x": 20,
+"y": 0
+},
+{
+"x": 60,
+"y": 0
+},
+{
+"x": 200,
+"y": 700
+},
+{
+"x": 165,
+"y": 700
+}
+],
+"isClosed": true
+},
+{
+"points": [
+{
+"x": 75,
+"y": 164
+},
+{
+"x": 325,
+"y": 164
+},
+{
+"x": 325,
+"y": 200
+},
+{
+"x": 75,
+"y": 200
+}
+],
+"isClosed": true
+},
+{
+"points": [
+{
+"x": 332,
+"y": 0
+},
+{
+"x": 376,
+"y": 0
+},
+{
+"x": 231,
+"y": 700
+},
+{
+"x": 192,
+"y": 700
+}
+],
+"isClosed": true
+},
+{
+"points": [
+{
+"x": 175,
+"y": 661
+},
+{
+"x": 222,
+"y": 661
+},
+{
+"x": 222,
+"y": 700
+},
+{
+"x": 175,
+"y": 700
+}
+],
+"isClosed": true
+}
+]
+},
+"xAdvance": 396
+}
+},
+"MutatorSansLightCondensed/support": {
+"glyph": {
+"xAdvance": 930
+}
+},
+"MutatorSansLightWide/foreground": {
+"glyph": {
+"path": {
+"contours": [
+{
+"points": [
+{
+"x": 50,
+"y": 0
+},
+{
+"x": 97,
+"y": 0
+},
+{
+"x": 612,
+"y": 700
+},
+{
+"x": 570,
+"y": 700
+}
+],
+"isClosed": true
+},
+{
+"points": [
+{
+"x": 245,
+"y": 224
+},
+{
+"x": 945,
+"y": 224
+},
+{
+"x": 945,
+"y": 254
+},
+{
+"x": 245,
+"y": 254
+}
+],
+"isClosed": true
+},
+{
+"points": [
+{
+"x": 1087,
+"y": 0
+},
+{
+"x": 1140,
+"y": 0
+},
+{
+"x": 620,
+"y": 700
+},
+{
+"x": 572,
+"y": 700
+}
+],
+"isClosed": true
+},
+{
+"points": [
+{
+"x": 570,
+"y": 664
+},
+{
+"x": 620,
+"y": 664
+},
+{
+"x": 620,
+"y": 700
+},
+{
+"x": 570,
+"y": 700
+}
+],
+"isClosed": true
+}
+]
+},
+"xAdvance": 1190
+}
+}
+}
+}

--- a/test-py/data/workflow/output-drop-unreachable-glyphs-composed.fontra/features.txt
+++ b/test-py/data/workflow/output-drop-unreachable-glyphs-composed.fontra/features.txt
@@ -1,0 +1,3 @@
+feature calt {
+    sub A A' A by A.alt;
+} calt;

--- a/test-py/data/workflow/output-drop-unreachable-glyphs-composed.fontra/glyph-info.csv
+++ b/test-py/data/workflow/output-drop-unreachable-glyphs-composed.fontra/glyph-info.csv
@@ -1,5 +1,6 @@
 glyph name;code points
 A;U+0041,U+0061
+A.alt;
 Adieresis;U+00C4,U+00E4
 dieresis;
 dot;

--- a/test-py/data/workflow/output-drop-unreachable-glyphs-composed.fontra/glyphs/A.alt^1.json
+++ b/test-py/data/workflow/output-drop-unreachable-glyphs-composed.fontra/glyphs/A.alt^1.json
@@ -1,0 +1,420 @@
+{
+"name": "A.alt",
+"sources": [
+{
+"name": "LightCondensed",
+"layerName": "MutatorSansLightCondensed/foreground",
+"location": {
+"italic": 0,
+"weight": 150,
+"width": 0
+}
+},
+{
+"name": "BoldCondensed",
+"layerName": "MutatorSansBoldCondensed/foreground",
+"location": {
+"italic": 0,
+"weight": 850,
+"width": 0
+}
+},
+{
+"name": "LightWide",
+"layerName": "MutatorSansLightWide/foreground",
+"location": {
+"italic": 0,
+"weight": 150,
+"width": 1000
+}
+},
+{
+"name": "BoldWide",
+"layerName": "MutatorSansBoldWide/foreground",
+"location": {
+"italic": 0,
+"weight": 850,
+"width": 1000
+}
+}
+],
+"layers": {
+"MutatorSansBoldCondensed/foreground": {
+"glyph": {
+"path": {
+"contours": [
+{
+"points": [
+{
+"x": -10,
+"y": 0
+},
+{
+"x": 250,
+"y": 0
+},
+{
+"x": 334,
+"y": 800
+},
+{
+"x": 104,
+"y": 800
+}
+],
+"isClosed": true
+},
+{
+"points": [
+{
+"x": 110,
+"y": 120
+},
+{
+"x": 580,
+"y": 120
+},
+{
+"x": 580,
+"y": 330
+},
+{
+"x": 110,
+"y": 330
+}
+],
+"isClosed": true
+},
+{
+"points": [
+{
+"x": 390,
+"y": 0
+},
+{
+"x": 730,
+"y": 0
+},
+{
+"x": 614,
+"y": 800
+},
+{
+"x": 294,
+"y": 800
+}
+],
+"isClosed": true
+},
+{
+"points": [
+{
+"x": 204,
+"y": 540
+},
+{
+"x": 474,
+"y": 540
+},
+{
+"x": 474,
+"y": 800
+},
+{
+"x": 204,
+"y": 800
+}
+],
+"isClosed": true
+}
+]
+},
+"xAdvance": 740
+}
+},
+"MutatorSansBoldWide/foreground": {
+"glyph": {
+"path": {
+"contours": [
+{
+"points": [
+{
+"x": 20,
+"y": 0
+},
+{
+"x": 350,
+"y": 0
+},
+{
+"x": 640,
+"y": 800
+},
+{
+"x": 360,
+"y": 800
+}
+],
+"isClosed": true
+},
+{
+"points": [
+{
+"x": 210,
+"y": 120
+},
+{
+"x": 940,
+"y": 120
+},
+{
+"x": 940,
+"y": 340
+},
+{
+"x": 210,
+"y": 340
+}
+],
+"isClosed": true
+},
+{
+"points": [
+{
+"x": 800,
+"y": 0
+},
+{
+"x": 1270,
+"y": 0
+},
+{
+"x": 930,
+"y": 800
+},
+{
+"x": 480,
+"y": 800
+}
+],
+"isClosed": true
+},
+{
+"points": [
+{
+"x": 410,
+"y": 540
+},
+{
+"x": 830,
+"y": 540
+},
+{
+"x": 830,
+"y": 800
+},
+{
+"x": 410,
+"y": 800
+}
+],
+"isClosed": true
+}
+]
+},
+"xAdvance": 1290
+}
+},
+"MutatorSansLightCondensed/foreground": {
+"glyph": {
+"path": {
+"contours": [
+{
+"points": [
+{
+"x": 20,
+"y": 0
+},
+{
+"x": 60,
+"y": 0
+},
+{
+"x": 200,
+"y": 700
+},
+{
+"x": 165,
+"y": 700
+}
+],
+"isClosed": true
+},
+{
+"points": [
+{
+"x": 75,
+"y": 164
+},
+{
+"x": 325,
+"y": 164
+},
+{
+"x": 325,
+"y": 200
+},
+{
+"x": 75,
+"y": 200
+}
+],
+"isClosed": true
+},
+{
+"points": [
+{
+"x": 332,
+"y": 0
+},
+{
+"x": 376,
+"y": 0
+},
+{
+"x": 231,
+"y": 700
+},
+{
+"x": 192,
+"y": 700
+}
+],
+"isClosed": true
+},
+{
+"points": [
+{
+"x": 175,
+"y": 661
+},
+{
+"x": 222,
+"y": 661
+},
+{
+"x": 222,
+"y": 700
+},
+{
+"x": 175,
+"y": 700
+}
+],
+"isClosed": true
+}
+]
+},
+"xAdvance": 396
+}
+},
+"MutatorSansLightCondensed/support": {
+"glyph": {
+"xAdvance": 930
+}
+},
+"MutatorSansLightWide/foreground": {
+"glyph": {
+"path": {
+"contours": [
+{
+"points": [
+{
+"x": 50,
+"y": 0
+},
+{
+"x": 97,
+"y": 0
+},
+{
+"x": 612,
+"y": 700
+},
+{
+"x": 570,
+"y": 700
+}
+],
+"isClosed": true
+},
+{
+"points": [
+{
+"x": 245,
+"y": 224
+},
+{
+"x": 945,
+"y": 224
+},
+{
+"x": 945,
+"y": 254
+},
+{
+"x": 245,
+"y": 254
+}
+],
+"isClosed": true
+},
+{
+"points": [
+{
+"x": 1087,
+"y": 0
+},
+{
+"x": 1140,
+"y": 0
+},
+{
+"x": 620,
+"y": 700
+},
+{
+"x": 572,
+"y": 700
+}
+],
+"isClosed": true
+},
+{
+"points": [
+{
+"x": 570,
+"y": 664
+},
+{
+"x": 620,
+"y": 664
+},
+{
+"x": 620,
+"y": 700
+},
+{
+"x": 570,
+"y": 700
+}
+],
+"isClosed": true
+}
+]
+},
+"xAdvance": 1190
+}
+}
+}
+}

--- a/test-py/data/workflow/output-drop-unreachable-glyphs-decomposed.fontra/features.txt
+++ b/test-py/data/workflow/output-drop-unreachable-glyphs-decomposed.fontra/features.txt
@@ -1,0 +1,3 @@
+feature calt {
+    sub A A' A by A.alt;
+} calt;

--- a/test-py/data/workflow/output-drop-unreachable-glyphs-decomposed.fontra/glyph-info.csv
+++ b/test-py/data/workflow/output-drop-unreachable-glyphs-decomposed.fontra/glyph-info.csv
@@ -1,3 +1,4 @@
 glyph name;code points
 A;U+0041,U+0061
+A.alt;
 Adieresis;U+00C4,U+00E4

--- a/test-py/data/workflow/output-drop-unreachable-glyphs-decomposed.fontra/glyphs/A.alt^1.json
+++ b/test-py/data/workflow/output-drop-unreachable-glyphs-decomposed.fontra/glyphs/A.alt^1.json
@@ -1,0 +1,420 @@
+{
+"name": "A.alt",
+"sources": [
+{
+"name": "LightCondensed",
+"layerName": "MutatorSansLightCondensed/foreground",
+"location": {
+"italic": 0,
+"weight": 150,
+"width": 0
+}
+},
+{
+"name": "BoldCondensed",
+"layerName": "MutatorSansBoldCondensed/foreground",
+"location": {
+"italic": 0,
+"weight": 850,
+"width": 0
+}
+},
+{
+"name": "LightWide",
+"layerName": "MutatorSansLightWide/foreground",
+"location": {
+"italic": 0,
+"weight": 150,
+"width": 1000
+}
+},
+{
+"name": "BoldWide",
+"layerName": "MutatorSansBoldWide/foreground",
+"location": {
+"italic": 0,
+"weight": 850,
+"width": 1000
+}
+}
+],
+"layers": {
+"MutatorSansBoldCondensed/foreground": {
+"glyph": {
+"path": {
+"contours": [
+{
+"points": [
+{
+"x": -10,
+"y": 0
+},
+{
+"x": 250,
+"y": 0
+},
+{
+"x": 334,
+"y": 800
+},
+{
+"x": 104,
+"y": 800
+}
+],
+"isClosed": true
+},
+{
+"points": [
+{
+"x": 110,
+"y": 120
+},
+{
+"x": 580,
+"y": 120
+},
+{
+"x": 580,
+"y": 330
+},
+{
+"x": 110,
+"y": 330
+}
+],
+"isClosed": true
+},
+{
+"points": [
+{
+"x": 390,
+"y": 0
+},
+{
+"x": 730,
+"y": 0
+},
+{
+"x": 614,
+"y": 800
+},
+{
+"x": 294,
+"y": 800
+}
+],
+"isClosed": true
+},
+{
+"points": [
+{
+"x": 204,
+"y": 540
+},
+{
+"x": 474,
+"y": 540
+},
+{
+"x": 474,
+"y": 800
+},
+{
+"x": 204,
+"y": 800
+}
+],
+"isClosed": true
+}
+]
+},
+"xAdvance": 740
+}
+},
+"MutatorSansBoldWide/foreground": {
+"glyph": {
+"path": {
+"contours": [
+{
+"points": [
+{
+"x": 20,
+"y": 0
+},
+{
+"x": 350,
+"y": 0
+},
+{
+"x": 640,
+"y": 800
+},
+{
+"x": 360,
+"y": 800
+}
+],
+"isClosed": true
+},
+{
+"points": [
+{
+"x": 210,
+"y": 120
+},
+{
+"x": 940,
+"y": 120
+},
+{
+"x": 940,
+"y": 340
+},
+{
+"x": 210,
+"y": 340
+}
+],
+"isClosed": true
+},
+{
+"points": [
+{
+"x": 800,
+"y": 0
+},
+{
+"x": 1270,
+"y": 0
+},
+{
+"x": 930,
+"y": 800
+},
+{
+"x": 480,
+"y": 800
+}
+],
+"isClosed": true
+},
+{
+"points": [
+{
+"x": 410,
+"y": 540
+},
+{
+"x": 830,
+"y": 540
+},
+{
+"x": 830,
+"y": 800
+},
+{
+"x": 410,
+"y": 800
+}
+],
+"isClosed": true
+}
+]
+},
+"xAdvance": 1290
+}
+},
+"MutatorSansLightCondensed/foreground": {
+"glyph": {
+"path": {
+"contours": [
+{
+"points": [
+{
+"x": 20,
+"y": 0
+},
+{
+"x": 60,
+"y": 0
+},
+{
+"x": 200,
+"y": 700
+},
+{
+"x": 165,
+"y": 700
+}
+],
+"isClosed": true
+},
+{
+"points": [
+{
+"x": 75,
+"y": 164
+},
+{
+"x": 325,
+"y": 164
+},
+{
+"x": 325,
+"y": 200
+},
+{
+"x": 75,
+"y": 200
+}
+],
+"isClosed": true
+},
+{
+"points": [
+{
+"x": 332,
+"y": 0
+},
+{
+"x": 376,
+"y": 0
+},
+{
+"x": 231,
+"y": 700
+},
+{
+"x": 192,
+"y": 700
+}
+],
+"isClosed": true
+},
+{
+"points": [
+{
+"x": 175,
+"y": 661
+},
+{
+"x": 222,
+"y": 661
+},
+{
+"x": 222,
+"y": 700
+},
+{
+"x": 175,
+"y": 700
+}
+],
+"isClosed": true
+}
+]
+},
+"xAdvance": 396
+}
+},
+"MutatorSansLightCondensed/support": {
+"glyph": {
+"xAdvance": 930
+}
+},
+"MutatorSansLightWide/foreground": {
+"glyph": {
+"path": {
+"contours": [
+{
+"points": [
+{
+"x": 50,
+"y": 0
+},
+{
+"x": 97,
+"y": 0
+},
+{
+"x": 612,
+"y": 700
+},
+{
+"x": 570,
+"y": 700
+}
+],
+"isClosed": true
+},
+{
+"points": [
+{
+"x": 245,
+"y": 224
+},
+{
+"x": 945,
+"y": 224
+},
+{
+"x": 945,
+"y": 254
+},
+{
+"x": 245,
+"y": 254
+}
+],
+"isClosed": true
+},
+{
+"points": [
+{
+"x": 1087,
+"y": 0
+},
+{
+"x": 1140,
+"y": 0
+},
+{
+"x": 620,
+"y": 700
+},
+{
+"x": 572,
+"y": 700
+}
+],
+"isClosed": true
+},
+{
+"points": [
+{
+"x": 570,
+"y": 664
+},
+{
+"x": 620,
+"y": 664
+},
+{
+"x": 620,
+"y": 700
+},
+{
+"x": 570,
+"y": 700
+}
+],
+"isClosed": true
+}
+]
+},
+"xAdvance": 1190
+}
+}
+}
+}


### PR DESCRIPTION
Use LayoutHandling.CLOSURE for drop-unreachable-glyphs, so we actually keep glyphs only reachable via features

Additionally (unrelated, but prevents a ufomerge warning), only add .notdef if we have it

This fixes #1481.