### PR TITLE
Fix #1759: Hovering over an icon can trigger the scroll bar

### DIFF
--- a/src/fontra/client/web-components/icon-button.js
+++ b/src/fontra/client/web-components/icon-button.js
@@ -12,21 +12,28 @@ export class IconButton extends UnlitElement {
       color: var(--foreground-color);
       width: 100%;
       height: 100%;
-      transition: 150ms;
       cursor: pointer;
-      will-change: transform;
+      contain: content;
     }
 
-    button:hover {
+    button svg {
+      will-change: transform;
+      transition: 150ms;
+    }
+
+    button:hover svg {
       transform: scale(1.1, 1.1);
     }
 
-    button:active {
+    button:active svg {
       transform: scale(1.2, 1.2);
     }
 
     button:disabled {
       opacity: 35%;
+    }
+
+    button:disabled svg {
       transform: none;
     }
 


### PR DESCRIPTION
As @justvanrossum said: https://github.com/googlefonts/fontra/issues/1759#issuecomment-2460640093, animating the svg inside the icon-button is indeed a good solution.

I changed the animating DOM object from the button itself to the svg inside the button.

I also added `will-change: transform` to the svg, in order to not to repeat the issue #1388.

Changing the animating object only didn't work in Windows. I added `contain: content` to the button, to indicate that the transform of its content should not affect the layout: https://developer.mozilla.org/en-US/docs/Web/CSS/contain

This fixes #1759 