### PR TITLE
Fix multiple kerning read in .fontra format

### DIFF
--- a/src/fontra/backends/fontra.py
+++ b/src/fontra/backends/fontra.py
@@ -313,19 +313,26 @@ def readKerningFile(path: pathlib.Path) -> dict[str, Kerning]:
         reader = csv.reader(file, delimiter=";")
         rowIter = iter(enumerate(reader, 1))
 
-        kernType = kerningReadType(rowIter)
-        groups = kerningReadGroups(rowIter)
-        sourceIdentifiers, values = kerningReadValues(rowIter)
+        while True:
+            kernType = kerningReadType(rowIter)
+            if kernType is None:
+                break
 
-        kerning[kernType] = Kerning(
-            groups=groups, sourceIdentifiers=sourceIdentifiers, values=values
-        )
+            groups = kerningReadGroups(rowIter)
+            sourceIdentifiers, values = kerningReadValues(rowIter)
+
+            kerning[kernType] = Kerning(
+                groups=groups, sourceIdentifiers=sourceIdentifiers, values=values
+            )
 
     return kerning
 
 
 def kerningReadType(rowIter):
     lineNumber, row = nextNonBlankRow(rowIter)
+    if lineNumber is None:
+        return None
+
     if not row or row[0] != "TYPE":
         raise KerningParseError(f"expected TYPE keyword (line {lineNumber})")
 


### PR DESCRIPTION
The .fontra kerning.csv reader would only read the first kern table, and skip any addition ones (say, vkrn). This PR fixes that. Testing will have to follow later, as changes it that area likely conflict with the ongoing work in https://github.com/googlefonts/fontra/pull/1518.