### PR TITLE
Mismatching guidelines should not be interpolation stoppers

### DIFF
--- a/src/fontra/core/instancer.py
+++ b/src/fontra/core/instancer.py
@@ -359,9 +359,13 @@ class GlyphInstancer:
 
     @cached_property
     def deltas(self) -> DiscreteDeltas:
-        sourceValues = [
-            MathWrapper(layerGlyph) for layerGlyph in self.activeLayerGlyphs
-        ]
+        layerGlyphs = self.activeLayerGlyphs
+        if not areGuidelinesCompatible(layerGlyphs):
+            layerGlyphs = [
+                replace(layerGlyph, guidelines=[]) for layerGlyph in layerGlyphs
+            ]
+
+        sourceValues = [MathWrapper(layerGlyph) for layerGlyph in layerGlyphs]
         return self.model.getDeltas(sourceValues)
 
     def checkCompatibility(self):


### PR DESCRIPTION
This fixes #1520.