### PR TITLE
[dialog] Don't misbehave after a dialog has been dismissed by clicking on the backdrop

### DIFF
--- a/src/fontra/client/web-components/modal-dialog.js
+++ b/src/fontra/client/web-components/modal-dialog.js
@@ -154,6 +154,7 @@ export class ModalDialog extends SimpleElement {
       if (upInBackdrop && downInBackdrop) {
         this._dialogDone(null);
       }
+      downInBackdrop = false;
     });
     this.dialogElement.appendChild(this.dialogBox);
     this.shadowRoot.append(this.dialogElement);


### PR DESCRIPTION
Current behavior:
- dismiss a dialog by clicking on the backdrop
- the next time the dialog is triggered by a double click it will be dismissed immediately

Arguably, the dialog shouldn't receive this second click to begin with, but the `downInBackdrop` was never reset, causing the described behavior.

This fixes #1601.