### PR TITLE
[observable-object] Optionally read the keys from localStorage

### DIFF
--- a/src/fontra/client/core/actions.js
+++ b/src/fontra/client/core/actions.js
@@ -22,7 +22,7 @@ let actionsByKeyOrCode = undefined;
 
 const actionInfoController = new ObservableController({});
 const actionCallbacks = {};
-actionInfoController.synchronizeWithLocalStorage("fontra-actions-");
+actionInfoController.synchronizeWithLocalStorage("fontra-actions-", true);
 actionInfoController.addListener((event) => {
   actionsByKeyOrCode = undefined;
 });


### PR DESCRIPTION
Originally, the synch-with-local-storage mechanism could only cope with key/values that were explicitly declared on startup. However, we also need to be able to retrieve the stored keys. This is a bit risky, as it requires the prefix to be unique, and that there is no longer prefix that has the target prefix in common.