### PR TITLE
Don't show transformation handles if readOnly or glyph locked

### DIFF
--- a/src/fontra/views/editor/edit-tools-pointer.js
+++ b/src/fontra/views/editor/edit-tools-pointer.js
@@ -720,6 +720,14 @@ registerVisualizationLayerDefinition({
     if (!model.showTransformSelection) {
       return;
     }
+
+    if (
+      !!positionedGlyph.varGlyph?.glyph.customData["fontra.glyph.locked"] ||
+      model.fontController.readOnly
+    ) {
+      return;
+    }
+
     const transformBounds = getTransformSelectionBounds(
       positionedGlyph.glyph,
       model.selection

--- a/src/fontra/views/editor/edit-tools-pointer.js
+++ b/src/fontra/views/editor/edit-tools-pointer.js
@@ -128,6 +128,7 @@ export class PointerTool extends BaseTool {
         !!rotationHandle
       );
       delete sceneController.sceneModel.clickedTransformSelectionHandle;
+      initialEvent.preventDefault();
       return;
     }
 

--- a/src/fontra/views/editor/edit-tools-pointer.js
+++ b/src/fontra/views/editor/edit-tools-pointer.js
@@ -721,14 +721,6 @@ registerVisualizationLayerDefinition({
     if (!model.showTransformSelection) {
       return;
     }
-
-    if (
-      !!positionedGlyph.varGlyph?.glyph.customData["fontra.glyph.locked"] ||
-      model.fontController.readOnly
-    ) {
-      return;
-    }
-
     const transformBounds = getTransformSelectionBounds(
       positionedGlyph.glyph,
       model.selection


### PR DESCRIPTION
Fixes #1702

Even though I don't know what the issue was caused by, it's already unnecessary to show the transformation handles if the file is readOnly or the glyph is locked – therefore I added code which don't show the handles if readOnly or glyph is locked.