### PR TITLE
Fix #1523: Change context menu positioning strategy to avoid edge case

### DIFF
--- a/src/fontra/client/web-components/menu-panel.js
+++ b/src/fontra/client/web-components/menu-panel.js
@@ -208,7 +208,7 @@ export class MenuPanel extends SimpleElement {
       const containerRect = this.positionContainer.getBoundingClientRect();
       const thisRect = this.getBoundingClientRect();
       if (thisRect.right > containerRect.right) {
-        position.x -= thisRect.right - containerRect.right + 2;
+        position.x -= thisRect.width + 2;
       }
       if (thisRect.bottom > containerRect.bottom) {
         position.y -= thisRect.bottom - containerRect.bottom + 2;


### PR DESCRIPTION
If you see the code below, before, if the calculated bounding rect of the context menu exceeded the bounding rect of the canvas, the strategy was to modify x only by the "exceeding amount":

```Javascript
if (thisRect.right > containerRect.right) {
        position.x -= thisRect.right - containerRect.right + 2;
        // ...
}
```
More clearyly, when you view the positioning of the context menu, "the right margin" was fixed: if you click the menu close enough from the right border of the canvas, the context menu is always positioned 2 px apart from the right border of the canvas.

So is the case with the bottom positioning too.

That means if you click more than 2px apart, but still close enough from the right border, it can end up making your pointer located inside the context menu.

Therefore I made the context menu appear on the "left side" of a pointer by adjusting its position by its width. And since the "original right side" position was 1px to the right and 1px to the bottom, I adjusted 2 more pixels to make it 1px to the left of the pointer.

This fixes #1523 