### PR TITLE
Don't allow guideline selection, if they are hidden.

### DIFF
--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -134,7 +134,8 @@ export class EditorController {
     this.sceneController = new SceneController(
       this.fontController,
       canvasController,
-      applicationSettingsController
+      applicationSettingsController,
+      this
     );
 
     this.sceneSettingsController = this.sceneController.sceneSettingsController;

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -131,11 +131,24 @@ export class EditorController {
       async (...args) => await this.editListenerCallback(...args)
     );
 
+    this.visualizationLayers = new VisualizationLayers(
+      visualizationLayerDefinitions,
+      this.isThemeDark
+    );
+
+    this.visualizationLayersSettings = newVisualizationLayersSettings(
+      this.visualizationLayers
+    );
+    this.visualizationLayersSettings.addListener((event) => {
+      this.visualizationLayers.toggle(event.key, event.newValue);
+      this.canvasController.requestUpdate();
+    }, true);
+
     this.sceneController = new SceneController(
       this.fontController,
       canvasController,
       applicationSettingsController,
-      this
+      this.visualizationLayersSettings
     );
 
     this.sceneSettingsController = this.sceneController.sceneSettingsController;
@@ -164,19 +177,6 @@ export class EditorController {
     );
 
     this.cjkDesignFrame = new CJKDesignFrame(this);
-
-    this.visualizationLayers = new VisualizationLayers(
-      visualizationLayerDefinitions,
-      this.isThemeDark
-    );
-
-    this.visualizationLayersSettings = newVisualizationLayersSettings(
-      this.visualizationLayers
-    );
-    this.visualizationLayersSettings.addListener((event) => {
-      this.visualizationLayers.toggle(event.key, event.newValue);
-      this.canvasController.requestUpdate();
-    }, true);
 
     const sceneView = new SceneView(this.sceneModel, (model, controller) =>
       this.visualizationLayers.drawVisualizationLayers(model, controller)
@@ -2783,7 +2783,10 @@ export class EditorController {
       }
     }
 
-    if (selectGuidelines) {
+    if (
+      selectGuidelines &&
+      this.visualizationLayersSettings.model["fontra.guidelines"]
+    ) {
       for (const guidelineIndex of range(positionedGlyph.glyph.guidelines.length)) {
         const guideline = positionedGlyph.glyph.guidelines[guidelineIndex];
         if (!guideline.locked) {

--- a/src/fontra/views/editor/scene-controller.js
+++ b/src/fontra/views/editor/scene-controller.js
@@ -36,7 +36,12 @@ import { translate, translatePlural } from "/core/localization.js";
 import { dialog, message } from "/web-components/modal-dialog.js";
 
 export class SceneController {
-  constructor(fontController, canvasController, applicationSettingsController) {
+  constructor(
+    fontController,
+    canvasController,
+    applicationSettingsController,
+    editorController
+  ) {
     this.canvasController = canvasController;
     this.applicationSettings = applicationSettingsController.model;
     this.fontController = fontController;
@@ -53,7 +58,8 @@ export class SceneController {
     this.sceneModel = new SceneModel(
       fontController,
       this.sceneSettingsController,
-      isPointInPath
+      isPointInPath,
+      editorController
     );
 
     this.selectedTool = undefined;

--- a/src/fontra/views/editor/scene-controller.js
+++ b/src/fontra/views/editor/scene-controller.js
@@ -40,7 +40,7 @@ export class SceneController {
     fontController,
     canvasController,
     applicationSettingsController,
-    editorController
+    visualizationLayersSettings
   ) {
     this.canvasController = canvasController;
     this.applicationSettings = applicationSettingsController.model;
@@ -59,7 +59,7 @@ export class SceneController {
       fontController,
       this.sceneSettingsController,
       isPointInPath,
-      editorController
+      visualizationLayersSettings
     );
 
     this.selectedTool = undefined;

--- a/src/fontra/views/editor/scene-model.js
+++ b/src/fontra/views/editor/scene-model.js
@@ -25,13 +25,13 @@ export class SceneModel {
     fontController,
     sceneSettingsController,
     isPointInPath,
-    editorController
+    visualizationLayersSettings
   ) {
     this.fontController = fontController;
     this.sceneSettingsController = sceneSettingsController;
     this.sceneSettings = sceneSettingsController.model;
     this.isPointInPath = isPointInPath;
-    this.editorController = editorController;
+    this.visualizationLayersSettings = visualizationLayersSettings;
     this.hoveredGlyph = undefined;
     this._glyphLocations = {}; // glyph name -> glyph location
     this.longestLineLength = 0;
@@ -687,7 +687,7 @@ export class SceneModel {
   }
 
   guidelineSelectionAtPoint(point, size, parsedCurrentSelection) {
-    if (!this.editorController.visualizationLayersSettings.model["fontra.guidelines"]) {
+    if (!this.visualizationLayersSettings.model["fontra.guidelines"]) {
       // If guidelines are hidden, don't allow selection
       return new Set();
     }

--- a/src/fontra/views/editor/scene-model.js
+++ b/src/fontra/views/editor/scene-model.js
@@ -21,11 +21,17 @@ import * as vector from "../core/vector.js";
 import { loaderSpinner } from "/core/loader-spinner.js";
 
 export class SceneModel {
-  constructor(fontController, sceneSettingsController, isPointInPath) {
+  constructor(
+    fontController,
+    sceneSettingsController,
+    isPointInPath,
+    editorController
+  ) {
     this.fontController = fontController;
     this.sceneSettingsController = sceneSettingsController;
     this.sceneSettings = sceneSettingsController.model;
     this.isPointInPath = isPointInPath;
+    this.editorController = editorController;
     this.hoveredGlyph = undefined;
     this._glyphLocations = {}; // glyph name -> glyph location
     this.longestLineLength = 0;
@@ -681,6 +687,10 @@ export class SceneModel {
   }
 
   guidelineSelectionAtPoint(point, size, parsedCurrentSelection) {
+    if (!this.editorController.visualizationLayersSettings.model["fontra.guidelines"]) {
+      // If guidelines are hidden, don't allow selection
+      return new Set();
+    }
     const positionedGlyph = this.getSelectedPositionedGlyph();
     if (!positionedGlyph) {
       return new Set();


### PR DESCRIPTION
Fixes #1760 

Hi @justvanrossum , this is a possible solution, but I am not sure if this is the right path.
My thinking here is, that when the visualizationLayersSettings for guidelines is set to be 'hidden', the guidelines should not be part of the general selection. But to check the status of the guidelines visualizationLayersSettings we need `editorController`, but this hasn't been part of `SceneModel`, yet. And I think it may has a reason??? 
Therefore this is just a proposal to get in a conversation with you to get some advice.