### PR TITLE
Make explicit route for appendPath through change recording, so we don't hit pointAttribute clashes

### DIFF
--- a/src/fontra/client/core/change-recorder.js
+++ b/src/fontra/client/core/change-recorder.js
@@ -1,5 +1,5 @@
-import { ChangeCollector, applyChange, consolidateChanges } from "./changes.js";
-import { range, reversed } from "./utils.js";
+import { ChangeCollector, applyChange } from "./changes.js";
+import { range } from "./utils.js";
 
 export function recordChanges(subject, func) {
   const changes = new ChangeCollector();

--- a/src/fontra/client/core/change-recorder.js
+++ b/src/fontra/client/core/change-recorder.js
@@ -34,6 +34,16 @@ function getArrayProxyMethods(subject, changes) {
 
 function getVarPackedPathProxyMethods(subject, changes) {
   return {
+    appendPath(path) {
+      changes.addChange("appendPath", path);
+      const deleteIndices = [
+        ...range(subject.numContours, subject.numContours + path.numContours),
+      ].reverse();
+      deleteIndices.forEach((index) =>
+        changes.addRollbackChange("deleteContour", index)
+      );
+      subject.appendPath(path);
+    },
     insertContour(index, contour) {
       changes.addChange("insertContour", index, contour);
       changes.addRollbackChange("deleteContour", index);

--- a/src/fontra/client/core/changes.js
+++ b/src/fontra/client/core/changes.js
@@ -248,6 +248,9 @@ const baseChangeFunctions = {
 const changeFunctions = {
   ...baseChangeFunctions,
   "=xy": (path, itemCast, pointIndex, x, y) => path.setPointPosition(pointIndex, x, y),
+  "appendPath": (path, itemCast, newPath) => {
+    path.appendPath(newPath);
+  },
   "insertContour": (path, itemCast, contourIndex, contour) =>
     path.insertContour(contourIndex, contour),
   "deleteContour": (path, itemCast, contourIndex) => path.deleteContour(contourIndex),

--- a/src/fontra/core/changes.py
+++ b/src/fontra/core/changes.py
@@ -8,7 +8,8 @@ from typing import (
     Sequence,
 )
 
-from .classes import classCastFuncs, classSchema
+from .classes import classCastFuncs, classSchema, structure
+from .path import PackedPath
 
 
 def setItem(subject, key, item, *, itemCast=None):
@@ -57,6 +58,7 @@ baseChangeFunctions: dict[str, Callable[..., None]] = {
 changeFunctions: dict[str, Callable[..., None]] = {
     **baseChangeFunctions,
     "=xy": lambda path, pointIndex, x, y: path.setPointPosition(pointIndex, x, y),
+    "appendPath": lambda path, newPath: path.appendPath(structure(newPath, PackedPath)),
     "insertContour": lambda path, contourIndex, contour: path.insertContour(
         contourIndex, contour
     ),


### PR DESCRIPTION
This fixes #1591, as an alternative to #1593.

This is a more thorough fix: the bug was caused by appendPath, that would cause changes at the individual PackedPath attributes, making it possible for pointAttributes to get mismatched.