### PR TITLE
Move sortedSourceIdentifiers to FontController

### DIFF
--- a/src/fontra/client/core/font-controller.js
+++ b/src/fontra/client/core/font-controller.js
@@ -23,7 +23,12 @@ import {
   uniqueID,
 } from "./utils.js";
 import { StaticGlyph, VariableGlyph } from "./var-glyph.js";
-import { locationToString, mapBackward, mapForward } from "./var-model.js";
+import {
+  locationToString,
+  mapAxesFromUserSpaceToSourceSpace,
+  mapBackward,
+  mapForward,
+} from "./var-model.js";
 
 const GLYPH_CACHE_SIZE = 2000;
 const BACKGROUND_IMAGE_CACHE_SIZE = 100;
@@ -130,6 +135,22 @@ export class FontController {
   async getSources() {
     // backwards compat, this.sources is the same
     return this._rootObject.sources;
+  }
+
+  async getSortedSourceIdentifiers() {
+    const fontAxesSourceSpace = mapAxesFromUserSpaceToSourceSpace(this.fontAxes);
+    const sortFunc = (identifierA, identifierB) => {
+      for (const axis of fontAxesSourceSpace) {
+        const valueA = this.sources[identifierA].location[axis.name];
+        const valueB = this.sources[identifierB].location[axis.name];
+        if (valueA === valueB) {
+          continue;
+        }
+        return valueA < valueB ? -1 : 0;
+      }
+      return 0;
+    };
+    return Object.keys(this.sources).sort(sortFunc);
   }
 
   getBackgroundImage(imageIdentifier) {

--- a/src/fontra/views/fontinfo/panel-sources.js
+++ b/src/fontra/views/fontinfo/panel-sources.js
@@ -50,10 +50,7 @@ export class SourcesPanel extends BaseInfoPanel {
       style: "display: grid; gap: 0.5em;",
     });
 
-    for (const identifier of sortedSourceIdentifiers(
-      sources,
-      this.fontAxesSourceSpace
-    )) {
+    for (const identifier of await this.fontController.getSortedSourceIdentifiers()) {
       if (!cardsInfos[identifier]) {
         cardsInfos[identifier] = {};
       }
@@ -619,21 +616,6 @@ class SourceBox extends HTMLElement {
 }
 
 customElements.define("source-box", SourceBox);
-
-function sortedSourceIdentifiers(sources, fontAxes) {
-  const sortFunc = (identifierA, identifierB) => {
-    for (const axis of fontAxes) {
-      const valueA = sources[identifierA].location[axis.name];
-      const valueB = sources[identifierB].location[axis.name];
-      if (valueA === valueB) {
-        continue;
-      }
-      return valueA < valueB ? -1 : 0;
-    }
-    return 0;
-  };
-  return Object.keys(sources).sort(sortFunc);
-}
 
 function buildElement(controller) {
   let items = [];


### PR DESCRIPTION
Fixes #1850

It would be great to have unittests for such methods, but I don't know how as we don't have any unittests for FontController, yet – and I don't know how to implement that. 
Also, I was thinking about to refactor `SourceBox` with replacing the arguments `this.fontAxesSourceSpace` and `sources` with `this.fontController` and then call `this.fontController.getSources()` and `mapAxesFromUserSpaceToSourceSpace` within `SourceBox`, but I think this has a negative impact to the performance, as we would do this then for each source while looping through all `sortedSourceIdentifiers`, why I didn't do it. 
So, I hope this PR is good to go.