### PR TITLE
Ensure sources have a location property

### DIFF
--- a/src/fontra/client/core/font-controller.js
+++ b/src/fontra/client/core/font-controller.js
@@ -932,6 +932,7 @@ function ensureDenseSources(sources) {
   return mapObjectValues(sources, (source) => {
     return {
       ...source,
+      location: source.location || {},
       lineMetricsHorizontalLayout: mapObjectValues(
         source.lineMetricsHorizontalLayout || {},
         (metric) => {


### PR DESCRIPTION
If the FontSource's location is {}, it will be elided from the JSON dump. But when loading, we need to ensure it is there.

This fixes #1734.