### PR TITLE
Turn Edit items into submenu in context menu

### DIFF
--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -3274,7 +3274,9 @@ export class EditorController {
   }
 
   buildContextMenuItems(event) {
-    const menuItems = [...this.basicContextMenuItems];
+    const menuItems = [
+      { title: translate("menubar.edit"), getItems: () => this.basicContextMenuItems },
+    ];
     if (this.sceneSettings.selectedGlyph?.isEditing) {
       this.sceneController.updateContextMenuState(event);
       menuItems.push(MenuItemDivider);


### PR DESCRIPTION
This makes the context menu shorter. It was getting a bit out of hand. More to follow.