### PR TITLE
Don't crash in selection code and getSelectionBounds() when anchors aren't compatible

### DIFF
--- a/src/fontra/client/core/glyph-controller.js
+++ b/src/fontra/client/core/glyph-controller.js
@@ -631,7 +631,9 @@ export class StaticGlyphController {
 
     for (const anchorIndex of anchorIndices) {
       const anchor = this.instance.anchors[anchorIndex];
-      selectionRects.push(centeredRect(anchor.x, anchor.y, 0));
+      if (anchor) {
+        selectionRects.push(centeredRect(anchor.x, anchor.y, 0));
+      }
     }
 
     return unionRect(...selectionRects);

--- a/src/fontra/views/editor/scene-model.js
+++ b/src/fontra/views/editor/scene-model.js
@@ -672,8 +672,7 @@ export class SceneModel {
       : [...range(anchors.length)];
     for (const i of reversed(indices)) {
       const anchor = anchors[i];
-      const anchorMatch = pointInRect(anchor.x, anchor.y, selRect);
-      if (anchorMatch) {
+      if (anchor && pointInRect(anchor.x, anchor.y, selRect)) {
         return new Set([`anchor/${i}`]);
       }
     }


### PR DESCRIPTION
This fixes #1509