### PR TITLE
[background image] On copy, put background image as image data on the clipboard

### DIFF
--- a/src/fontra/client/core/utils.js
+++ b/src/fontra/client/core/utils.js
@@ -252,9 +252,13 @@ export async function writeToClipboard(clipboardObject) {
 
   const clipboardItemObject = {};
   for (const [key, value] of Object.entries(clipboardObject)) {
-    clipboardItemObject[key] = new Blob([value], {
-      type: key,
-    });
+    if (value instanceof Blob)
+      clipboardItemObject[key] =
+        value instanceof Blob
+          ? value
+          : new Blob([value], {
+              type: key,
+            });
   }
 
   try {

--- a/src/fontra/client/core/utils.js
+++ b/src/fontra/client/core/utils.js
@@ -252,13 +252,12 @@ export async function writeToClipboard(clipboardObject) {
 
   const clipboardItemObject = {};
   for (const [key, value] of Object.entries(clipboardObject)) {
-    if (value instanceof Blob)
-      clipboardItemObject[key] =
-        value instanceof Blob
-          ? value
-          : new Blob([value], {
-              type: key,
-            });
+    if (value instanceof Blob) {
+      assert(key === value.type);
+      clipboardItemObject[key] = value;
+    } else {
+      clipboardItemObject[key] = new Blob([value], { type: key });
+    }
   }
 
   try {

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -1833,7 +1833,23 @@ export class EditorController {
         "web image/svg+xml": svgString,
         "web fontra/static-glyph": jsonString,
       };
+
+      await this._addBackgroundImageToClipboard(clipboardObject, backgroundImageData);
+
       await writeToClipboard(clipboardObject);
+    }
+  }
+
+  async _addBackgroundImageToClipboard(clipboardObject, backgroundImageData) {
+    if (
+      this.sceneController.selection.size == 1 &&
+      this.sceneController.selection.has("backgroundImage/0") &&
+      backgroundImageData &&
+      Object.keys(backgroundImageData).length == 1
+    ) {
+      const res = await fetch(Object.values(backgroundImageData)[0]);
+      const blob = await res.blob();
+      clipboardObject[blob.type] = blob;
     }
   }
 


### PR DESCRIPTION
...but only if it's the only selected item.

This will *not* work in Safari over HTTP (ie. Fontra Pak), due to Safari not supporting the async clipboard API in that case. (To be clear, it does work in Safari when we run Fontra on HTTPS, but that's not the case with Fontra Pak.)

This fixes #1796.