### PR TITLE
Glyphs search refactor 2

### DIFF
--- a/src/fontra/client/web-components/glyphs-search-field.js
+++ b/src/fontra/client/web-components/glyphs-search-field.js
@@ -28,10 +28,8 @@ export class GlyphsSearchField extends SimpleElement {
     }
   `;
 
-  constructor(glyphsListItemsController, controllerKey) {
+  constructor() {
     super();
-    this.glyphsListItemsController = glyphsListItemsController;
-    this.controllerKey = controllerKey;
     this.searchField = html.input({
       type: "text",
       placeholder: translate("sidebar.glyphs.search"),
@@ -41,35 +39,11 @@ export class GlyphsSearchField extends SimpleElement {
 
     this._glyphNamesListFilterFunc = (item) => true; // pass all through
 
-    this.glyphMap = {};
-
     this.shadowRoot.appendChild(this.searchField);
   }
 
   focusSearchField() {
     this.searchField.focus();
-  }
-
-  get glyphMap() {
-    return this._glyphMap;
-  }
-
-  set glyphMap(glyphMap) {
-    this._glyphMap = glyphMap;
-    this.updateGlyphNamesListContent();
-  }
-
-  updateGlyphNamesListContent() {
-    const glyphMap = this.glyphMap;
-    this.glyphsListItems = [];
-    for (const glyphName in glyphMap) {
-      this.glyphsListItems.push({
-        glyphName: glyphName,
-        unicodes: glyphMap[glyphName],
-      });
-    }
-    this.glyphsListItems.sort(glyphItemSortFunc);
-    this._setFilteredGlyphNamesListContent();
   }
 
   _searchFieldChanged(event) {
@@ -80,21 +54,24 @@ export class GlyphsSearchField extends SimpleElement {
       .map((item) => item.codePointAt(0).toString(16).toUpperCase().padStart(4, "0"));
     searchItems.push(...hexSearchItems);
     this._glyphNamesListFilterFunc = (item) => glyphFilterFunc(item, searchItems);
-    this._setFilteredGlyphNamesListContent();
+    this.oninput?.(event);
   }
 
-  _setFilteredGlyphNamesListContent() {
-    const filteredGlyphItems = this.glyphsListItems.filter(
-      this._glyphNamesListFilterFunc
-    );
-    this.glyphsListItemsController.model[this.controllerKey] = filteredGlyphItems;
+  sortGlyphs(glyphs) {
+    glyphs = [...glyphs];
+    glyphs.sort(glyphItemSortFunc);
+    return glyphs;
+  }
+
+  filterGlyphs(glyphs) {
+    return glyphs.filter(this._glyphNamesListFilterFunc);
   }
 }
 
 customElements.define("glyphs-search-field", GlyphsSearchField);
 
 function glyphItemSortFunc(item1, item2) {
-  const uniCmp = compare(item1.unicodes[0], item2.unicodes[0]);
+  const uniCmp = compare(item1.codePoints[0], item2.codePoints[0]);
   const glyphNameCmp = compare(item1.glyphName, item2.glyphName);
   return uniCmp ? uniCmp : glyphNameCmp;
 }
@@ -107,8 +84,8 @@ function glyphFilterFunc(item, searchItems) {
     if (item.glyphName.indexOf(searchString) >= 0) {
       return true;
     }
-    if (item.unicodes[0] !== undefined) {
-      const char = String.fromCodePoint(item.unicodes[0]);
+    if (item.codePoints[0] !== undefined) {
+      const char = String.fromCodePoint(item.codePoints[0]);
       if (searchString === char) {
         return true;
       }

--- a/src/fontra/client/web-components/glyphs-search-field.js
+++ b/src/fontra/client/web-components/glyphs-search-field.js
@@ -70,12 +70,6 @@ export class GlyphsSearchField extends SimpleElement {
 
 customElements.define("glyphs-search-field", GlyphsSearchField);
 
-function glyphItemSortFunc(item1, item2) {
-  const uniCmp = compare(item1.codePoints[0], item2.codePoints[0]);
-  const glyphNameCmp = compare(item1.glyphName, item2.glyphName);
-  return uniCmp ? uniCmp : glyphNameCmp;
-}
-
 function glyphFilterFunc(item, searchItems) {
   if (!searchItems.length) {
     return true;
@@ -92,6 +86,12 @@ function glyphFilterFunc(item, searchItems) {
     }
   }
   return false;
+}
+
+function glyphItemSortFunc(item1, item2) {
+  const uniCmp = compare(item1.codePoints[0], item2.codePoints[0]);
+  const glyphNameCmp = compare(item1.glyphName, item2.glyphName);
+  return uniCmp ? uniCmp : glyphNameCmp;
 }
 
 function compare(a, b) {

--- a/src/fontra/client/web-components/glyphs-search-list.js
+++ b/src/fontra/client/web-components/glyphs-search-list.js
@@ -2,7 +2,6 @@ import { GlyphsSearchField } from "./glyphs-search-field.js";
 import { UIList } from "./ui-list.js";
 import * as html from "/core/html-utils.js";
 import { SimpleElement } from "/core/html-utils.js";
-import { ObservableController } from "/core/observable-object.js";
 import {
   getCharFromCodePoint,
   guessCharFromGlyphName,


### PR DESCRIPTION
This moves some responsibilities from glyphs-search-field to glyphs-search-list for a cleaner separation of concerns.

This also changes the use of the name `unicodes` to `codePoints`, like we do elsewhere.

This will break #1849, will fix there.