### PR TITLE
[fontra-workflow] Implement "fork" and "fork-merge" step styles

### DIFF
--- a/src/fontra/workflow/merger.py
+++ b/src/fontra/workflow/merger.py
@@ -30,6 +30,7 @@ logger = logging.getLogger(__name__)
 class FontBackendMerger:
     inputA: ReadableFontBackend
     inputB: ReadableFontBackend
+    warnAboutDuplicates: bool = True
 
     def __post_init__(self):
         self._glyphNamesA = None
@@ -63,7 +64,7 @@ class FontBackendMerger:
     async def getGlyph(self, glyphName: str) -> VariableGlyph | None:
         await self._prepareGlyphMap()
         if glyphName in self._glyphNamesB:
-            if glyphName in self._glyphNamesA:
+            if glyphName in self._glyphNamesA and self.warnAboutDuplicates:
                 logger.warning(f"Merger: Glyph {glyphName!r} exists in both fonts")
             return await self.inputB.getGlyph(glyphName)
         elif glyphName in self._glyphNamesA:

--- a/src/fontra/workflow/workflow.py
+++ b/src/fontra/workflow/workflow.py
@@ -181,7 +181,6 @@ class ForkActionStep:
     ) -> WorkflowEndPoints:
         # set up nested steps
         endPoints = await _prepareEndPoints(currentInput, self.steps, exitStack)
-
         return WorkflowEndPoints(endPoint=currentInput, outputs=endPoints.outputs)
 
 

--- a/src/fontra/workflow/workflow.py
+++ b/src/fontra/workflow/workflow.py
@@ -179,8 +179,6 @@ class ForkActionStep:
     async def setup(
         self, currentInput: ReadableFontBackend, exitStack
     ) -> WorkflowEndPoints:
-        # backend = await exitStack.enter_async_context(currentInput.connect(currentInput))
-
         # set up nested steps
         endPoints = await _prepareEndPoints(currentInput, self.steps, exitStack)
 

--- a/test-py/data/workflow/output-fork-A.fontra/font-data.json
+++ b/test-py/data/workflow/output-fork-A.fontra/font-data.json
@@ -1,0 +1,29 @@
+{
+"sources": {
+"5bea6334": {
+"name": "LightCondensed",
+"lineMetricsHorizontalLayout": {
+"ascender": {
+"value": 800,
+"zone": 16
+},
+"capHeight": {
+"value": 750,
+"zone": 16
+},
+"xHeight": {
+"value": 500,
+"zone": 16
+},
+"baseline": {
+"value": 0,
+"zone": -16
+},
+"descender": {
+"value": -250,
+"zone": -16
+}
+}
+}
+}
+}

--- a/test-py/data/workflow/output-fork-A.fontra/glyph-info.csv
+++ b/test-py/data/workflow/output-fork-A.fontra/glyph-info.csv
@@ -1,0 +1,2 @@
+glyph name;code points
+A;U+0041,U+0061

--- a/test-py/data/workflow/output-fork-A.fontra/glyphs/A^1.json
+++ b/test-py/data/workflow/output-fork-A.fontra/glyphs/A^1.json
@@ -1,0 +1,109 @@
+{
+"name": "A",
+"sources": [
+{
+"name": "LightCondensed",
+"layerName": "MutatorSansLightCondensed/foreground"
+}
+],
+"layers": {
+"MutatorSansLightCondensed/foreground": {
+"glyph": {
+"path": {
+"contours": [
+{
+"points": [
+{
+"x": 20,
+"y": 0
+},
+{
+"x": 60,
+"y": 0
+},
+{
+"x": 200,
+"y": 700
+},
+{
+"x": 165,
+"y": 700
+}
+],
+"isClosed": true
+},
+{
+"points": [
+{
+"x": 75,
+"y": 164
+},
+{
+"x": 325,
+"y": 164
+},
+{
+"x": 325,
+"y": 200
+},
+{
+"x": 75,
+"y": 200
+}
+],
+"isClosed": true
+},
+{
+"points": [
+{
+"x": 332,
+"y": 0
+},
+{
+"x": 376,
+"y": 0
+},
+{
+"x": 231,
+"y": 700
+},
+{
+"x": 192,
+"y": 700
+}
+],
+"isClosed": true
+},
+{
+"points": [
+{
+"x": 175,
+"y": 661
+},
+{
+"x": 222,
+"y": 661
+},
+{
+"x": 222,
+"y": 700
+},
+{
+"x": 175,
+"y": 700
+}
+],
+"isClosed": true
+}
+]
+},
+"xAdvance": 396
+}
+},
+"MutatorSansLightCondensed/support": {
+"glyph": {
+"xAdvance": 930
+}
+}
+}
+}

--- a/test-py/data/workflow/output-fork-B.fontra/font-data.json
+++ b/test-py/data/workflow/output-fork-B.fontra/font-data.json
@@ -1,0 +1,29 @@
+{
+"sources": {
+"5bea6334": {
+"name": "LightCondensed",
+"lineMetricsHorizontalLayout": {
+"ascender": {
+"value": 800,
+"zone": 16
+},
+"capHeight": {
+"value": 750,
+"zone": 16
+},
+"xHeight": {
+"value": 500,
+"zone": 16
+},
+"baseline": {
+"value": 0,
+"zone": -16
+},
+"descender": {
+"value": -250,
+"zone": -16
+}
+}
+}
+}
+}

--- a/test-py/data/workflow/output-fork-B.fontra/glyph-info.csv
+++ b/test-py/data/workflow/output-fork-B.fontra/glyph-info.csv
@@ -1,0 +1,2 @@
+glyph name;code points
+B;U+0042,U+0062

--- a/test-py/data/workflow/output-fork-B.fontra/glyphs/B^1.json
+++ b/test-py/data/workflow/output-fork-B.fontra/glyphs/B^1.json
@@ -1,0 +1,208 @@
+{
+"name": "B",
+"sources": [
+{
+"name": "LightCondensed",
+"layerName": "MutatorSansLightCondensed/foreground"
+}
+],
+"layers": {
+"MutatorSansLightCondensed/foreground": {
+"glyph": {
+"path": {
+"contours": [
+{
+"points": [
+{
+"x": 60,
+"y": 0
+},
+{
+"x": 100,
+"y": 0
+},
+{
+"x": 100,
+"y": 700
+},
+{
+"x": 60,
+"y": 700
+}
+],
+"isClosed": true
+},
+{
+"points": [
+{
+"x": 80,
+"y": 333
+},
+{
+"x": 210,
+"y": 333,
+"smooth": true
+},
+{
+"x": 315,
+"y": 333,
+"type": "cubic"
+},
+{
+"x": 364,
+"y": 269,
+"type": "cubic"
+},
+{
+"x": 364,
+"y": 183,
+"smooth": true
+},
+{
+"x": 364,
+"y": 93,
+"type": "cubic"
+},
+{
+"x": 312,
+"y": 36,
+"type": "cubic"
+},
+{
+"x": 200,
+"y": 36,
+"smooth": true
+},
+{
+"x": 80,
+"y": 36
+},
+{
+"x": 80,
+"y": 0
+},
+{
+"x": 190,
+"y": 0,
+"smooth": true
+},
+{
+"x": 343,
+"y": 0,
+"type": "cubic"
+},
+{
+"x": 403,
+"y": 79,
+"type": "cubic"
+},
+{
+"x": 403,
+"y": 183,
+"smooth": true
+},
+{
+"x": 403,
+"y": 273,
+"type": "cubic"
+},
+{
+"x": 353,
+"y": 351,
+"type": "cubic"
+},
+{
+"x": 233,
+"y": 361
+},
+{
+"x": 253,
+"y": 350
+},
+{
+"x": 342,
+"y": 366,
+"type": "cubic"
+},
+{
+"x": 383,
+"y": 439,
+"type": "cubic"
+},
+{
+"x": 383,
+"y": 517,
+"smooth": true
+},
+{
+"x": 383,
+"y": 618,
+"type": "cubic"
+},
+{
+"x": 341,
+"y": 700,
+"type": "cubic"
+},
+{
+"x": 180,
+"y": 700,
+"smooth": true
+},
+{
+"x": 80,
+"y": 700
+},
+{
+"x": 80,
+"y": 664
+},
+{
+"x": 190,
+"y": 664,
+"smooth": true
+},
+{
+"x": 310,
+"y": 664,
+"type": "cubic"
+},
+{
+"x": 344,
+"y": 603,
+"type": "cubic"
+},
+{
+"x": 344,
+"y": 517,
+"smooth": true
+},
+{
+"x": 344,
+"y": 431,
+"type": "cubic"
+},
+{
+"x": 295,
+"y": 368,
+"type": "cubic"
+},
+{
+"x": 190,
+"y": 368,
+"smooth": true
+},
+{
+"x": 80,
+"y": 368
+}
+],
+"isClosed": true
+}
+]
+},
+"xAdvance": 443
+}
+}
+}
+}

--- a/test-py/data/workflow/output-fork-merge.fontra/font-data.json
+++ b/test-py/data/workflow/output-fork-merge.fontra/font-data.json
@@ -1,0 +1,29 @@
+{
+"sources": {
+"5bea6334": {
+"name": "LightCondensed",
+"lineMetricsHorizontalLayout": {
+"ascender": {
+"value": 400,
+"zone": 8
+},
+"capHeight": {
+"value": 375,
+"zone": 8
+},
+"xHeight": {
+"value": 250,
+"zone": 8
+},
+"baseline": {
+"value": 0,
+"zone": -8
+},
+"descender": {
+"value": -125,
+"zone": -8
+}
+}
+}
+}
+}

--- a/test-py/data/workflow/output-fork-merge.fontra/glyph-info.csv
+++ b/test-py/data/workflow/output-fork-merge.fontra/glyph-info.csv
@@ -1,0 +1,3 @@
+glyph name;code points
+A;U+0041,U+0061
+B;U+0042,U+0062

--- a/test-py/data/workflow/output-fork-merge.fontra/glyphs/A^1.json
+++ b/test-py/data/workflow/output-fork-merge.fontra/glyphs/A^1.json
@@ -1,0 +1,109 @@
+{
+"name": "A",
+"sources": [
+{
+"name": "LightCondensed",
+"layerName": "MutatorSansLightCondensed/foreground"
+}
+],
+"layers": {
+"MutatorSansLightCondensed/foreground": {
+"glyph": {
+"path": {
+"contours": [
+{
+"points": [
+{
+"x": 20,
+"y": 0
+},
+{
+"x": 60,
+"y": 0
+},
+{
+"x": 200,
+"y": 700
+},
+{
+"x": 165,
+"y": 700
+}
+],
+"isClosed": true
+},
+{
+"points": [
+{
+"x": 75,
+"y": 164
+},
+{
+"x": 325,
+"y": 164
+},
+{
+"x": 325,
+"y": 200
+},
+{
+"x": 75,
+"y": 200
+}
+],
+"isClosed": true
+},
+{
+"points": [
+{
+"x": 332,
+"y": 0
+},
+{
+"x": 376,
+"y": 0
+},
+{
+"x": 231,
+"y": 700
+},
+{
+"x": 192,
+"y": 700
+}
+],
+"isClosed": true
+},
+{
+"points": [
+{
+"x": 175,
+"y": 661
+},
+{
+"x": 222,
+"y": 661
+},
+{
+"x": 222,
+"y": 700
+},
+{
+"x": 175,
+"y": 700
+}
+],
+"isClosed": true
+}
+]
+},
+"xAdvance": 396
+}
+},
+"MutatorSansLightCondensed/support": {
+"glyph": {
+"xAdvance": 930
+}
+}
+}
+}

--- a/test-py/data/workflow/output-fork-merge.fontra/glyphs/B^1.json
+++ b/test-py/data/workflow/output-fork-merge.fontra/glyphs/B^1.json
@@ -1,0 +1,208 @@
+{
+"name": "B",
+"sources": [
+{
+"name": "LightCondensed",
+"layerName": "MutatorSansLightCondensed/foreground"
+}
+],
+"layers": {
+"MutatorSansLightCondensed/foreground": {
+"glyph": {
+"path": {
+"contours": [
+{
+"points": [
+{
+"x": 30,
+"y": 0
+},
+{
+"x": 50,
+"y": 0
+},
+{
+"x": 50,
+"y": 350
+},
+{
+"x": 30,
+"y": 350
+}
+],
+"isClosed": true
+},
+{
+"points": [
+{
+"x": 40,
+"y": 166.5
+},
+{
+"x": 105,
+"y": 166.5,
+"smooth": true
+},
+{
+"x": 157.5,
+"y": 166.5,
+"type": "cubic"
+},
+{
+"x": 182,
+"y": 134.5,
+"type": "cubic"
+},
+{
+"x": 182,
+"y": 91.5,
+"smooth": true
+},
+{
+"x": 182,
+"y": 46.5,
+"type": "cubic"
+},
+{
+"x": 156,
+"y": 18,
+"type": "cubic"
+},
+{
+"x": 100,
+"y": 18,
+"smooth": true
+},
+{
+"x": 40,
+"y": 18
+},
+{
+"x": 40,
+"y": 0
+},
+{
+"x": 95,
+"y": 0,
+"smooth": true
+},
+{
+"x": 171.5,
+"y": 0,
+"type": "cubic"
+},
+{
+"x": 201.5,
+"y": 39.5,
+"type": "cubic"
+},
+{
+"x": 201.5,
+"y": 91.5,
+"smooth": true
+},
+{
+"x": 201.5,
+"y": 136.5,
+"type": "cubic"
+},
+{
+"x": 176.5,
+"y": 175.5,
+"type": "cubic"
+},
+{
+"x": 116.5,
+"y": 180.5
+},
+{
+"x": 126.5,
+"y": 175
+},
+{
+"x": 171,
+"y": 183,
+"type": "cubic"
+},
+{
+"x": 191.5,
+"y": 219.5,
+"type": "cubic"
+},
+{
+"x": 191.5,
+"y": 258.5,
+"smooth": true
+},
+{
+"x": 191.5,
+"y": 309,
+"type": "cubic"
+},
+{
+"x": 170.5,
+"y": 350,
+"type": "cubic"
+},
+{
+"x": 90,
+"y": 350,
+"smooth": true
+},
+{
+"x": 40,
+"y": 350
+},
+{
+"x": 40,
+"y": 332
+},
+{
+"x": 95,
+"y": 332,
+"smooth": true
+},
+{
+"x": 155,
+"y": 332,
+"type": "cubic"
+},
+{
+"x": 172,
+"y": 301.5,
+"type": "cubic"
+},
+{
+"x": 172,
+"y": 258.5,
+"smooth": true
+},
+{
+"x": 172,
+"y": 215.5,
+"type": "cubic"
+},
+{
+"x": 147.5,
+"y": 184,
+"type": "cubic"
+},
+{
+"x": 95,
+"y": 184,
+"smooth": true
+},
+{
+"x": 40,
+"y": 184
+}
+],
+"isClosed": true
+}
+]
+},
+"xAdvance": 221.5
+}
+}
+}
+}

--- a/test-py/test_workflow.py
+++ b/test-py/test_workflow.py
@@ -1364,6 +1364,30 @@ def test_command(tmpdir, configYAMLSources, substitutions):
             False,
             [],
         ),
+        (
+            "fork",
+            """
+            steps:
+            - input: fontra-read
+              source: "test-py/data/workflow/input1-A.fontra"
+            - filter: subset-axes
+              axisNames: []
+            - fork:
+              steps:
+              - filter: subset-glyphs
+                glyphNames: ["A"]
+              - output: fontra-write
+                destination: "output-fork-A.fontra"
+            - fork:
+              steps:
+              - filter: subset-glyphs
+                glyphNames: ["B"]
+              - output: fontra-write
+                destination: "output-fork-B.fontra"
+            """,
+            False,
+            [],
+        ),
     ],
 )
 async def test_workflow_actions(

--- a/test-py/test_workflow.py
+++ b/test-py/test_workflow.py
@@ -1388,6 +1388,26 @@ def test_command(tmpdir, configYAMLSources, substitutions):
             False,
             [],
         ),
+        (
+            "fork-merge",
+            """
+            steps:
+            - input: fontra-read
+              source: "test-py/data/workflow/input1-A.fontra"
+            - filter: subset-axes
+              axisNames: []
+            - fork-merge:
+              steps:
+              - filter: subset-glyphs
+                glyphNames: ["B"]
+              - filter: scale
+                scaleFactor: 0.5
+            - output: fontra-write
+              destination: "output-fork-merge.fontra"
+            """,
+            False,
+            [],
+        ),
     ],
 )
 async def test_workflow_actions(


### PR DESCRIPTION
With `fork:`, one can group multiple `output` steps and have common steps for pre-processing, without affecting the source pipeline.

With `fork-merge:` one can for example process a _subset_ of glyphs and merge the result back into the source pipeline.