### PR TITLE
[background image] delete image, cut/copy/paste

### DIFF
--- a/src/fontra/backends/designspace.py
+++ b/src/fontra/backends/designspace.py
@@ -1915,6 +1915,8 @@ def populateUFOLayerGlyph(
         layerGlyph.image = packBackgroundImage(
             staticGlyph.backgroundImage, imageFileName
         )
+    else:
+        layerGlyph.image = None
 
     for component in staticGlyph.components:
         if component.location or forceVariableComponents:

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -1932,10 +1932,10 @@ export class EditorController {
     }
     const instance = StaticGlyph.fromObject({
       ...editInstance,
-      path: path,
-      components: components,
-      anchors: anchors,
-      guidelines: guidelines,
+      path,
+      components,
+      anchors,
+      guidelines,
       backgroundImage,
     });
     return {

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -2159,6 +2159,10 @@ export class EditorController {
           layerGlyph.components.push(...pasteGlyph.components.map(copyComponent));
           layerGlyph.anchors.push(...pasteGlyph.anchors);
           layerGlyph.guidelines.push(...pasteGlyph.guidelines);
+          if (pasteGlyph.backgroundImage) {
+            layerGlyph.backgroundImage = pasteGlyph.backgroundImage;
+            selection.add("backgroundImage/0");
+          }
         }
         this.sceneController.selection = selection;
         return "Paste";

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -2207,6 +2207,7 @@ export class EditorController {
       component: componentSelection,
       anchor: anchorSelection,
       guideline: guidelineSelection,
+      backgroundImage: backgroundImageSelection,
       //fontGuideline: fontGuidelineSelection,
     } = parseSelection(this.sceneController.selection);
     // TODO: Font Guidelines
@@ -2243,6 +2244,11 @@ export class EditorController {
               }
               layerGlyph.guidelines.splice(guidelineIndex, 1);
             }
+          }
+          if (backgroundImageSelection) {
+            // TODO: don't delete if bg images are locked
+            // (even though we shouldn't be able to select them)
+            layerGlyph.backgroundImage = null;
           }
         }
       }

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -1883,11 +1883,13 @@ export class EditorController {
       component: componentIndices,
       anchor: anchorIndices,
       guideline: guidelineIndices,
+      backgroundImage: backgroundImageIndices,
     } = parseSelection(this.sceneController.selection);
     let path;
     let components;
     let anchors;
     let guidelines;
+    let backgroundImage;
     const flattenedPathList = wantFlattenedPath ? [] : undefined;
     if (pointIndices) {
       path = filterPathByPointIndices(editInstance.path, pointIndices, doCut);
@@ -1920,12 +1922,21 @@ export class EditorController {
         }
       }
     }
+    if (backgroundImageIndices) {
+      backgroundImage = editInstance.backgroundImage;
+      if (doCut) {
+        // TODO: don't delete if bg images are locked
+        // (even though we shouldn't be able to select them)
+        editInstance.backgroundImage = undefined;
+      }
+    }
     const instance = StaticGlyph.fromObject({
       ...editInstance,
       path: path,
       components: components,
       anchors: anchors,
       guidelines: guidelines,
+      backgroundImage,
     });
     return {
       instance: instance,
@@ -2248,7 +2259,7 @@ export class EditorController {
           if (backgroundImageSelection) {
             // TODO: don't delete if bg images are locked
             // (even though we shouldn't be able to select them)
-            layerGlyph.backgroundImage = null;
+            layerGlyph.backgroundImage = undefined;
           }
         }
       }


### PR DESCRIPTION
Implement delete background image, and cut/copy/paste.

This fixes #1788.

This also fixed a bug with the designspace backend that prevented a background image reference to be deleted.

Copy/paste in this PR only deals with the background image _references_, and not yet the actual image data. Followup: #1793.