### PR TITLE
Ensure we write contents.plist, or we'll get an invalid ufo if no glyphs are ever added

### DIFF
--- a/src/fontra/backends/designspace.py
+++ b/src/fontra/backends/designspace.py
@@ -724,7 +724,8 @@ class DesignspaceBackend:
             if value is not None:
                 setattr(info, infoAttr, value)
         reader.writeInfo(info)
-        _ = reader.getGlyphSet()  # this creates the default layer
+        glyphSet = reader.getGlyphSet()  # this creates the default layer
+        glyphSet.writeContents()
         reader.writeLayerContents()
         ufoLayerName = reader.getDefaultLayerName()
         assert os.path.isdir(ufoPath)
@@ -755,6 +756,8 @@ class DesignspaceBackend:
 
         if ufoLayerName not in existingLayerNames:
             reader.writeLayerContents()
+            glyphSet = self.ufoManager.getGlyphSet(ufoPath, ufoLayerName)
+            glyphSet.writeContents()
 
         ufoLayer = UFOLayer(
             manager=self.ufoManager,
@@ -1370,7 +1373,8 @@ def createDSDocFromUFOPath(ufoPath, styleName):
     info = UFOFontInfo()
     _updateFontInfoFromDict(info, defaultUFOInfoAttrs)
     writer.writeInfo(info)
-    _ = writer.getGlyphSet()  # this creates the default layer
+    glyphSet = writer.getGlyphSet()  # this creates the default layer
+    glyphSet.writeContents()
     writer.writeLayerContents()
     assert os.path.isdir(ufoPath)
 

--- a/test-py/test_backends_designspace.py
+++ b/test-py/test_backends_designspace.py
@@ -921,6 +921,21 @@ async def test_null_output(tmpdir, suffix):
         await copyFont(inputBackend, outBackend)
 
 
+@pytest.mark.parametrize("suffix", [".ufo", ".designspace"])
+async def test_empty_layers_have_contents_plist(tmpdir, suffix, testFont):
+    tmpdir = pathlib.Path(tmpdir)
+    outPath = tmpdir / ("test" + suffix)
+
+    sources = await testFont.getSources()
+
+    outBackend = newFileSystemBackend(outPath)
+    await outBackend.putSources(sources)
+
+    for ufoPath in tmpdir.glob("*.ufo"):
+        for glyphsDir in ufoPath.glob("glyphs*"):
+            assert (glyphsDir / "contents.plist").exists()
+
+
 def fileNamesFromDir(path):
     return sorted(p.name for p in path.iterdir())
 


### PR DESCRIPTION
Previously, we could run into a situation where a layer with no glyphs would have no contents.plist, which makes various tools choke.