### PR TITLE
Refactor component controller

### DIFF
--- a/src/fontra/client/core/font-controller.js
+++ b/src/fontra/client/core/font-controller.js
@@ -11,6 +11,7 @@ import { CrossAxisMapping } from "./cross-axis-mapping.js";
 import { FontSourcesInstancer } from "./font-sources-instancer.js";
 import { StaticGlyphController, VariableGlyphController } from "./glyph-controller.js";
 import { LRUCache } from "./lru-cache.js";
+import { setPopFirst } from "./set-ops.js";
 import { TaskPool } from "./task-pool.js";
 import {
   chain,
@@ -879,18 +880,6 @@ function collectGlyphNames(change) {
   return collectChangePaths(change, 2)
     .filter((item) => item[0] === "glyphs" && item[1] !== undefined)
     .map((item) => item[1]);
-}
-
-function setPopFirst(set) {
-  if (!set.size) {
-    return;
-  }
-  let firstItem;
-  for (firstItem of set) {
-    break;
-  }
-  set.delete(firstItem);
-  return firstItem;
 }
 
 function objectPropertyTracker(obj) {

--- a/src/fontra/client/core/glyph-controller.js
+++ b/src/fontra/client/core/glyph-controller.js
@@ -1145,6 +1145,7 @@ async function getGlyphAndDependenciesShallow(glyphName, getGlyphFunc) {
 async function getGlyphAndDependenciesDeep(glyphName, getGlyphFunc) {
   const glyphs = {};
   const todo = new Set([glyphName]);
+
   while (todo.size) {
     const glyphName = setPopFirst(todo);
     const glyph = await getGlyphFunc(glyphName);

--- a/src/fontra/client/core/glyph-controller.js
+++ b/src/fontra/client/core/glyph-controller.js
@@ -15,6 +15,7 @@ import {
   getRepresentation,
   registerRepresentationFactory,
 } from "./representation-cache.js";
+import { setPopFirst } from "./set-ops.js";
 import {
   Transform,
   decomposedToTransform,
@@ -230,13 +231,13 @@ export class VariableGlyphController {
     );
   }
 
-  async getDeltas(getGlyphFunc) {
+  getDeltas(glyphDependencies) {
     if (this._deltas === undefined) {
-      const masterValues = await ensureGlyphCompatibility(
+      const masterValues = ensureGlyphCompatibility(
         this.sources
           .filter((source) => !source.inactive)
           .map((source) => this.layers[source.layerName].glyph),
-        getGlyphFunc
+        glyphDependencies
       );
 
       this._deltas = this.model.getDeltas(masterValues);
@@ -377,9 +378,18 @@ export class VariableGlyphController {
   }
 
   async instantiate(sourceLocation, getGlyphFunc) {
+    const glyphDependencies = await getGlyphAndDependencies(
+      this.name,
+      getGlyphFunc,
+      false
+    );
+    return this.instantiateSync(sourceLocation, glyphDependencies);
+  }
+
+  instantiateSync(sourceLocation, glyphDependencies) {
     let { instance, errors } = this.model.interpolateFromDeltas(
       sourceLocation,
-      await this.getDeltas(getGlyphFunc)
+      this.getDeltas(glyphDependencies)
     );
     if (errors) {
       errors = errors.map((error) => {
@@ -488,15 +498,20 @@ export class StaticGlyphController {
     this.components = [];
     const componentErrors = [];
     for (const compo of this.instance.components) {
-      const compoController = new ComponentController(compo);
-      const errors = await compoController.setupPath(
+      const glyphDependencies = await getGlyphAndDependencies(
+        compo.name,
         getGlyphFunc,
-        parentLocation,
-        [this.name],
-        fontAxisNames
+        true
       );
-      if (errors) {
-        componentErrors.push(...errors);
+      const compoController = new ComponentController(
+        compo,
+        parentLocation,
+        glyphDependencies,
+        fontAxisNames,
+        [this.name]
+      );
+      if (compoController.errors) {
+        componentErrors.push(...compoController.errors);
       }
       this.components.push(compoController);
     }
@@ -700,20 +715,23 @@ registerRepresentationFactory(
 );
 
 class ComponentController {
-  constructor(compo) {
+  constructor(
+    compo,
+    parentLocation,
+    glyphDependencies,
+    fontAxisNames,
+    parentGlyphNames
+  ) {
     this.compo = compo;
-  }
-
-  async setupPath(getGlyphFunc, parentLocation, parentGlyphNames, fontAxisNames) {
-    const { path, errors } = await flattenComponent(
-      this.compo,
-      getGlyphFunc,
+    const { path, errors } = flattenComponent(
+      compo,
+      glyphDependencies,
       parentLocation,
       parentGlyphNames,
       fontAxisNames
     );
     this.path = path;
-    return errors;
+    this.errors = errors;
   }
 
   get path2d() {
@@ -774,18 +792,18 @@ class ComponentController {
   }
 }
 
-async function flattenComponent(
+function flattenComponent(
   compo,
-  getGlyphFunc,
+  glyphDependencies,
   parentLocation,
   parentGlyphNames,
   fontAxisNames
 ) {
   let componentErrors = [];
   const paths = [];
-  for await (const { path, errors } of iterFlattenedComponentPaths(
+  for (const { path, errors } of iterFlattenedComponentPaths(
     compo,
-    getGlyphFunc,
+    glyphDependencies,
     parentLocation,
     parentGlyphNames,
     fontAxisNames
@@ -801,9 +819,9 @@ async function flattenComponent(
   return { path: joinPaths(paths), errors: componentErrors };
 }
 
-async function* iterFlattenedComponentPaths(
+function* iterFlattenedComponentPaths(
   compo,
-  getGlyphFunc,
+  glyphDependencies,
   parentLocation,
   parentGlyphNames,
   fontAxisNames,
@@ -820,13 +838,16 @@ async function* iterFlattenedComponentPaths(
   parentGlyphNames = [...parentGlyphNames, compo.name];
 
   const compoLocation = mergeLocations(parentLocation, compo.location);
-  const glyph = await getGlyphFunc(compo.name);
+  const glyph = glyphDependencies[compo.name];
   let inst, instErrors;
   if (!glyph) {
     // console.log(`component glyph ${compo.name} was not found`);
     inst = makeMissingComponentPlaceholderGlyph();
   } else {
-    const { instance, errors } = await glyph.instantiate(compoLocation, getGlyphFunc);
+    const { instance, errors } = glyph.instantiateSync(
+      compoLocation,
+      glyphDependencies
+    );
     inst = instance;
     instErrors = errors?.map((error) => {
       return { ...error, glyphs: parentGlyphNames };
@@ -846,7 +867,7 @@ async function* iterFlattenedComponentPaths(
   for (const subCompo of inst.components) {
     yield* iterFlattenedComponentPaths(
       subCompo,
-      getGlyphFunc,
+      glyphDependencies,
       filterLocation(compoLocation, fontAxisNames),
       parentGlyphNames,
       fontAxisNames,
@@ -1015,10 +1036,10 @@ function makeDefaultLocation(axes) {
   return Object.fromEntries(axes.map((axis) => [axis.name, axis.defaultValue]));
 }
 
-async function ensureGlyphCompatibility(glyphs, getGlyphFunc) {
+function ensureGlyphCompatibility(layerGlyphs, glyphDependencies) {
   const baseGlyphFallbackValues = {};
 
-  glyphs.forEach((glyph) =>
+  layerGlyphs.forEach((glyph) =>
     glyph.components.forEach((compo) => {
       let fallbackValues = baseGlyphFallbackValues[compo.name];
       if (!fallbackValues) {
@@ -1032,7 +1053,7 @@ async function ensureGlyphCompatibility(glyphs, getGlyphFunc) {
   );
 
   for (const [glyphName, fallbackValues] of Object.entries(baseGlyphFallbackValues)) {
-    const baseGlyph = await getGlyphFunc(glyphName);
+    const baseGlyph = glyphDependencies[glyphName];
     for (const axis of baseGlyph?.combinedAxes || []) {
       if (axis.name in fallbackValues) {
         fallbackValues[axis.name] = axis.defaultValue;
@@ -1040,9 +1061,9 @@ async function ensureGlyphCompatibility(glyphs, getGlyphFunc) {
     }
   }
 
-  const guidelinesAreCompatible = areGuidelinesCompatible(glyphs);
+  const guidelinesAreCompatible = areGuidelinesCompatible(layerGlyphs);
 
-  return glyphs.map((glyph) =>
+  return layerGlyphs.map((glyph) =>
     StaticGlyph.fromObject(
       {
         ...glyph,
@@ -1108,4 +1129,24 @@ function checkInterpolationCompatibility(
     }
   }
   return errors;
+}
+
+async function getGlyphAndDependencies(glyphName, getGlyphFunc, recurse) {
+  const glyphs = {};
+  const todo = new Set([glyphName]);
+  while (todo.size) {
+    const glyphName = setPopFirst(todo);
+    const glyph = await getGlyphFunc(glyphName);
+    glyphs[glyphName] = glyph;
+    for (const compoName of glyph.getAllComponentNames()) {
+      if (!(compoName in glyphs)) {
+        if (recurse) {
+          todo.add(compoName);
+        } else {
+          glyphs[glyphName] = await getGlyphFunc(glyphName);
+        }
+      }
+    }
+  }
+  return glyphs;
 }

--- a/src/fontra/client/core/set-ops.js
+++ b/src/fontra/client/core/set-ops.js
@@ -80,3 +80,15 @@ export function updateSet(set, iterable) {
 export function filterSet(set, func) {
   return new Set([...set].filter(func));
 }
+
+export function setPopFirst(set) {
+  if (!set.size) {
+    return;
+  }
+  let firstItem;
+  for (firstItem of set) {
+    break;
+  }
+  set.delete(firstItem);
+  return firstItem;
+}


### PR DESCRIPTION
Make the ComponentController to be async-free, as we'll need it to do bounds computations as part of the upcoming bounds resize addition for variable components. Inside an interactive edit loop we can't use async/await.