### PR TITLE
[background image] Allow a PNG or JPEG file to be dropped onto a glyph in edit mode

### DIFF
--- a/src/fontra/client/core/glyph-controller.js
+++ b/src/fontra/client/core/glyph-controller.js
@@ -1134,9 +1134,12 @@ function ensureGlyphCompatibility(layerGlyphs, glyphDependencies) {
 }
 
 function stripNonInterpolatables(glyph) {
-  if (!glyph.components.length && !glyph.guidelines.length && !glyph.backgroundImage) {
-    return glyph;
-  }
+  // Hm, the following optimization oddly causes a false positive when undoing a bg img
+  // placement. TODO: figure out what's going on.
+  // if (!glyph.components.length && !glyph.guidelines.length && !glyph.backgroundImage) {
+  //   console.log("have bg img?", !!glyph.backgroundImage);
+  //   return glyph;
+  // }
   return StaticGlyph.fromObject(
     {
       ...glyph,

--- a/src/fontra/views/editor/editor.css
+++ b/src/fontra/views/editor/editor.css
@@ -388,6 +388,10 @@ body {
   outline: none;
 }
 
+#edit-canvas.dropping-files {
+  background-color: #99556655;
+}
+
 .cleanable-overlay.overlay-layer-hidden {
   display: none;
 }

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -2204,7 +2204,7 @@ export class EditorController {
   }
 
   async _pasteClipboardImage() {
-    if (!this.sceneSettings.selectedGlyph?.isEditing) {
+    if (!this.canPlaceBackgroundImage()) {
       return;
     }
 
@@ -3660,7 +3660,7 @@ export class EditorController {
     location.reload();
   }
 
-  canDropBackgroundImage() {
+  canPlaceBackgroundImage() {
     return (
       this.fontController.backendInfo.features["background-image"] &&
       this.canEditGlyph()
@@ -3681,7 +3681,7 @@ export class EditorController {
 
   _onDragEnter(event) {
     event.preventDefault();
-    if (!this.canDropBackgroundImage()) {
+    if (!this.canPlaceBackgroundImage()) {
       return;
     }
     this.canvasController.canvas.classList.add("dropping-files");
@@ -3689,7 +3689,7 @@ export class EditorController {
 
   _onDragOver(event) {
     event.preventDefault();
-    if (!this.canDropBackgroundImage()) {
+    if (!this.canPlaceBackgroundImage()) {
       return;
     }
     this.canvasController.canvas.classList.add("dropping-files");
@@ -3697,7 +3697,7 @@ export class EditorController {
 
   _onDragLeave(event) {
     event.preventDefault();
-    if (!this.canDropBackgroundImage()) {
+    if (!this.canPlaceBackgroundImage()) {
       return;
     }
     this.canvasController.canvas.classList.remove("dropping-files");
@@ -3705,7 +3705,7 @@ export class EditorController {
 
   _onDrop(event) {
     event.preventDefault();
-    if (!this.canDropBackgroundImage()) {
+    if (!this.canPlaceBackgroundImage()) {
       return;
     }
     this.canvasController.canvas.classList.remove("dropping-files");

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -2146,6 +2146,8 @@ export class EditorController {
       const mappedIdentifier = identifierMapping[imageIdentifier] || imageIdentifier;
       await this.fontController.putBackgroundImageData(mappedIdentifier, imageData);
     }
+    // Writing the background image data does not cause a refresh
+    this.canvasController.requestUpdate();
   }
 
   async _unpackClipboard() {
@@ -2254,6 +2256,8 @@ export class EditorController {
     for (const imageIdentifier of imageIdentifiers) {
       await this.fontController.putBackgroundImageData(imageIdentifier, dataURL);
     }
+    // Writing the background image data does not cause a refresh
+    this.canvasController.requestUpdate();
   }
 
   async _pasteReplaceGlyph(varGlyph) {

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -404,21 +404,21 @@ export class EditorController {
         "action.add-component",
         { topic },
         () => this.doAddComponent(),
-        () => this.canAddComponent()
+        () => this.canEditGlyph()
       );
 
       registerAction(
         "action.add-anchor",
         { topic },
         () => this.doAddAnchor(),
-        () => this.canAddAnchor()
+        () => this.canEditGlyph()
       );
 
       registerAction(
         "action.add-guideline",
         { topic },
         () => this.doAddGuideline(),
-        () => this.canAddGuideline()
+        () => this.canEditGlyph()
       );
 
       registerAction(
@@ -2448,10 +2448,6 @@ export class EditorController {
     });
   }
 
-  canAddComponent() {
-    return this.sceneModel.getSelectedPositionedGlyph()?.glyph.canEdit;
-  }
-
   async doAddComponent() {
     const glyphName = await this.runGlyphSearchDialog(
       translate("action.add-component"),
@@ -2483,10 +2479,6 @@ export class EditorController {
       this.sceneController.selection = new Set([`component/${newComponentIndex}`]);
       return translate("action.add-component");
     });
-  }
-
-  canAddAnchor() {
-    return this.sceneModel.getSelectedPositionedGlyph()?.glyph.canEdit;
   }
 
   async doAddAnchor() {
@@ -2733,9 +2725,6 @@ export class EditorController {
   // TODO: We may want to make a more general code for adding and editing
   // so we can handle both anchors and guidelines with the same code
   // Guidelines
-  canAddGuideline() {
-    return this.sceneModel.getSelectedPositionedGlyph()?.glyph.canEdit;
-  }
 
   async doAddGuideline(global = false) {
     this.visualizationLayersSettings.model["fontra.guidelines"] = true;
@@ -3656,6 +3645,16 @@ export class EditorController {
       [{ title: "Reconnect", resultValue: "ok" }]
     );
     location.reload();
+  }
+
+  canEditGlyph() {
+    const positionedGlyph = this.sceneModel.getSelectedPositionedGlyph();
+    return !!(
+      positionedGlyph &&
+      !this.fontController.readOnly &&
+      !this.sceneModel.isSelectedGlyphLocked() &&
+      positionedGlyph.glyph.canEdit
+    );
   }
 }
 

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -3660,6 +3660,13 @@ export class EditorController {
     location.reload();
   }
 
+  canDropBackgroundImage() {
+    return (
+      this.fontController.backendInfo.features["background-image"] &&
+      this.canEditGlyph()
+    );
+  }
+
   canEditGlyph() {
     const positionedGlyph = this.sceneModel.getSelectedPositionedGlyph();
     return !!(
@@ -3674,7 +3681,7 @@ export class EditorController {
 
   _onDragEnter(event) {
     event.preventDefault();
-    if (!this.canEditGlyph()) {
+    if (!this.canDropBackgroundImage()) {
       return;
     }
     this.canvasController.canvas.classList.add("dropping-files");
@@ -3682,7 +3689,7 @@ export class EditorController {
 
   _onDragOver(event) {
     event.preventDefault();
-    if (!this.canEditGlyph()) {
+    if (!this.canDropBackgroundImage()) {
       return;
     }
     this.canvasController.canvas.classList.add("dropping-files");
@@ -3690,7 +3697,7 @@ export class EditorController {
 
   _onDragLeave(event) {
     event.preventDefault();
-    if (!this.canEditGlyph()) {
+    if (!this.canDropBackgroundImage()) {
       return;
     }
     this.canvasController.canvas.classList.remove("dropping-files");
@@ -3698,7 +3705,7 @@ export class EditorController {
 
   _onDrop(event) {
     event.preventDefault();
-    if (!this.canEditGlyph()) {
+    if (!this.canDropBackgroundImage()) {
       return;
     }
     this.canvasController.canvas.classList.remove("dropping-files");

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -2110,10 +2110,12 @@ export class EditorController {
       await this._pasteLayerGlyphs(pasteLayerGlyphs);
     }
 
-    await this._writeBackgroundImageData(
-      backgroundImageData,
-      backgroundImageIdentifierMapping
-    );
+    if (this.fontController.backendInfo.features["background-image"]) {
+      await this._writeBackgroundImageData(
+        backgroundImageData,
+        backgroundImageIdentifierMapping
+      );
+    }
   }
 
   _makeBackgroundImageIdentifierMapping(backgroundImageData) {


### PR DESCRIPTION
This fixes #1807.

This also adds some checks so we don't offer image drop/paste when the backend doesn't support it.