### PR TITLE
Make sure to aclose the backend to avoid a warning

### DIFF
--- a/test-py/test_backends_workflow.py
+++ b/test-py/test_backends_workflow.py
@@ -1,4 +1,5 @@
 import pathlib
+from contextlib import aclosing
 
 from fontra.backends import getFileSystemBackend
 
@@ -9,12 +10,13 @@ workflowPath = dataDir / "mutatorsans" / "MutatorSans_workflow.yaml"
 async def test_workflow_backend():
     backend = getFileSystemBackend(workflowPath)
 
-    glyphMap = await backend.getGlyphMap()
+    async with aclosing(backend):
+        glyphMap = await backend.getGlyphMap()
 
-    assert {"A": [65, 97], "B": [66, 98]} == glyphMap
+        assert {"A": [65, 97], "B": [66, 98]} == glyphMap
 
-    glyph = await backend.getGlyph("A")
-    assert glyph is not None
+        glyph = await backend.getGlyph("A")
+        assert glyph is not None
 
-    glyph = await backend.getGlyph("C")
-    assert glyph is None
+        glyph = await backend.getGlyph("C")
+        assert glyph is None


### PR DESCRIPTION
Previously, this test code caused a warning on Python 3.13.