### PR TITLE
FontMetric -> LineMetric; verticalMetrics -> lineMetricsHorizontalLayout; initial line metrics for vertical layout.

### DIFF
--- a/src/fontra/client/core/classes.json
+++ b/src/fontra/client/core/classes.json
@@ -433,9 +433,13 @@
       "type": "dict",
       "subtype": "float"
     },
-    "verticalMetrics": {
+    "lineMetricsHorizontalLayout": {
       "type": "dict",
-      "subtype": "FontMetric"
+      "subtype": "LineMetric"
+    },
+    "lineMetricsVerticalLayout": {
+      "type": "dict",
+      "subtype": "LineMetric"
     },
     "italicAngle": {
       "type": "float"
@@ -449,7 +453,7 @@
       "subtype": "Any"
     }
   },
-  "FontMetric": {
+  "LineMetric": {
     "value": {
       "type": "float"
     },

--- a/src/fontra/client/core/font-controller.js
+++ b/src/fontra/client/core/font-controller.js
@@ -924,9 +924,18 @@ function ensureDenseSources(sources) {
   return mapObjectValues(sources, (source) => {
     return {
       ...source,
-      verticalMetrics: mapObjectValues(source.verticalMetrics || {}, (metric) => {
-        return { value: metric.value, zone: metric.zone || 0 };
-      }),
+      metricsHorizontalLayout: mapObjectValues(
+        source.metricsHorizontalLayout || {},
+        (metric) => {
+          return { value: metric.value, zone: metric.zone || 0 };
+        }
+      ),
+      metricsVerticalLayout: mapObjectValues(
+        source.metricsVerticalLayout || {},
+        (metric) => {
+          return { value: metric.value, zone: metric.zone || 0 };
+        }
+      ),
     };
   });
 }

--- a/src/fontra/core/classes.py
+++ b/src/fontra/core/classes.py
@@ -85,14 +85,15 @@ class FontSource:
     name: str
     isSparse: bool = False
     location: Location = field(default_factory=dict)
-    verticalMetrics: dict[str, FontMetric] = field(default_factory=dict)
+    lineMetricsHorizontalLayout: dict[str, LineMetric] = field(default_factory=dict)
+    lineMetricsVerticalLayout: dict[str, LineMetric] = field(default_factory=dict)
     italicAngle: float = 0
     guidelines: list[Guideline] = field(default_factory=list)
     customData: CustomData = field(default_factory=dict)
 
 
 @dataclass(kw_only=True)
-class FontMetric:
+class LineMetric:
     value: float
     zone: float = 0
     customData: CustomData = field(default_factory=dict)
@@ -415,11 +416,12 @@ registerHook(
 registerHook(Path)
 registerHook(PackedPath)
 registerHook(AxisValueLabel)
-registerHook(FontMetric, customData=_unstructureDictSortedRecursively)
+registerHook(LineMetric, customData=_unstructureDictSortedRecursively)
 registerHook(
     FontSource,
     location=_unstructureDictSorted,
-    verticalMetrics=_unstructureDictSorted,
+    metricsHorizontalLayout=_unstructureDictSorted,
+    metricsVerticalLayout=_unstructureDictSorted,
     customData=_unstructureDictSortedRecursively,
 )
 registerHook(FontAxis, customData=_unstructureDictSortedRecursively)

--- a/src/fontra/views/editor/visualization-layer-definitions.js
+++ b/src/fontra/views/editor/visualization-layer-definitions.js
@@ -172,8 +172,8 @@ registerVisualizationLayerDefinition({
 });
 
 registerVisualizationLayerDefinition({
-  identifier: "fontra.verticalMetrics",
-  name: "Vertical font metrics",
+  identifier: "fontra.lineMetrics",
+  name: "Line metrics",
   selectionMode: "editing",
   userSwitchable: true,
   defaultOn: true,
@@ -188,25 +188,25 @@ registerVisualizationLayerDefinition({
     if (!model.fontSourceInstance) {
       return;
     }
-    const verticalMetrics = model.fontSourceInstance.verticalMetrics;
+    const lineMetrics = model.fontSourceInstance.lineMetricsHorizontalLayout;
     const glyphWidth = positionedGlyph.glyph.xAdvance
       ? positionedGlyph.glyph.xAdvance
       : 0;
 
     // glyph box
     const pathBox = new Path2D();
-    if (verticalMetrics.ascender && verticalMetrics.descender) {
+    if (lineMetrics.ascender && lineMetrics.descender) {
       pathBox.rect(
         0,
-        verticalMetrics.descender.value,
+        lineMetrics.descender.value,
         positionedGlyph.glyph.xAdvance,
-        verticalMetrics.ascender.value - verticalMetrics.descender.value
+        lineMetrics.ascender.value - lineMetrics.descender.value
       );
     }
 
     // collect paths: vertical metrics and alignment zones
     const pathZones = [];
-    for (const [key, metric] of Object.entries(verticalMetrics)) {
+    for (const [key, metric] of Object.entries(lineMetrics)) {
       if (metric.zone) {
         const pathZone = new Path2D();
         pathZone.rect(0, metric.value, glyphWidth, metric.zone);

--- a/src/fontra/views/fontinfo/panel-sources.js
+++ b/src/fontra/views/fontinfo/panel-sources.js
@@ -195,14 +195,16 @@ export class SourcesPanel extends BaseInfoPanel {
       location: newLocation,
     };
 
-    if (interpolatedSource.verticalMetrics) {
-      newSource.verticalMetrics = getVerticalMetricsRounded(
-        interpolatedSource.verticalMetrics
+    if (interpolatedSource.lineMetricsHorizontalLayout) {
+      newSource.lineMetricsHorizontalLayout = getLineMetricsHorRounded(
+        interpolatedSource.lineMetricsHorizontalLayout
       );
     }
 
     return {
-      verticalMetrics: getDefaultVerticalMetrics(this.fontController.unitsPerEm),
+      lineMetricsHorizontalLayout: getDefaultLineMetricsHor(
+        this.fontController.unitsPerEm
+      ),
       ...interpolatedSource,
       ...newSource,
     };
@@ -294,7 +296,7 @@ fontra-ui-font-info-sources-panel-source-box.min-height,
   height: 45px;
 }
 
-.fontra-ui-font-info-sources-panel-vertical-metrics {
+.fontra-ui-font-info-sources-panel-line-metrics-hor {
   grid-template-columns: minmax(4.5em, max-content) 4em 4em;
 }
 
@@ -346,8 +348,10 @@ class SourceBox extends HTMLElement {
         //isSparse: source.isSparse ? source.isSparse : false,
       },
       location: { ...source.location },
-      verticalMetrics: prepareVerticalMetricsForController(source.verticalMetrics),
-      // TODO: hhea, OS/2 verticalMetrics, etc
+      lineMetricsHorizontalLayout: prepareLineMetricsHorForController(
+        source.lineMetricsHorizontalLayout
+      ),
+      // TODO: hhea, OS/2 line metrics, etc
       // customData: { ...source.customData },
     };
     // NOTE: Font guidelines could be read/write here,
@@ -465,14 +469,14 @@ class SourceBox extends HTMLElement {
       }, `edit source location ${event.key}`);
     });
 
-    this.controllers.verticalMetrics.addListener((event) => {
+    this.controllers.lineMetricsHorizontalLayout.addListener((event) => {
       this.editSource((source) => {
         if (event.key.startsWith("value-")) {
-          source.verticalMetrics[event.key.slice(6)].value = event.newValue;
+          source.lineMetricsHorizontalLayout[event.key.slice(6)].value = event.newValue;
         } else {
-          source.verticalMetrics[event.key.slice(5)].zone = event.newValue;
+          source.lineMetricsHorizontalLayout[event.key.slice(5)].zone = event.newValue;
         }
-      }, `edit source vertical metrics ${event.key}`);
+      }, `edit source line metrics ${event.key}`);
     });
 
     this.innerHTML = "";
@@ -510,7 +514,9 @@ class SourceBox extends HTMLElement {
     this.append(
       buildElementLocations(this.controllers.location, this.fontAxesSourceSpace)
     );
-    this.append(buildElementVerticalMetrics(this.controllers.verticalMetrics));
+    this.append(
+      buildElementLineMetricsHor(this.controllers.lineMetricsHorizontalLayout)
+    );
   }
 }
 
@@ -553,19 +559,19 @@ function buildElement(controller) {
   );
 }
 
-function buildElementVerticalMetrics(controller) {
+function buildElementLineMetricsHor(controller) {
   let items = [];
-  for (const key of Object.keys(verticalMetricsDefaults)) {
+  for (const key of Object.keys(lineMetricsHorizontalLayoutDefaults)) {
     if (`value-${key}` in controller.model) {
       items.push([getLabelFromKey(key), key]);
     }
   }
-  // TODO: Custom vertical metrics
+  // TODO: Custom line metrics
 
   return html.div(
     {
       class:
-        "fontra-ui-font-info-sources-panel-column min-height fontra-ui-font-info-sources-panel-vertical-metrics",
+        "fontra-ui-font-info-sources-panel-column min-height fontra-ui-font-info-sources-panel-line-metrics-hor",
     },
     items
       .map(([labelName, keyName]) => {
@@ -605,7 +611,7 @@ function getInterpolatedSourceData(fontController, newLocation) {
   return JSON.parse(JSON.stringify(fontSourceInstance));
 }
 
-const verticalMetricsDefaults = {
+const lineMetricsHorizontalLayoutDefaults = {
   ascender: { value: 0.8, zone: 0.016 },
   capHeight: { value: 0.75, zone: 0.016 },
   xHeight: { value: 0.5, zone: 0.016 },
@@ -613,34 +619,38 @@ const verticalMetricsDefaults = {
   descender: { value: -0.25, zone: -0.016 },
 };
 
-function getDefaultVerticalMetrics(unitsPerEm) {
-  const defaultVerticalMetrics = {};
-  for (const [name, defaultFactor] of Object.entries(verticalMetricsDefaults)) {
+function getDefaultLineMetricsHor(unitsPerEm) {
+  const lineMetricsHorizontalLayout = {};
+  for (const [name, defaultFactor] of Object.entries(
+    lineMetricsHorizontalLayoutDefaults
+  )) {
     const value = Math.round(defaultFactor.value * unitsPerEm);
     const zone = Math.round(defaultFactor.zone * unitsPerEm);
-    defaultVerticalMetrics[name] = { value: value, zone: zone };
+    lineMetricsHorizontalLayout[name] = { value: value, zone: zone };
   }
-  return defaultVerticalMetrics;
+  return lineMetricsHorizontalLayout;
 }
 
-function prepareVerticalMetricsForController(verticalMetrics) {
-  const newVerticalMetrics = {};
-  for (const key in verticalMetrics) {
-    newVerticalMetrics[`value-${key}`] = verticalMetrics[key].value;
-    newVerticalMetrics[`zone-${key}`] = verticalMetrics[key].zone | 0;
+function prepareLineMetricsHorForController(lineMetricsHorizontalLayout) {
+  const newLineMetricsHorizontalLayout = {};
+  for (const key in lineMetricsHorizontalLayout) {
+    newLineMetricsHorizontalLayout[`value-${key}`] =
+      lineMetricsHorizontalLayout[key].value;
+    newLineMetricsHorizontalLayout[`zone-${key}`] =
+      lineMetricsHorizontalLayout[key].zone | 0;
   }
-  return newVerticalMetrics;
+  return newLineMetricsHorizontalLayout;
 }
 
-function getVerticalMetricsRounded(verticalMetrics) {
-  const newVerticalMetrics = {};
-  for (const key in verticalMetrics) {
-    newVerticalMetrics[key] = {
-      value: round(verticalMetrics[key].value, 2),
-      zone: round(verticalMetrics[key].zone, 2) | 0,
+function getLineMetricsHorRounded(lineMetricsHorizontalLayout) {
+  const newLineMetricsHorizontalLayout = {};
+  for (const key in lineMetricsHorizontalLayout) {
+    newLineMetricsHorizontalLayout[key] = {
+      value: round(lineMetricsHorizontalLayout[key].value, 2),
+      zone: round(lineMetricsHorizontalLayout[key].zone, 2) | 0,
     };
   }
-  return newVerticalMetrics;
+  return newLineMetricsHorizontalLayout;
 }
 
 function getLabelFromKey(key) {
@@ -656,7 +666,7 @@ function getLabelFromKey(key) {
     descender: "Descender",
     general: "General",
     location: "Location",
-    verticalMetrics: "Vertical metrics",
+    lineMetricsHorizontalLayout: "Line metrics",
   };
   return keyLabelMap[key] || key;
 }

--- a/test-py/test_backends_designspace.py
+++ b/test-py/test_backends_designspace.py
@@ -510,7 +510,7 @@ getSourcesTestData = [
     {
         "location": {"italic": 0.0, "weight": 150.0, "width": 0.0},
         "name": "LightCondensed",
-        "verticalMetrics": {
+        "lineMetricsHorizontalLayout": {
             "ascender": {"value": 700, "zone": 16},
             "capHeight": {"value": 700, "zone": 16},
             "descender": {"value": -200, "zone": -16},
@@ -526,7 +526,7 @@ getSourcesTestData = [
     {
         "location": {"italic": 0.0, "weight": 850.0, "width": 0.0},
         "name": "BoldCondensed",
-        "verticalMetrics": {
+        "lineMetricsHorizontalLayout": {
             "ascender": {"value": 800, "zone": 16},
             "capHeight": {"value": 800, "zone": 16},
             "descender": {"value": -200, "zone": -16},
@@ -537,7 +537,7 @@ getSourcesTestData = [
     {
         "location": {"italic": 0.0, "weight": 150.0, "width": 1000.0},
         "name": "LightWide",
-        "verticalMetrics": {
+        "lineMetricsHorizontalLayout": {
             "ascender": {"value": 700, "zone": 16},
             "capHeight": {"value": 700, "zone": 16},
             "descender": {"value": -200, "zone": -16},
@@ -548,7 +548,7 @@ getSourcesTestData = [
     {
         "location": {"italic": 0.0, "weight": 850.0, "width": 1000.0},
         "name": "BoldWide",
-        "verticalMetrics": {
+        "lineMetricsHorizontalLayout": {
             "ascender": {"value": 800, "zone": 16},
             "capHeight": {"value": 800, "zone": 16},
             "descender": {"value": -200, "zone": -16},
@@ -574,7 +574,7 @@ getSourcesTestData = [
     {
         "location": {"italic": 1.0, "weight": 150.0, "width": 0.0},
         "name": "LightCondensedItalic",
-        "verticalMetrics": {
+        "lineMetricsHorizontalLayout": {
             "ascender": {"value": 750, "zone": 16},
             "capHeight": {"value": 750, "zone": 16},
             "descender": {"value": -250, "zone": -16},
@@ -596,10 +596,10 @@ async def test_putSources(writableTestFont):
     sources = deepcopy(await writableTestFont.getSources())
     testSource = sources["light-condensed"]
 
-    assert testSource.verticalMetrics["ascender"].value == 700
-    assert testSource.verticalMetrics["ascender"].zone == 16
-    testSource.verticalMetrics["ascender"].value = 800
-    testSource.verticalMetrics["ascender"].zone = 10
+    assert testSource.lineMetricsHorizontalLayout["ascender"].value == 700
+    assert testSource.lineMetricsHorizontalLayout["ascender"].zone == 16
+    testSource.lineMetricsHorizontalLayout["ascender"].value = 800
+    testSource.lineMetricsHorizontalLayout["ascender"].zone = 10
     assert testSource.guidelines[0].y == 700
     testSource.guidelines[0].y = 750
 
@@ -608,8 +608,8 @@ async def test_putSources(writableTestFont):
     reopenedBackend = getFileSystemBackend(writableTestFont.dsDoc.path)
     reopenedSources = await reopenedBackend.getSources()
     testSource = reopenedSources["light-condensed"]
-    assert testSource.verticalMetrics["ascender"].value == 800
-    assert testSource.verticalMetrics["ascender"].zone == 10
+    assert testSource.lineMetricsHorizontalLayout["ascender"].value == 800
+    assert testSource.lineMetricsHorizontalLayout["ascender"].zone == 10
     assert testSource.guidelines[0].y == 750
     assert sources == reopenedSources
 


### PR DESCRIPTION
The term "vertical metrics" is problematic once you start talking about vertical writing/layout. The OpenType spec uses the term "line metrics" here and there (OS/2 for example).

Since we need to add support for ascender/descender etc for vertical layout, let's improve the terminology.