### PR TITLE
add section to panel view

### DIFF
--- a/src/fontra/client/web-components/ui-accordion.js
+++ b/src/fontra/client/web-components/ui-accordion.js
@@ -5,14 +5,12 @@ import { enumerate } from "/core/utils.js";
 export class Accordion extends UnlitElement {
   static styles = `
   .ui-accordion-contents {
-    padding: 1em;
     display: grid;
     grid-template-rows: auto;
     align-content: start;
     gap: 0.5em;
     text-wrap: wrap;
     width: 100%;
-    height: 100%;
     box-sizing: border-box;
   }
 

--- a/src/fontra/client/web-components/ui-form.js
+++ b/src/fontra/client/web-components/ui-form.js
@@ -14,8 +14,6 @@ export class Form extends SimpleElement {
   static styles = `
     :host {
       --label-column-width: 32%;
-      padding: 1em;
-      overflow: hidden auto;
     }
 
     .ui-form {

--- a/src/fontra/views/editor/panel-designspace-navigation.js
+++ b/src/fontra/views/editor/panel-designspace-navigation.js
@@ -42,8 +42,29 @@ export default class DesignspaceNavigationPanel extends Panel {
   identifier = "designspace-navigation";
   iconPath = "/images/sliders.svg";
 
+  static stylesAccordion = `
+    .interpolation-error-icon {
+      display: inline-block;
+      height: 1.35em;
+      width: 1.35em;
+      color: var(--fontra-light-red-color);
+      transform: translate(0, 0.3em);
+      margin-right: 0.25em;
+    }
+  `;
+
   constructor(editorController) {
     super(editorController);
+
+    this.accordion = new Accordion();
+    this.accordion.appendStyle(DesignspaceNavigationPanel.stylesAccordion);
+    this.accordion.items = this.getAccordionItems();
+    this.contentElement.appendChild(
+      this.getPanelSection({
+        children: [this.accordion],
+      })
+    );
+
     this.fontController = this.editorController.fontController;
     this.sceneSettingsController = this.editorController.sceneSettingsController;
     this.sceneSettings = this.editorController.sceneSettingsController.model;
@@ -97,19 +118,8 @@ export default class DesignspaceNavigationPanel extends Panel {
     }
   }
 
-  getContentElement() {
-    const accordion = new Accordion();
-    accordion.appendStyle(`
-      .interpolation-error-icon {
-        display: inline-block;
-        height: 1.35em;
-        width: 1.35em;
-        color: var(--fontra-light-red-color);
-        transform: translate(0, 0.3em);
-        margin-right: 0.25em;
-      }
-    `);
-    accordion.items = [
+  getAccordionItems() {
+    return [
       {
         id: "font-axes-accordion-item",
         label: translate("sidebar.designspace-navigation.font-axes"),
@@ -209,28 +219,26 @@ export default class DesignspaceNavigationPanel extends Panel {
         ),
       },
     ];
-
-    return accordion;
   }
 
   get fontAxesElement() {
-    return this.contentElement.querySelector("#font-axes");
+    return this.accordion.querySelector("#font-axes");
   }
 
   get glyphAxesElement() {
-    return this.contentElement.querySelector("#glyph-axes");
+    return this.accordion.querySelector("#glyph-axes");
   }
 
   get glyphAxesAccordionItem() {
-    return this.contentElement.querySelector("#glyph-axes-accordion-item");
+    return this.accordion.querySelector("#glyph-axes-accordion-item");
   }
 
   get glyphSourcesAccordionItem() {
-    return this.contentElement.querySelector("#glyph-sources-accordion-item");
+    return this.accordion.querySelector("#glyph-sources-accordion-item");
   }
 
   get glyphLayersAccordionItem() {
-    return this.contentElement.querySelector("#glyph-layers-accordion-item");
+    return this.accordion.querySelector("#glyph-layers-accordion-item");
   }
 
   setup() {
@@ -366,7 +374,7 @@ export default class DesignspaceNavigationPanel extends Panel {
 
     const columnDescriptions = this._setupSourceListColumnDescriptions();
 
-    this.sourcesList = this.contentElement.querySelector("#sources-list");
+    this.sourcesList = this.accordion.querySelector("#sources-list");
     this.sourcesList.appendStyle(`
       .clickable-icon-header {
         transition: 150ms;
@@ -381,7 +389,7 @@ export default class DesignspaceNavigationPanel extends Panel {
     this.sourcesList.showHeader = true;
     this.sourcesList.columnDescriptions = columnDescriptions;
 
-    this.addRemoveSourceButtons = this.contentElement.querySelector(
+    this.addRemoveSourceButtons = this.accordion.querySelector(
       "#sources-list-add-remove-buttons"
     );
 
@@ -414,7 +422,7 @@ export default class DesignspaceNavigationPanel extends Panel {
       this.editSourceProperties(sourceIndex);
     });
 
-    this.sourceLayersList = this.contentElement.querySelector("#layers-list");
+    this.sourceLayersList = this.accordion.querySelector("#layers-list");
     this.sourceLayersList.columnDescriptions = [{ key: "shortName" }];
     this.sourceLayersList.addEventListener("listSelectionChanged", (event) => {
       const sourceItem = this.sourcesList.getSelectedItem();
@@ -625,12 +633,12 @@ export default class DesignspaceNavigationPanel extends Panel {
   _updateResetAllAxesButtonState() {
     let button;
     const fontAxesSourceSpace = mapAxesFromUserSpaceToSourceSpace(this.fontAxes);
-    button = this.contentElement.querySelector("#reset-font-axes-button");
+    button = this.accordion.querySelector("#reset-font-axes-button");
     button.disabled = isLocationAtDefault(
       this.sceneSettings.fontLocationSourceMapped,
       fontAxesSourceSpace
     );
-    button = this.contentElement.querySelector("#reset-glyph-axes-button");
+    button = this.accordion.querySelector("#reset-glyph-axes-button");
     button.disabled = isLocationAtDefault(
       this.sceneSettings.glyphLocation,
       this.glyphAxesElement.axes
@@ -1418,7 +1426,7 @@ export default class DesignspaceNavigationPanel extends Panel {
   }
 
   async _updateInterpolationErrorInfo() {
-    const infoElement = this.contentElement.querySelector("#interpolation-error-info");
+    const infoElement = this.accordion.querySelector("#interpolation-error-info");
     const varGlyphController =
       await this.sceneModel.getSelectedVariableGlyphController();
     const glyphController = await this.sceneModel.getSelectedStaticGlyphController();

--- a/src/fontra/views/editor/panel-glyph-note.js
+++ b/src/fontra/views/editor/panel-glyph-note.js
@@ -7,17 +7,7 @@ export default class GlyphNotePanel extends Panel {
   identifier = "glyph-note";
   iconPath = "/tabler-icons/notes.svg";
 
-  static styles = `
-    .sidebar-glyph-note {
-      box-sizing: border-box;
-      height: 100%;
-      width: 100%;
-      display: flex;
-      flex-direction: column;
-      gap: 0.5em;
-      padding: 1em;
-    }
-
+  static stylesContent = `
     #glyph-note-textarea {
       background-color: var(--text-input-background-color);
       color: var(--text-input-foreground-color);
@@ -37,10 +27,12 @@ export default class GlyphNotePanel extends Panel {
     }
 
     .glyph-note-header {
-      overflow-x: unset;
-      text-align: left;
-      text-wrap: wrap;
-      word-break: break-word;
+      margin-bottom: 0.5em;
+    }
+
+    .glyph-note-content {
+      display: flex;
+      flex-direction: column;
     }
   `;
 
@@ -49,6 +41,24 @@ export default class GlyphNotePanel extends Panel {
     this.throttledUpdate = throttleCalls((senderID) => this.update(senderID), 100);
     this.fontController = this.editorController.fontController;
     this.sceneController = this.editorController.sceneController;
+
+    this.appendStyle(GlyphNotePanel.stylesContent);
+    this.contentElement.appendChild(
+      this.getPanelSection({
+        children: [
+          html.div({ class: "glyph-note-header", id: "glyph-note-header" }, [
+            translate("sidebar.glyph-note"),
+          ]),
+          html.div({ class: "glyph-note-content" }, [
+            html.createDomElement("textarea", {
+              rows: 1,
+              wrap: "off",
+              id: "glyph-note-textarea",
+            }),
+          ]),
+        ],
+      })
+    );
 
     this.setupGlyphNoteElement();
 
@@ -60,24 +70,6 @@ export default class GlyphNotePanel extends Panel {
     this.sceneController.addCurrentGlyphChangeListener((event) => {
       this.throttledUpdate(event.senderID);
     });
-  }
-
-  getContentElement() {
-    return html.div(
-      {
-        class: "sidebar-glyph-note",
-      },
-      [
-        html.div({ class: "glyph-note-header", id: "glyph-note-header" }, [
-          translate("sidebar.glyph-note"),
-        ]),
-        html.createDomElement("textarea", {
-          rows: 1,
-          wrap: "off",
-          id: "glyph-note-textarea",
-        }),
-      ]
-    );
   }
 
   setupGlyphNoteElement() {

--- a/src/fontra/views/editor/panel-glyph-search.js
+++ b/src/fontra/views/editor/panel-glyph-search.js
@@ -5,19 +5,29 @@ export default class GlyphSearchPanel extends Panel {
   identifier = "glyph-search";
   iconPath = "/images/magnifyingglass.svg";
 
-  static styles = `
-    .glyph-search {
-      box-sizing: border-box;
-      height: 100%;
-      width: 100%;
-      display: grid;
-      gap: 1em;
-      padding: 1em;
-    }
-  `;
+  static stylesContent = `
+  .glyph-search {
+    box-sizing: border-box;
+    height: 100%;
+    width: 100%;
+    display: grid;
+    gap: 1em;
+    padding: 1em;
+  }
+`;
 
   constructor(editorController) {
     super(editorController);
+
+    this.appendStyle(GlyphSearchPanel.stylesContent);
+    this.contentElement.appendChild(
+      html.div({ class: "glyph-search" }, [
+        html.createDomElement("glyphs-search", {
+          id: "glyphs-search",
+        }),
+      ])
+    );
+
     this.glyphsSearch = this.contentElement.querySelector("#glyphs-search");
     this.glyphsSearch.addEventListener("selectedGlyphNameChanged", (event) =>
       this.glyphNameChangedCallback(event.detail)
@@ -57,19 +67,6 @@ export default class GlyphSearchPanel extends Panel {
     }
 
     this.editorController.sceneSettings.selectedGlyph = selectedGlyphState;
-  }
-
-  getContentElement() {
-    return html.div(
-      {
-        class: "glyph-search",
-      },
-      [
-        html.createDomElement("glyphs-search", {
-          id: "glyphs-search",
-        }),
-      ]
-    );
   }
 
   async toggle(on, focus) {

--- a/src/fontra/views/editor/panel-selection-info.js
+++ b/src/fontra/views/editor/panel-selection-info.js
@@ -23,32 +23,13 @@ export default class SelectionInfoPanel extends Panel {
   identifier = "selection-info";
   iconPath = "/images/info.svg";
 
-  static styles = `
-    .selection-info {
-      display: flex;
-      flex-direction: column;
-      justify-content: space-between;
-      box-sizing: border-box;
-      height: 100%;
-      width: 100%;
-      white-space: normal;
-    }
-
-    .selection-info-form {
-      flex: 1;
-    }
-
-    .behavior-field {
-      padding: 1em;
-    }
-  `;
-
   constructor(editorController) {
     super(editorController);
-    this.infoForm = new Form();
-    this.infoForm.classList.add("selection-info-form");
-    this.contentElement.appendChild(this.infoForm);
-    this.contentElement.appendChild(this.setupBehaviorCheckBox());
+    this.uiForm = new Form();
+    this.contentElement.appendChild(this.getPanelSection({ children: [this.uiForm] }));
+    this.contentElement.appendChild(
+      this.getPanelSection({ children: [this.getBehaviorField()], flexible: false })
+    );
     this.throttledUpdate = throttleCalls((senderID) => this.update(senderID), 100);
     this.fontController = this.editorController.fontController;
     this.sceneController = this.editorController.sceneController;
@@ -86,22 +67,13 @@ export default class SelectionInfoPanel extends Panel {
     });
   }
 
-  getContentElement() {
-    return html.div(
-      {
-        class: "selection-info",
-      },
-      []
-    );
-  }
-
   async toggle(on, focus) {
     if (on) {
       this.update();
     }
   }
 
-  setupBehaviorCheckBox() {
+  getBehaviorField() {
     const storageKey = "fontra.selection-info.absolute-value-changes";
     this.multiEditChangesAreAbsolute = localStorage.getItem(storageKey) === "true";
     return html.div({ class: "behavior-field" }, [
@@ -133,7 +105,7 @@ export default class SelectionInfoPanel extends Panel {
       await this.updateDimensions();
       return;
     }
-    if (!this.infoForm.contentElement.offsetParent) {
+    if (!this.uiForm.contentElement.offsetParent) {
       // If the info form is not visible, do nothing
       return;
     }
@@ -449,11 +421,11 @@ export default class SelectionInfoPanel extends Panel {
     }
 
     if (!formContents.length) {
-      this.infoForm.setFieldDescriptions([
+      this.uiForm.setFieldDescriptions([
         { type: "text", value: translate("selection.none") },
       ]);
     } else {
-      this.infoForm.setFieldDescriptions(formContents);
+      this.uiForm.setFieldDescriptions(formContents);
       if (glyphController) {
         await this._setupSelectionInfoHandlers(glyphName);
       }
@@ -477,7 +449,7 @@ export default class SelectionInfoPanel extends Panel {
       }
     }
 
-    const iconElement = this.infoForm.shadowRoot.querySelectorAll("#glyphLocking")[0];
+    const iconElement = this.uiForm.shadowRoot.querySelectorAll("#glyphLocking")[0];
     iconElement.src = varGlyph.customData["fontra.glyph.locked"]
       ? "/tabler-icons/lock-open-2.svg"
       : "/tabler-icons/lock.svg";
@@ -586,8 +558,8 @@ export default class SelectionInfoPanel extends Panel {
       pointIndices,
       componentIndices
     );
-    if (this.infoForm.hasKey("dimensions")) {
-      this.infoForm.setValue("dimensions", dimensionsString);
+    if (this.uiForm.hasKey("dimensions")) {
+      this.uiForm.setValue("dimensions", dimensionsString);
     }
   }
 
@@ -642,7 +614,7 @@ export default class SelectionInfoPanel extends Panel {
   async _setupSelectionInfoHandlers(glyphName) {
     const varGlyph = await this.fontController.getGlyph(glyphName);
 
-    this.infoForm.onFieldChange = async (fieldItem, value, valueStream) => {
+    this.uiForm.onFieldChange = async (fieldItem, value, valueStream) => {
       const changePath = JSON.parse(fieldItem.key);
       const senderInfo = { senderID: this, fieldKeyPath: changePath };
 
@@ -731,7 +703,7 @@ export default class SelectionInfoPanel extends Panel {
 
     const keyToUpdata = keyMap[changedKey];
     const fieldKey = JSON.stringify([keyToUpdata]);
-    this.infoForm.setValue(fieldKey, glyphController[keyToUpdata]);
+    this.uiForm.setValue(fieldKey, glyphController[keyToUpdata]);
   }
 }
 

--- a/src/fontra/views/editor/panel-text-entry.js
+++ b/src/fontra/views/editor/panel-text-entry.js
@@ -6,22 +6,13 @@ export default class TextEntryPanel extends Panel {
   identifier = "text-entry";
   iconPath = "/images/texttool.svg";
 
-  static styles = `
-    .sidebar-text-entry {
-      box-sizing: border-box;
-      height: 100%;
-      width: 100%;
-      display: flex;
-      flex-direction: column;
-      gap: 0.5em;
-      padding: 1em;
-    }
-
+  static stylesContent = `
     #text-align-menu {
       display: grid;
       grid-template-columns: auto auto auto;
       justify-content: start;
       gap: 0.5em;
+      margin: 1em 0;
     }
 
     #text-align-menu > inline-svg {
@@ -59,10 +50,50 @@ export default class TextEntryPanel extends Panel {
       resize: none;
       overflow-x: auto;
     }
+
+    .text-entry {
+      display: flex;
+      flex-direction: column;
+    }
   `;
 
   constructor(editorController) {
     super(editorController);
+
+    this.appendStyle(TextEntryPanel.stylesContent);
+    this.contentElement.appendChild(
+      this.getPanelSection({
+        children: [
+          html.div({ class: "text-entry" }, [
+            html.createDomElement("textarea", {
+              rows: 1,
+              wrap: "off",
+              id: "text-entry-textarea",
+            }),
+          ]),
+          html.div(
+            {
+              id: "text-align-menu",
+            },
+            [
+              html.createDomElement("inline-svg", {
+                "data-align": "left",
+                "src": "/images/alignleft.svg",
+              }),
+              html.createDomElement("inline-svg", {
+                "class": "selected",
+                "data-align": "center",
+                "src": "/images/aligncenter.svg",
+              }),
+              html.createDomElement("inline-svg", {
+                "data-align": "right",
+                "src": "/images/alignright.svg",
+              }),
+            ]
+          ),
+        ],
+      })
+    );
 
     this.textSettingsController = this.editorController.sceneSettingsController;
     this.sceneController = this.editorController.sceneController;
@@ -71,41 +102,6 @@ export default class TextEntryPanel extends Panel {
     this.setupTextEntryElement();
     this.setupTextAlignElement();
     this.setupIntersectionObserver();
-  }
-
-  getContentElement() {
-    return html.div(
-      {
-        class: "sidebar-text-entry",
-      },
-      [
-        html.createDomElement("textarea", {
-          rows: 1,
-          wrap: "off",
-          id: "text-entry-textarea",
-        }),
-        html.div(
-          {
-            id: "text-align-menu",
-          },
-          [
-            html.createDomElement("inline-svg", {
-              "data-align": "left",
-              "src": "/images/alignleft.svg",
-            }),
-            html.createDomElement("inline-svg", {
-              "class": "selected",
-              "data-align": "center",
-              "src": "/images/aligncenter.svg",
-            }),
-            html.createDomElement("inline-svg", {
-              "data-align": "right",
-              "src": "/images/alignright.svg",
-            }),
-          ]
-        ),
-      ]
-    );
   }
 
   updateAlignElement(align) {

--- a/src/fontra/views/editor/panel-transformation.js
+++ b/src/fontra/views/editor/panel-transformation.js
@@ -32,22 +32,6 @@ export default class TransformationPanel extends Panel {
   identifier = "selection-transformation";
   iconPath = "/tabler-icons/shape.svg";
 
-  static styles = `
-    .selection-transformation {
-      display: flex;
-      flex-direction: column;
-      justify-content: space-between;
-      box-sizing: border-box;
-      height: 100%;
-      width: 100%;
-      white-space: normal;
-    }
-
-    .selection-transformation-form {
-      flex: 1;
-    }
-  `;
-
   static stylesForm = `
   .ui-form-label {
     overflow-x: unset;
@@ -83,13 +67,11 @@ export default class TransformationPanel extends Panel {
 
   constructor(editorController) {
     super(editorController);
-    this.infoForm = new Form();
-    this.infoForm.classList.add("selection-transformation-form");
-    this.infoForm.appendStyle(TransformationPanel.stylesForm);
-    this.contentElement.appendChild(this.infoForm);
+    this.uiForm = new Form();
+    this.uiForm.appendStyle(TransformationPanel.stylesForm);
+    this.contentElement.appendChild(this.getPanelSection({ children: [this.uiForm] }));
     this.fontController = this.editorController.fontController;
     this.sceneController = this.editorController.sceneController;
-
     this.transformParameters = {
       scaleX: 100,
       scaleY: undefined,
@@ -146,17 +128,8 @@ export default class TransformationPanel extends Panel {
     }
   }
 
-  getContentElement() {
-    return html.div(
-      {
-        class: "selection-transformation",
-      },
-      []
-    );
-  }
-
   async update(senderInfo) {
-    if (!this.infoForm.contentElement.offsetParent) {
+    if (!this.uiForm.contentElement.offsetParent) {
       // If the info form is not visible, do nothing
       return;
     }
@@ -556,14 +529,14 @@ export default class TransformationPanel extends Panel {
       field3: {},
     });
 
-    this.infoForm.setFieldDescriptions(formContents);
+    this.uiForm.setFieldDescriptions(formContents);
 
-    this.infoForm.onFieldChange = async (fieldItem, value, valueStream) => {
+    this.uiForm.onFieldChange = async (fieldItem, value, valueStream) => {
       this.transformParameters[fieldItem.key] = value;
       if (fieldItem.key === "originXButton" || fieldItem.key === "originYButton") {
         this.transformParameters[fieldItem.key.replace("Button", "")] = value;
 
-        const iconRadioButtons = this.infoForm.shadowRoot.querySelectorAll(
+        const iconRadioButtons = this.uiForm.shadowRoot.querySelectorAll(
           ".ui-form-radio-button"
         );
         iconRadioButtons.forEach((radioButton) => {

--- a/src/fontra/views/editor/panel.js
+++ b/src/fontra/views/editor/panel.js
@@ -1,14 +1,50 @@
-import { SimpleElement } from "/core/html-utils.js";
+import { SimpleElement, div } from "/core/html-utils.js";
 
 export default class Panel extends SimpleElement {
+  static styles = `
+    .panel {
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+      box-sizing: border-box;
+      height: 100%;
+      white-space: normal;
+    }
+
+    .panel-section {
+      padding: 1em;
+      overflow: hidden auto;
+    }
+
+    .panel-section--flex {
+      flex: 1;
+    }
+  `;
+
   constructor(editorController) {
     super();
     this.editorController = editorController;
-    this.contentElement = this.getContentElement();
+    this.contentElement = div(
+      {
+        class: "panel",
+      },
+      []
+    );
     this.shadowRoot.appendChild(this.contentElement);
   }
 
-  getContentElement() {}
+  getPanelSection({ children = [], flexible = true }) {
+    const classes = ["panel-section"];
+    if (flexible) {
+      classes.push("panel-section--flex");
+    }
+    return div(
+      {
+        class: classes.join(" "),
+      },
+      children
+    );
+  }
 
   async toggle(on, focus) {}
 }


### PR DESCRIPTION
This adds the possibility to wrap panel contents in multiple auto-scrollable sections. So overflow logic is separated from contents.

**Changes**

+ removed `getContentElement` function for wrapper consistency
+ added `getPanelSection` factory to handle overflow of contents (this removed the extraneous styles from `ui-form`)
+ deferred use of `static styles` in panel class extensions 
+ implement panel sections across the application
