### PR TITLE
[background image] Get rid of redundant args to putBackgroundImage()

### DIFF
--- a/src/fontra/backends/copy.py
+++ b/src/fontra/backends/copy.py
@@ -138,7 +138,7 @@ async def copyGlyphs(
         }
         glyphNamesToCopy.extend(sorted(componentNames - glyphNamesCopied))
 
-        for layerName, layer in glyph.layers.items():
+        for layer in glyph.layers.values():
             if layer.glyph.backgroundImage is not None:
                 backgroundImageIdentifiers.append(
                     layer.glyph.backgroundImage.identifier

--- a/src/fontra/backends/copy.py
+++ b/src/fontra/backends/copy.py
@@ -87,15 +87,13 @@ async def _copyFont(
         raise e
 
     if isinstance(destBackend, WriteBackgroundImage):
-        backgroundImageInfos = [info for t in done for info in t.result()]
-        if backgroundImageInfos:
+        backgroundImageIdentifiers = [info for t in done for info in t.result()]
+        if backgroundImageIdentifiers:
             assert isinstance(sourceBackend, ReadBackgroundImage), type(sourceBackend)
-            for glyphName, layerName, imageIdentifier in backgroundImageInfos:
+            for imageIdentifier in backgroundImageIdentifiers:
                 imageData = await sourceBackend.getBackgroundImage(imageIdentifier)
                 if imageData is not None:
-                    await destBackend.putBackgroundImage(
-                        imageIdentifier, glyphName, layerName, imageData
-                    )
+                    await destBackend.putBackgroundImage(imageIdentifier, imageData)
 
     await destBackend.putKerning(await sourceBackend.getKerning())
     await destBackend.putFeatures(await sourceBackend.getFeatures())
@@ -110,7 +108,7 @@ async def copyGlyphs(
     progressInterval: int,
     continueOnError: bool,
 ) -> list:
-    backgroundImageInfos = []
+    backgroundImageIdentifiers = []
 
     while glyphNamesToCopy:
         if progressInterval and not (len(glyphNamesToCopy) % progressInterval):
@@ -142,13 +140,13 @@ async def copyGlyphs(
 
         for layerName, layer in glyph.layers.items():
             if layer.glyph.backgroundImage is not None:
-                backgroundImageInfos.append(
-                    (glyphName, layerName, layer.glyph.backgroundImage.identifier)
+                backgroundImageIdentifiers.append(
+                    layer.glyph.backgroundImage.identifier
                 )
 
         await destBackend.putGlyph(glyphName, glyph, glyphMap[glyphName])
 
-    return backgroundImageInfos
+    return backgroundImageIdentifiers
 
 
 async def mainAsync() -> None:

--- a/src/fontra/backends/fontra.py
+++ b/src/fontra/backends/fontra.py
@@ -197,9 +197,7 @@ class FontraBackend:
 
         return None  # Image not found
 
-    async def putBackgroundImage(
-        self, imageIdentifier: str, glyphName: str, layerName: str, data: ImageData
-    ) -> None:
+    async def putBackgroundImage(self, imageIdentifier: str, data: ImageData) -> None:
         fileName = f"{imageIdentifier}.{data.type.lower()}"
         self.backgroundImagesDir.mkdir(exist_ok=True)
         path = self.backgroundImagesDir / fileName

--- a/src/fontra/core/protocols.py
+++ b/src/fontra/core/protocols.py
@@ -101,9 +101,7 @@ class ReadBackgroundImage(Protocol):
 
 @runtime_checkable
 class WriteBackgroundImage(Protocol):
-    async def putBackgroundImage(
-        self, imageIdentifier: str, glyphName: str, layerName: str, data: ImageData
-    ) -> None:
+    async def putBackgroundImage(self, imageIdentifier: str, data: ImageData) -> None:
         pass
 
     # TODO: since the image data does not itself participate in change messages,

--- a/test-py/test_backends_designspace.py
+++ b/test-py/test_backends_designspace.py
@@ -402,9 +402,10 @@ async def test_putBackgroundImage(writableTestFont):
 
     glyphName = "D"
     imageIdentifier = str(uuid.uuid4())
-    await writableTestFont.putBackgroundImage(
-        imageIdentifier, glyphName, layerName, imageData
-    )
+    await writableTestFont.putBackgroundImage(imageIdentifier, imageData)
+    glyph2 = deepcopy(glyph)
+    glyph2.layers[layerName].glyph.backgroundImage.identifier = imageIdentifier
+    await writableTestFont.putGlyph(glyphName, glyph2, [ord("D")])
 
     imageData2 = await writableTestFont.getBackgroundImage(imageIdentifier)
 

--- a/test-py/test_backends_designspace.py
+++ b/test-py/test_backends_designspace.py
@@ -412,7 +412,7 @@ async def test_putBackgroundImage(writableTestFont):
     assert imageData2 == imageData
 
 
-async def test_putBackgroundImage_new_font(testFont, tmpdir):
+async def test_putGlyph_with_backgroundImage_new_font(testFont, tmpdir):
     tmpdir = pathlib.Path(tmpdir)
     newFont = DesignspaceBackend.createFromPath(tmpdir / "test.designspace")
 


### PR DESCRIPTION
Get rid of redundant args to putBackgroundImage: turns out the designspace backend doesn't really need this after all, when put in some more effort.