### PR TITLE
Bugfix same destPath and sourcePath

### DIFF
--- a/src/fontra/backends/copy.py
+++ b/src/fontra/backends/copy.py
@@ -189,6 +189,12 @@ async def mainAsync() -> None:
     if not sourcePath.exists():
         raise FileNotFoundError(sourcePath)
     destPath = pathlib.Path(args.destination)
+
+    if destPath == sourcePath:
+        raise argparse.ArgumentError(
+            None, "the destination file is equal to the source file"
+        )
+
     if args:
         if destPath.is_dir():
             shutil.rmtree(destPath)


### PR DESCRIPTION
Fixes #1858 

The issue lives in         
```
if destPath.is_dir():
    shutil.rmtree(destPath)
```

As `.fontra` is a folder it get's removed. But because the sourcePath is equal to the destPath fontra-copy fails.

I think, as we don't have the concept of saving a file (because of auto-save) we should raise an error if someone tries to overwrite the sourcePath.

