### PR TITLE
Fix: getResizeHandle error on incompatible source

### DIFF
--- a/src/fontra/client/core/glyph-controller.js
+++ b/src/fontra/client/core/glyph-controller.js
@@ -615,9 +615,12 @@ export class StaticGlyphController {
 
     const selectionRects = [];
     if (pointIndices.length) {
-      const path = filterPathByPointIndices(this.instance.path, pointIndices);
-      if (path.getBounds()) {
-        selectionRects.push(path.getBounds());
+      const pathBounds = filterPathByPointIndices(
+        this.instance.path,
+        pointIndices
+      ).getBounds();
+      if (pathBounds) {
+        selectionRects.push(pathBounds);
       }
     }
 

--- a/src/fontra/client/core/glyph-controller.js
+++ b/src/fontra/client/core/glyph-controller.js
@@ -616,7 +616,7 @@ export class StaticGlyphController {
     const selectionRects = [];
     if (pointIndices.length) {
       const path = filterPathByPointIndices(this.instance.path, pointIndices);
-      if (path) {
+      if (path.getBounds()) {
         selectionRects.push(path.getBounds());
       }
     }

--- a/src/fontra/client/core/path-functions.js
+++ b/src/fontra/client/core/path-functions.js
@@ -626,11 +626,14 @@ export function scalePoint(pinPoint, point, factor) {
 export function getSelectionByContour(path, pointIndices) {
   const selectionByContour = new Map();
   for (const pointIndex of pointIndices) {
-    const [contourIndex, contourPointIndex] = path.getContourAndPointIndex(pointIndex);
-    if (!selectionByContour.has(contourIndex)) {
-      selectionByContour.set(contourIndex, []);
+    if (pointIndex !== undefined && pointIndex < path.numPoints) {
+      const [contourIndex, contourPointIndex] =
+        path.getContourAndPointIndex(pointIndex);
+      if (!selectionByContour.has(contourIndex)) {
+        selectionByContour.set(contourIndex, []);
+      }
+      selectionByContour.get(contourIndex).push(contourPointIndex);
     }
-    selectionByContour.get(contourIndex).push(contourPointIndex);
   }
   return selectionByContour;
 }

--- a/src/fontra/client/core/path-functions.js
+++ b/src/fontra/client/core/path-functions.js
@@ -626,14 +626,15 @@ export function scalePoint(pinPoint, point, factor) {
 export function getSelectionByContour(path, pointIndices) {
   const selectionByContour = new Map();
   for (const pointIndex of pointIndices) {
-    if (pointIndex !== undefined && pointIndex < path.numPoints) {
-      const [contourIndex, contourPointIndex] =
-        path.getContourAndPointIndex(pointIndex);
-      if (!selectionByContour.has(contourIndex)) {
-        selectionByContour.set(contourIndex, []);
-      }
-      selectionByContour.get(contourIndex).push(contourPointIndex);
+    if (pointIndex >= path.numPoints) {
+      // Ignore out-of-bounds indices
+      continue;
     }
+    const [contourIndex, contourPointIndex] = path.getContourAndPointIndex(pointIndex);
+    if (!selectionByContour.has(contourIndex)) {
+      selectionByContour.set(contourIndex, []);
+    }
+    selectionByContour.get(contourIndex).push(contourPointIndex);
   }
   return selectionByContour;
 }

--- a/src/fontra/views/editor/edit-tools-pointer.js
+++ b/src/fontra/views/editor/edit-tools-pointer.js
@@ -666,15 +666,7 @@ function getResizeHandles(resizeBounds, margin) {
 }
 
 function getResizeBounds(glyph, selection) {
-  let selectionBounds;
-  try {
-    selectionBounds = glyph.getSelectionBounds(selection);
-  } catch (e) {
-    // getSelectionBounds may fail, when selection is invalid, for example:
-    // when switching between layers with different amount of components/points
-    return undefined;
-  }
-
+  const selectionBounds = glyph.getSelectionBounds(selection);
   if (!selectionBounds) {
     return undefined;
   }

--- a/src/fontra/views/editor/edit-tools-pointer.js
+++ b/src/fontra/views/editor/edit-tools-pointer.js
@@ -666,7 +666,15 @@ function getResizeHandles(resizeBounds, margin) {
 }
 
 function getResizeBounds(glyph, selection) {
-  const selectionBounds = glyph.getSelectionBounds(selection);
+  let selectionBounds;
+  try {
+    selectionBounds = glyph.getSelectionBounds(selection);
+  } catch (e) {
+    // getSelectionBounds may fail, when selection is invalid, for example:
+    // when switching between layers with different amount of components/points
+    return undefined;
+  }
+
   if (!selectionBounds) {
     return undefined;
   }

--- a/test-js/test-glyph-controller.js
+++ b/test-js/test-glyph-controller.js
@@ -243,6 +243,7 @@ describe("StaticGlyphController getSelectionBounds", () => {
         { xMin: 0, yMin: 0, xMax: 110, yMax: 200 },
       ],
       [["point/0", "point/1", "anchor/0"], { xMin: 60, yMin: 0, xMax: 110, yMax: 100 }],
+      [["point/18"], undefined], // out of bounds
     ],
     (testData) => {
       const [selection, result] = testData;


### PR DESCRIPTION
Fixes #1524 

The issues lives more deep into 
`getSelectionBounds` -> 
`filterPathByPointIndices` -> 
`getSelectionByContour` -> 
`getContourAndPointIndex`, 
when the selection does not match with the actual path/components. 
I first thought it would be good to fix it somewhere in getSelectionBounds, but probably this would change the behaviour too much???

Why I added a try/catch to getResizeBounds. 
I am happy to do it differently if you have an idea how to fix it in more proper way.
