### PR TITLE
Use overshootColor from cjk.design.frame

### DIFF
--- a/src/fontra/views/editor/visualization-layer-definitions.js
+++ b/src/fontra/views/editor/visualization-layer-definitions.js
@@ -179,8 +179,8 @@ registerVisualizationLayerDefinition({
   defaultOn: true,
   zIndex: 100,
   screenParameters: { strokeWidth: 1 },
-  colors: { strokeColor: "#0004", zoneColor: "#0001" },
-  colorsDarkMode: { strokeColor: "#FFF6", zoneColor: "#FFF1" },
+  colors: { strokeColor: "#0004", zoneColor: "#00BFFF26" },
+  colorsDarkMode: { strokeColor: "#FFF6", zoneColor: "#00BFFF26" },
   draw: (context, positionedGlyph, parameters, model, controller) => {
     context.strokeStyle = parameters.strokeColor;
     context.lineWidth = parameters.strokeWidth;

--- a/src/fontra/views/editor/visualization-layer-definitions.js
+++ b/src/fontra/views/editor/visualization-layer-definitions.js
@@ -179,10 +179,17 @@ registerVisualizationLayerDefinition({
   defaultOn: true,
   zIndex: 100,
   screenParameters: { strokeWidth: 1 },
-  colors: { strokeColor: "#0004", zoneColor: "#00BFFF26" },
-  colorsDarkMode: { strokeColor: "#FFF6", zoneColor: "#00BFFF26" },
+  colors: {
+    strokeColor: "#0004",
+    zoneColor: "#00BFFF18",
+    zoneStrokeColor: "#00608018",
+  },
+  colorsDarkMode: {
+    strokeColor: "#FFF6",
+    zoneColor: "#00BFFF18",
+    zoneStrokeColor: "#80DFFF18",
+  },
   draw: (context, positionedGlyph, parameters, model, controller) => {
-    context.strokeStyle = parameters.strokeColor;
     context.lineWidth = parameters.strokeWidth;
 
     if (!model.fontSourceInstance) {
@@ -205,12 +212,16 @@ registerVisualizationLayerDefinition({
     }
 
     // collect paths: vertical metrics and alignment zones
-    const pathZones = [];
+    const zoneFillPaths = [];
+    const zoneEndStrokes = new Path2D();
     for (const [key, metric] of Object.entries(lineMetrics)) {
       if (metric.zone) {
         const pathZone = new Path2D();
         pathZone.rect(0, metric.value, glyphWidth, metric.zone);
-        pathZones.push(pathZone);
+        zoneFillPaths.push(pathZone);
+        const zoneY = metric.value + metric.zone;
+        zoneEndStrokes.moveTo(0, zoneY);
+        zoneEndStrokes.lineTo(glyphWidth, zoneY);
       }
 
       const pathMetric = new Path2D();
@@ -221,9 +232,14 @@ registerVisualizationLayerDefinition({
 
     // draw zones (with filled path)
     context.fillStyle = parameters.zoneColor;
-    pathZones.forEach((zonePath) => context.fill(zonePath));
+    zoneFillPaths.forEach((zonePath) => context.fill(zonePath));
+
+    // draw zone top/bottom terminating stroke
+    context.strokeStyle = parameters.zoneStrokeColor;
+    context.stroke(zoneEndStrokes);
 
     // draw glyph box + vertical metrics (with stroke path)
+    context.strokeStyle = parameters.strokeColor;
     context.stroke(pathBox);
   },
 });


### PR DESCRIPTION
Fixes #1690 

Still draft PR, because I like the grey more. 

This is how it looks with the cjk.design.frame overshootColor:
<img width="1141" alt="Screenshot 2024-10-03 at 15 54 35" src="https://github.com/user-attachments/assets/4a5f08a2-0aa9-49ae-b569-79cd8b4844f8">

<img width="1141" alt="Screenshot 2024-10-03 at 15 54 41" src="https://github.com/user-attachments/assets/48dfb00e-73c0-40ca-a2d0-c9dd2bda0386">
