### PR TITLE
[background image] Add 'Add background image' menu to context menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2024-11-27
 
+- Add 'Add background image' menu to context menu [PR 1827](https://github.com/googlefonts/fontra/pull/1827)
 - Fixed bug with colorizing the background image on Safari [PR 1825](https://github.com/googlefonts/fontra/pull/1825)
 - Reorganize context menu: put "Edit" items under a sub menu [PR 1824](https://github.com/googlefonts/fontra/pull/1824)
 - Fix the Knife tool [PR 1823](https://github.com/googlefonts/fontra/pull/1823)

--- a/src/fontra/views/editor/scene-controller.js
+++ b/src/fontra/views/editor/scene-controller.js
@@ -793,6 +793,7 @@ export class SceneController {
           ),
         actionIdentifier: "action.decompose-component",
       },
+      { actionIdentifier: "action.glyph.add-background-image" },
       {
         title: () =>
           translate(


### PR DESCRIPTION
This was previously left out because the context menu was getting too crowded. This is getting better now.