### PR TITLE
Add link to changelog page from Help menu

### DIFF
--- a/src/fontra/client/lang/de.js
+++ b/src/fontra/client/lang/de.js
@@ -147,7 +147,7 @@ export const strings = {
   "menubar.glyph.delete": "Source entfernen...",
   "menubar.glyph.edit-axes": "Glyph-Achse bearbeiten...",
   "menubar.help": "Hilfe",
-  "menubar.help.changelog": "Update Notes",
+  "menubar.help.changelog": "Letzte Änderungen",
   "menubar.help.documentation": "Dokumentation",
   "menubar.help.homepage": "Homepage",
   "menubar.view": "Ansicht",

--- a/src/fontra/client/lang/de.js
+++ b/src/fontra/client/lang/de.js
@@ -147,6 +147,7 @@ export const strings = {
   "menubar.glyph.delete": "Source entfernen...",
   "menubar.glyph.edit-axes": "Glyph-Achse bearbeiten...",
   "menubar.help": "Hilfe",
+  "menubar.help.changelog": "Update Notes",
   "menubar.help.documentation": "Dokumentation",
   "menubar.help.homepage": "Homepage",
   "menubar.view": "Ansicht",

--- a/src/fontra/client/lang/en.js
+++ b/src/fontra/client/lang/en.js
@@ -146,7 +146,7 @@ export const strings = {
   "menubar.glyph.delete": "Delete source...",
   "menubar.glyph.edit-axes": "Edit glyph axes...",
   "menubar.help": "Help",
-  "menubar.help.changelog": "Update Notes",
+  "menubar.help.changelog": "Latest changes",
   "menubar.help.documentation": "Documentation",
   "menubar.help.homepage": "Homepage",
   "menubar.view": "View",

--- a/src/fontra/client/lang/en.js
+++ b/src/fontra/client/lang/en.js
@@ -146,6 +146,7 @@ export const strings = {
   "menubar.glyph.delete": "Delete source...",
   "menubar.glyph.edit-axes": "Edit glyph axes...",
   "menubar.help": "Help",
+  "menubar.help.changelog": "Update Notes",
   "menubar.help.documentation": "Documentation",
   "menubar.help.homepage": "Homepage",
   "menubar.view": "View",

--- a/src/fontra/client/lang/fr.js
+++ b/src/fontra/client/lang/fr.js
@@ -147,6 +147,7 @@ export const strings = {
   "menubar.glyph.delete": "Supprimer la source…",
   "menubar.glyph.edit-axes": "Éditer les axes du glyphe…",
   "menubar.help": "Aide",
+  "menubar.help.changelog": "Update Notes",
   "menubar.help.documentation": "Documentation",
   "menubar.help.homepage": "Page d'accueil",
   "menubar.view": "Affichage",

--- a/src/fontra/client/lang/fr.js
+++ b/src/fontra/client/lang/fr.js
@@ -147,7 +147,7 @@ export const strings = {
   "menubar.glyph.delete": "Supprimer la source…",
   "menubar.glyph.edit-axes": "Éditer les axes du glyphe…",
   "menubar.help": "Aide",
-  "menubar.help.changelog": "Update Notes",
+  "menubar.help.changelog": "Latest changes",
   "menubar.help.documentation": "Documentation",
   "menubar.help.homepage": "Page d'accueil",
   "menubar.view": "Affichage",

--- a/src/fontra/client/lang/nl.js
+++ b/src/fontra/client/lang/nl.js
@@ -146,7 +146,7 @@ export const strings = {
   "menubar.glyph.delete": "Verwijder source...",
   "menubar.glyph.edit-axes": "Wijzig glyph assen...",
   "menubar.help": "Help",
-  "menubar.help.changelog": "Update Notes",
+  "menubar.help.changelog": "Latest changes",
   "menubar.help.documentation": "Documentatie",
   "menubar.help.homepage": "Thuispagina",
   "menubar.view": "Weergave",

--- a/src/fontra/client/lang/nl.js
+++ b/src/fontra/client/lang/nl.js
@@ -146,6 +146,7 @@ export const strings = {
   "menubar.glyph.delete": "Verwijder source...",
   "menubar.glyph.edit-axes": "Wijzig glyph assen...",
   "menubar.help": "Help",
+  "menubar.help.changelog": "Update Notes",
   "menubar.help.documentation": "Documentatie",
   "menubar.help.homepage": "Thuispagina",
   "menubar.view": "Weergave",

--- a/src/fontra/client/lang/zh-CN.js
+++ b/src/fontra/client/lang/zh-CN.js
@@ -145,6 +145,7 @@ export const strings = {
   "menubar.glyph.delete": "删除图层……",
   "menubar.glyph.edit-axes": "编辑字形参数轴……",
   "menubar.help": "帮助",
+  "menubar.help.changelog": "Update Notes",
   "menubar.help.documentation": "文档",
   "menubar.help.homepage": "主页",
   "menubar.view": "视图",

--- a/src/fontra/client/lang/zh-CN.js
+++ b/src/fontra/client/lang/zh-CN.js
@@ -145,7 +145,7 @@ export const strings = {
   "menubar.glyph.delete": "删除图层……",
   "menubar.glyph.edit-axes": "编辑字形参数轴……",
   "menubar.help": "帮助",
-  "menubar.help.changelog": "Update Notes",
+  "menubar.help.changelog": "Latest changes",
   "menubar.help.documentation": "文档",
   "menubar.help.homepage": "主页",
   "menubar.view": "视图",

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -855,6 +855,13 @@ export class EditorController {
               },
             },
             {
+              title: translate("menubar.help.changelog"),
+              enabled: () => true,
+              callback: () => {
+                window.open("https://fontra.xyz/changelog.html");
+              },
+            },
+            {
               title: "GitHub",
               enabled: () => true,
               callback: () => {


### PR DESCRIPTION
Fixes #1751

This is a draft PR, as the displayed name has not yet been defined.

My comment on the google sheet:
```
VS Code: Show Release Notes
Chrome: Release Notes

As we don't do any official releases, here are some alternates:
Change Log
Update Notes
Version History
Software Update Notes
Version Notes
```

For reference, please see: https://docs.google.com/spreadsheets/d/1woTU8dZCHJh7yvdk-N1kgQBUj4Sn3SdRsbKgn6ltJQs/edit?pli=1&disco=AAABX4SxtcA