### PR TITLE
Move task starting to startTask method; consistently call startTasks() in tests

### DIFF
--- a/src/fontra/core/fonthandler.py
+++ b/src/fontra/core/fonthandler.py
@@ -50,14 +50,15 @@ class FontHandler:
         self.localData = LRUCache()
         self._dataScheduledForWriting = {}
         self.glyphMap = {}
-        if hasattr(self.backend, "startOptionalBackgroundTasks"):
-            self.backend.startOptionalBackgroundTasks()
 
     @cached_property
     def writableBackend(self) -> WritableFontBackend | None:
         return self.backend if isinstance(self.backend, WritableFontBackend) else None
 
     async def startTasks(self) -> None:
+        if hasattr(self.backend, "startOptionalBackgroundTasks"):
+            self.backend.startOptionalBackgroundTasks()
+
         if isinstance(self.backend, WatchableFontBackend):
             await self.backend.watchExternalChanges(self.processExternalChanges)
 

--- a/test-py/test_fonthandler.py
+++ b/test-py/test_fonthandler.py
@@ -46,7 +46,7 @@ async def testFontHandler(testFontPath):
 @pytest.mark.asyncio
 async def test_fontHandler_basic(testFontHandler):
     async with aclosing(testFontHandler):
-        # await testFontHandler.startTasks()
+        await testFontHandler.startTasks()
         glyph = await testFontHandler.getGlyph("A", connection=None)
 
     layerName, layer = firstLayerItem(glyph)
@@ -165,6 +165,7 @@ async def test_fontHandler_editGlyph_delete_layer(testFontHandler):
 @pytest.mark.asyncio
 async def test_fontHandler_getData(testFontHandler):
     async with aclosing(testFontHandler):
+        await testFontHandler.startTasks()
         unitsPerEm = await testFontHandler.getData("unitsPerEm")
         assert 1000 == unitsPerEm
 


### PR DESCRIPTION
I was seeing some intermittent teardown errors while running the tests, related to tasks not being shut down properly. So far, these changes seem to help.