### PR TITLE
Fix action identifiers for cut/copy/paste

### DIFF
--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -1503,15 +1503,15 @@ export class EditorController {
       this.basicContextMenuItems.push(
         {
           title: "Cut",
-          actionIdentifier: "action.clipboard.cut",
+          actionIdentifier: "action.cut",
         },
         {
           title: "Copy",
-          actionIdentifier: "action.clipboard.copy",
+          actionIdentifier: "action.copy",
         },
         {
           title: "Paste",
-          actionIdentifier: "action.clipboard.paste",
+          actionIdentifier: "action.paste",
         }
       );
     }


### PR DESCRIPTION
This fixes #1755.

This fixes a regression caused by https://github.com/googlefonts/fontra/pull/1636.