### PR TITLE
Show nodes and handles from component

### DIFF
--- a/src/fontra/views/editor/visualization-layer-definitions.js
+++ b/src/fontra/views/editor/visualization-layer-definitions.js
@@ -1126,7 +1126,6 @@ registerVisualizationLayerDefinition({
     }
 
     context.fillStyle = parameters.color;
-    context.strokeStyle = parameters.strokeColor;
     for (const pt of glyph.componentsPath.iterPoints()) {
       fillNode(context, pt, cornerSize, smoothSize, handleSize);
       strokeNode(context, pt, cornerSize, smoothSize, handleSize);

--- a/src/fontra/views/editor/visualization-layer-definitions.js
+++ b/src/fontra/views/editor/visualization-layer-definitions.js
@@ -1099,6 +1099,49 @@ registerVisualizationLayerDefinition({
 });
 
 registerVisualizationLayerDefinition({
+  identifier: "fontra.component.handles",
+  name: "Component handles",
+  selectionMode: "editing",
+  userSwitchable: true,
+  defaultOn: false,
+  zIndex: 500,
+  screenParameters: { strokeWidth: 1 },
+  colors: { color: "#BBB" },
+  colorsDarkMode: { color: "#777" },
+  draw: (context, positionedGlyph, parameters, model, controller) => {
+    const glyph = positionedGlyph.glyph;
+    context.strokeStyle = parameters.color;
+    context.lineWidth = parameters.strokeWidth;
+    for (const [pt1, pt2] of glyph.componentsPath.iterHandles()) {
+      strokeLine(context, pt1.x, pt1.y, pt2.x, pt2.y);
+    }
+  },
+});
+
+registerVisualizationLayerDefinition({
+  identifier: "fontra.component.nodes",
+  name: "Component Nodes",
+  selectionMode: "editing",
+  userSwitchable: true,
+  defaultOn: false,
+  zIndex: 500,
+  screenParameters: { cornerSize: 8, smoothSize: 8, handleSize: 6.5 },
+  colors: { color: "#CCC" },
+  colorsDarkMode: { color: "#777" },
+  draw: (context, positionedGlyph, parameters, model, controller) => {
+    const glyph = positionedGlyph.glyph;
+    const cornerSize = parameters.cornerSize;
+    const smoothSize = parameters.smoothSize;
+    const handleSize = parameters.handleSize;
+
+    context.fillStyle = parameters.color;
+    for (const pt of glyph.componentsPath.iterPoints()) {
+      fillNode(context, pt, cornerSize, smoothSize, handleSize);
+    }
+  },
+});
+
+registerVisualizationLayerDefinition({
   identifier: "fontra.handles",
   name: "Bezier handles",
   selectionMode: "editing",

--- a/src/fontra/views/editor/visualization-layer-definitions.js
+++ b/src/fontra/views/editor/visualization-layer-definitions.js
@@ -1099,44 +1099,39 @@ registerVisualizationLayerDefinition({
 });
 
 registerVisualizationLayerDefinition({
-  identifier: "fontra.component.handles",
-  name: "Component handles",
-  selectionMode: "editing",
-  userSwitchable: true,
-  defaultOn: false,
-  zIndex: 500,
-  screenParameters: { strokeWidth: 1 },
-  colors: { color: "#BBB" },
-  colorsDarkMode: { color: "#777" },
-  draw: (context, positionedGlyph, parameters, model, controller) => {
-    const glyph = positionedGlyph.glyph;
-    context.strokeStyle = parameters.color;
-    context.lineWidth = parameters.strokeWidth;
-    for (const [pt1, pt2] of glyph.componentsPath.iterHandles()) {
-      strokeLine(context, pt1.x, pt1.y, pt2.x, pt2.y);
-    }
-  },
-});
-
-registerVisualizationLayerDefinition({
   identifier: "fontra.component.nodes",
   name: "Component Nodes",
   selectionMode: "editing",
   userSwitchable: true,
   defaultOn: false,
   zIndex: 500,
-  screenParameters: { cornerSize: 8, smoothSize: 8, handleSize: 6.5 },
-  colors: { color: "#CCC" },
-  colorsDarkMode: { color: "#777" },
+  screenParameters: {
+    cornerSize: 8,
+    smoothSize: 8,
+    handleSize: 6.5,
+    strokeWidth: 1,
+    lineDash: [4, 4],
+  },
+  colors: { color: "#EEE", strokeColor: "#BBB" },
+  colorsDarkMode: { color: "#999", strokeColor: "#777" },
   draw: (context, positionedGlyph, parameters, model, controller) => {
     const glyph = positionedGlyph.glyph;
     const cornerSize = parameters.cornerSize;
     const smoothSize = parameters.smoothSize;
     const handleSize = parameters.handleSize;
 
+    context.strokeStyle = parameters.strokeColor;
+    context.lineWidth = parameters.strokeWidth;
+    //context.setLineDash(parameters.lineDash);
+    for (const [pt1, pt2] of glyph.componentsPath.iterHandles()) {
+      strokeLine(context, pt1.x, pt1.y, pt2.x, pt2.y);
+    }
+
     context.fillStyle = parameters.color;
+    context.strokeStyle = parameters.strokeColor;
     for (const pt of glyph.componentsPath.iterPoints()) {
       fillNode(context, pt, cornerSize, smoothSize, handleSize);
+      strokeNode(context, pt, cornerSize, smoothSize, handleSize);
     }
   },
 });

--- a/src/fontra/views/editor/visualization-layer-definitions.js
+++ b/src/fontra/views/editor/visualization-layer-definitions.js
@@ -1110,10 +1110,9 @@ registerVisualizationLayerDefinition({
     smoothSize: 8,
     handleSize: 6.5,
     strokeWidth: 1,
-    lineDash: [4, 4],
   },
   colors: { color: "#EEE", strokeColor: "#BBB" },
-  colorsDarkMode: { color: "#999", strokeColor: "#777" },
+  colorsDarkMode: { color: "#555", strokeColor: "#999" },
   draw: (context, positionedGlyph, parameters, model, controller) => {
     const glyph = positionedGlyph.glyph;
     const cornerSize = parameters.cornerSize;
@@ -1122,7 +1121,6 @@ registerVisualizationLayerDefinition({
 
     context.strokeStyle = parameters.strokeColor;
     context.lineWidth = parameters.strokeWidth;
-    //context.setLineDash(parameters.lineDash);
     for (const [pt1, pt2] of glyph.componentsPath.iterHandles()) {
       strokeLine(context, pt1.x, pt1.y, pt2.x, pt2.y);
     }


### PR DESCRIPTION
Fixes #1630

This is how it looks like:

<img width="1547" alt="Screenshot 2024-09-12 at 09 01 23" src="https://github.com/user-attachments/assets/4e016d26-1d2b-4452-9c16-afc99cc8f191">
<img width="1547" alt="Screenshot 2024-09-12 at 09 01 26" src="https://github.com/user-attachments/assets/cb75e1d0-b36e-49d3-b83d-c928c3af7a75">
