### PR TITLE
Quick fix / workaround for the pointAttributes bug after using the knife tool

### DIFF
--- a/src/fontra/client/core/path-functions.js
+++ b/src/fontra/client/core/path-functions.js
@@ -1148,4 +1148,10 @@ function cleanupPointAttributes(path) {
       path.setPoint(pointIndex, point);
     }
   }
+  if (
+    path.pointAttributes &&
+    !path.pointAttributes.some((attr) => attr && !isObjectEmpty(attrs))
+  ) {
+    path.pointAttributes = null;
+  }
 }

--- a/src/fontra/client/core/path-functions.js
+++ b/src/fontra/client/core/path-functions.js
@@ -4,6 +4,7 @@ import {
   arrayExtend,
   assert,
   enumerate,
+  isObjectEmpty,
   modulo,
   pointCompareFunc,
   range,
@@ -1150,7 +1151,7 @@ function cleanupPointAttributes(path) {
   }
   if (
     path.pointAttributes &&
-    !path.pointAttributes.some((attr) => attr && !isObjectEmpty(attrs))
+    !path.pointAttributes.some((attrs) => attrs && !isObjectEmpty(attrs))
   ) {
     path.pointAttributes = null;
   }

--- a/src/fontra/core/changes.py
+++ b/src/fontra/core/changes.py
@@ -41,6 +41,7 @@ def insertItems(subject, index, *items, itemCast=None):
 def spliceItems(subject, index, deleteCount, *items, itemCast=None):
     if itemCast is not None:
         items = [itemCast(item) for item in items]
+    assert subject is not None, items
     subject[index : index + deleteCount] = items
 
 


### PR DESCRIPTION
This fixes #1591.

It is a bit of a workaround, but it does effectively prevent the error.

This is somewhat redundant after #1595, but is still a good cleanup.