### PR TITLE
[fontra-workflow] Merge kerning: disambiguate group names instead of merging them blindly

### DIFF
--- a/src/fontra/workflow/merger.py
+++ b/src/fontra/workflow/merger.py
@@ -287,14 +287,13 @@ def _mergeKernTable(kernTableA, kernTableB):
     sidMapA = [(sid, sidIndicesA.get(sid)) for sid in mergedSourceIdentifiers]
     sidMapB = [(sid, sidIndicesB.get(sid)) for sid in mergedSourceIdentifiers]
 
-    mergedValues = _remapKernValuesBySourceIdentifiers(
-        kernTableA.values, sidMapA
-    ) | _remapKernValuesBySourceIdentifiers(kernTableB.values, sidMapB)
+    mappedValuesA = _remapKernValuesBySourceIdentifiers(kernTableA.values, sidMapA)
+    mappedValuesB = _remapKernValuesBySourceIdentifiers(kernTableB.values, sidMapB)
 
     return Kerning(
         groups=kernTableA.groups | kernTableB.groups,
         sourceIdentifiers=mergedSourceIdentifiers,
-        values=mergedValues,
+        values=mappedValuesA | mappedValuesB,
     )
 
 

--- a/src/fontra/workflow/merger.py
+++ b/src/fontra/workflow/merger.py
@@ -153,6 +153,7 @@ class FontBackendMerger:
             await self.inputA.getKerning(), self._glyphNamesA - self._glyphNamesB
         )
         kerningB = subsetKerning(await self.inputB.getKerning(), self._glyphNamesB)
+
         newKerning = {}
         for kernType in sorted(set(kerningA) | set(kerningB)):
             kernTableA = kerningA.get(kernType)
@@ -270,6 +271,10 @@ def _mergeAxes(axisA, axisB):
 
 
 def _mergeKernTable(kernTableA, kernTableB):
+    if not set(kernTableA.groups).isdisjoint(set(kernTableB.groups)):
+        kernTableA = _disambiguateKerningGroupNames(kernTableA, kernTableB)
+
+    assert set(kernTableA.groups).isdisjoint(set(kernTableB.groups))
     assert set(kernTableA.values).isdisjoint(set(kernTableB.values))
 
     mergedSourceIdentifiers = list(kernTableA.sourceIdentifiers)
@@ -282,20 +287,50 @@ def _mergeKernTable(kernTableA, kernTableB):
     sidMapA = [(sid, sidIndicesA.get(sid)) for sid in mergedSourceIdentifiers]
     sidMapB = [(sid, sidIndicesB.get(sid)) for sid in mergedSourceIdentifiers]
 
-    mergedValues = _remapKernValues(kernTableA.values, sidMapA) | _remapKernValues(
-        kernTableB.values, sidMapB
-    )
-
-    mergedGroups = _mergeKernGroups(kernTableA.groups, kernTableB.groups)
+    mergedValues = _remapKernValuesBySourceIdentifiers(
+        kernTableA.values, sidMapA
+    ) | _remapKernValuesBySourceIdentifiers(kernTableB.values, sidMapB)
 
     return Kerning(
-        groups=mergedGroups,
+        groups=kernTableA.groups | kernTableB.groups,
         sourceIdentifiers=mergedSourceIdentifiers,
         values=mergedValues,
     )
 
 
-def _remapKernValues(kerningValues, sidMap):
+def _disambiguateKerningGroupNames(kernTableA, kernTableB):
+    groupsNamesA = set(kernTableA.groups)
+    groupsNamesB = set(kernTableB.groups)
+
+    conflictingNames = groupsNamesA & groupsNamesB
+    usedNames = groupsNamesA | groupsNamesB
+
+    renameMap = {}
+    for name in sorted(conflictingNames):
+        count = 1
+        while True:
+            newName = f"{name}.{count}"
+            if newName not in usedNames:
+                break
+            count += 1
+        usedNames.add(newName)
+        renameMap[name] = newName
+
+    newGroups = {
+        renameMap.get(name, name): group for name, group in kernTableA.groups.items()
+    }
+
+    newValues = {
+        renameMap.get(left, left): {
+            renameMap.get(right, right): values for right, values in rightDict.items()
+        }
+        for left, rightDict in kernTableA.values.items()
+    }
+
+    return replace(kernTableA, groups=newGroups, values=newValues)
+
+
+def _remapKernValuesBySourceIdentifiers(kerningValues, sidMap):
     mappedKerningValues = {}
 
     for left, rightDict in kerningValues.items():
@@ -308,23 +343,3 @@ def _remapKernValues(kerningValues, sidMap):
         mappedKerningValues[left] = mappedRightDict
 
     return mappedKerningValues
-
-
-def _mergeKernGroups(groupsA, groupsB):
-    mergedGroups = {}
-
-    for groupName in sorted(set(groupsA) | set(groupsB)):
-        groupA = groupsA.get(groupName)
-        groupB = groupsB.get(groupName)
-
-        if groupA is None:
-            mergedGroup = groupB
-        elif groupB is None:
-            mergedGroup = groupA
-        else:
-            assert set(groupA).isdisjoint(set(groupB))
-            mergedGroup = groupA + groupB
-
-        mergedGroups[groupName] = mergedGroup
-
-    return mergedGroups

--- a/test-py/data/workflow/output-merge-kerning.fontra/kerning.csv
+++ b/test-py/data/workflow/output-merge-kerning.fontra/kerning.csv
@@ -4,12 +4,13 @@ kern
 GROUPS
 public.kern1.A;A;Adieresis
 public.kern1.O;D;O
-public.kern2.MERGETEST;A;Adieresis;W
+public.kern2.MERGETEST;W
+public.kern2.MERGETEST.1;A;Adieresis
 
 VALUES
 side1;side2;38953841;f21bb6bb;4c8cddbd;c6801eea;10e1c129;14d3aeff
 public.kern1.A;T;10;20;30;40;;
 public.kern1.A;V;15;25;35;;;
-A;public.kern2.MERGETEST;-10;-20;-30;-40;;
+A;public.kern2.MERGETEST.1;-10;-20;-30;-40;;
 public.kern1.O;W;12;22;;;32;
 public.kern1.O;public.kern2.MERGETEST;-5;-15;;;-25;-35


### PR DESCRIPTION
Previously, groups with the same name were merged as-is, which adds unwanted kerning to the merged font, and breaks the isdisjoint check for the values.