### PR TITLE
Bugfix: Bounds Resize on component vs. info panel glitch

### DIFF
--- a/src/fontra/views/editor/edit-tools-pointer.js
+++ b/src/fontra/views/editor/edit-tools-pointer.js
@@ -95,6 +95,15 @@ export class PointerTool extends BaseTool {
 
   async handleDrag(eventStream, initialEvent) {
     const sceneController = this.sceneController;
+    const initialSelection = sceneController.selection;
+    const resizeHandle = this.getResizeHandle(initialEvent, initialSelection);
+    if (resizeHandle) {
+      sceneController.sceneModel.clickedResizeHandle = resizeHandle;
+      await this.handleBoundsResize(initialSelection, eventStream, initialEvent);
+      delete sceneController.sceneModel.clickedResizeHandle;
+      return;
+    }
+
     const point = sceneController.localPoint(initialEvent);
     const size = sceneController.mouseClickMargin;
     const { selection, pathHit } = this.sceneModel.selectionAtPoint(
@@ -124,7 +133,6 @@ export class PointerTool extends BaseTool {
       return;
     }
 
-    const initialSelection = sceneController.selection;
     let initiateDrag = false;
     let initiateRectSelect = false;
 
@@ -167,21 +175,14 @@ export class PointerTool extends BaseTool {
     }
 
     sceneController.hoveredGlyph = undefined;
-    const resizeHandle = this.getResizeHandle(initialEvent, initialSelection);
-
-    if (initiateRectSelect && !resizeHandle) {
+    if (initiateRectSelect) {
       return await this.handleRectSelect(eventStream, initialEvent, initialSelection);
-    } else if (initiateDrag && !resizeHandle) {
+    } else if (initiateDrag) {
       this.sceneController.sceneModel.initialClickedPointIndex =
         initialClickedPointIndex;
       const result = await this.handleDragSelection(eventStream, initialEvent);
       delete this.sceneController.sceneModel.initialClickedPointIndex;
       return result;
-    } else if (resizeHandle) {
-      sceneController.selection = initialSelection;
-      this.sceneController.sceneModel.clickedResizeHandle = resizeHandle;
-      await this.handleBoundsResize(initialSelection, eventStream, initialEvent);
-      delete this.sceneController.sceneModel.clickedResizeHandle;
     }
   }
 


### PR DESCRIPTION
Fixes #1512 

I moved the whole code for 'bounds resize' up to the top of `handleDrag`. If `resizeHandle` exists, there is no need to go through the rest of the code. This fixes the glitch with the component vs. info panel. 
Plus: It is more close to what it was before we added the 'resize bounds'-feature.