### PR TITLE
Make json paths used in js file use the cache busting version token

### DIFF
--- a/src/fontra/client/core/localization.js
+++ b/src/fontra/client/core/localization.js
@@ -18,7 +18,10 @@ export const ensureLanguageHasLoaded = new Promise((resolve) => {
 });
 
 function languageChanged(locale) {
-  fetchJSON(`/lang/${locale}.json`).then((data) => {
+  // Do explicit .replace() because our cache busting mechanism is simplistic,
+  // and backtick strings don't work.
+  const translationsPath = "/lang/locale.json".replace("locale", locale);
+  fetchJSON(translationsPath).then((data) => {
     localizationData = data;
     resolveLanguageHasLoaded();
   });

--- a/src/fontra/core/server.py
+++ b/src/fontra/core/server.py
@@ -299,7 +299,7 @@ class FontraServer:
     def _addVersionTokenToReferences(self, data: bytes, contentType: str) -> bytes:
         if self.versionToken is None:
             return data
-        jsAllowedFileExtensions = ["css", "js", "svg"]
+        jsAllowedFileExtensions = ["css", "js", "svg", "json"]
         extensionMapping = {
             "text/html": self.allowedFileExtensions,
             "text/css": ["woff2", "svg"],


### PR DESCRIPTION
This fixes #1655.