### PR TITLE
[background image] Some fixups regarding bg image locking

### DIFF
--- a/src/fontra/views/editor/scene-controller.js
+++ b/src/fontra/views/editor/scene-controller.js
@@ -295,6 +295,9 @@ export class SceneController {
     this.sceneSettingsController.addKeyListener(
       ["selection", "hoverSelection"],
       (event) => {
+        if (event.key === "selection") {
+          this._checkSelectionForLockedItems();
+        }
         this.sceneSettings.combinedSelection = union(
           this.sceneSettings.selection,
           this.sceneSettings.hoverSelection
@@ -334,6 +337,18 @@ export class SceneController {
         { senderID: this }
       );
     });
+  }
+
+  _checkSelectionForLockedItems() {
+    if (
+      this.sceneSettings.backgroundImagesAreLocked &&
+      this.sceneSettings.selection.has("backgroundImage/0")
+    ) {
+      this.sceneSettings.selection = difference(this.sceneSettings.selection, [
+        "backgroundImage/0",
+      ]);
+      console.log("did something");
+    }
   }
 
   setupChangeListeners() {

--- a/src/fontra/views/editor/scene-controller.js
+++ b/src/fontra/views/editor/scene-controller.js
@@ -347,7 +347,6 @@ export class SceneController {
       this.sceneSettings.selection = difference(this.sceneSettings.selection, [
         "backgroundImage/0",
       ]);
-      console.log("did something");
     }
   }
 

--- a/src/fontra/views/editor/visualization-layer-definitions.js
+++ b/src/fontra/views/editor/visualization-layer-definitions.js
@@ -418,8 +418,8 @@ registerVisualizationLayerDefinition({
   screenParameters: {
     strokeWidth: 2,
   },
-  colors: { strokeColor: "#888" },
-  colorsDarkMode: { strokeColor: "#FFF" },
+  colors: { strokeColor: "#888", hoverStrokeColor: "#8885" },
+  colorsDarkMode: { strokeColor: "#FFF", hoverStrokeColor: "#FFF5" },
 
   draw: (context, positionedGlyph, parameters, model, controller) => {
     const backgroundImage = positionedGlyph.glyph.backgroundImage;
@@ -466,8 +466,12 @@ registerVisualizationLayerDefinition({
     const rectPoly = rectToPoints(backgroundImageBounds);
     const polygon = rectPoly.map((point) => affine.transformPointObject(point));
 
-    if (model.selection.has("backgroundImage/0")) {
-      context.strokeStyle = parameters.strokeColor;
+    const isSelected = model.selection.has("backgroundImage/0");
+    const isHovered = model.hoverSelection.has("backgroundImage/0");
+
+    if (isSelected || isHovered) {
+      context.strokeStyle =
+        isHovered && !isSelected ? parameters.hoverStrokeColor : parameters.strokeColor;
       context.lineWidth = parameters.strokeWidth;
       context.lineJoin = "round";
       strokePolygon(context, polygon);


### PR DESCRIPTION
Followup to #1801

- Visualize hover state with different stroke color
- Ensure the bg image can't be selected if bg images are locked, no matter what (before this, they could still be selected via page reload and undo/redo)