### PR TITLE
[font overview] use settings object

### DIFF
--- a/src/fontra/client/core/glyph-organizer.js
+++ b/src/fontra/client/core/glyph-organizer.js
@@ -1,0 +1,63 @@
+export class GlyphOrganizer {
+  constructor() {
+    this._glyphNamesListFilterFunc = (item) => true; // pass all through
+  }
+
+  setSearchString(searchString) {
+    const searchItems = searchString.split(/\s+/).filter((item) => item.length);
+    const hexSearchItems = searchItems
+      .filter((item) => [...item].length === 1) // num chars, not utf16 units!
+      .map((item) => item.codePointAt(0).toString(16).toUpperCase().padStart(4, "0"));
+    searchItems.push(...hexSearchItems);
+    this._glyphNamesListFilterFunc = (item) => glyphFilterFunc(item, searchItems);
+  }
+
+  sortGlyphs(glyphs) {
+    glyphs = [...glyphs];
+    glyphs.sort(glyphItemSortFunc);
+    return glyphs;
+  }
+
+  filterGlyphs(glyphs) {
+    return glyphs.filter(this._glyphNamesListFilterFunc);
+  }
+}
+
+function glyphFilterFunc(item, searchItems) {
+  if (!searchItems.length) {
+    return true;
+  }
+  for (const searchString of searchItems) {
+    if (item.glyphName.indexOf(searchString) >= 0) {
+      return true;
+    }
+    if (item.codePoints[0] !== undefined) {
+      const char = String.fromCodePoint(item.codePoints[0]);
+      if (searchString === char) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function glyphItemSortFunc(item1, item2) {
+  const uniCmp = compare(item1.codePoints[0], item2.codePoints[0]);
+  const glyphNameCmp = compare(item1.glyphName, item2.glyphName);
+  return uniCmp ? uniCmp : glyphNameCmp;
+}
+
+function compare(a, b) {
+  // sort undefined at the end
+  if (a === b) {
+    return 0;
+  } else if (a === undefined) {
+    return 1;
+  } else if (b === undefined) {
+    return -1;
+  } else if (a < b) {
+    return -1;
+  } else {
+    return 1;
+  }
+}

--- a/src/fontra/client/web-components/glyph-cell-view.js
+++ b/src/fontra/client/web-components/glyph-cell-view.js
@@ -1,6 +1,5 @@
 import * as html from "/core/html-utils.js";
 import { translate } from "/core/localization.js";
-import { ObservableController } from "/core/observable-object.js";
 import { difference, intersection, symmetricDifference, union } from "/core/set-ops.js";
 import { enumerate } from "/core/utils.js";
 import { GlyphCell } from "/web-components/glyph-cell.js";

--- a/src/fontra/client/web-components/glyph-cell-view.js
+++ b/src/fontra/client/web-components/glyph-cell-view.js
@@ -7,11 +7,12 @@ import { GlyphCell } from "/web-components/glyph-cell.js";
 import { Accordion } from "/web-components/ui-accordion.js";
 
 export class GlyphCellView extends HTMLElement {
-  constructor(fontController, locationController) {
+  constructor(fontController, observer, options) {
     super();
 
     this.fontController = fontController;
-    this.locationController = locationController;
+    this.observer = observer;
+    this.locationKey = options?.locationKey || "fontLocationSourceMapped";
 
     this.glyphSelectionController = new ObservableController({ selection: new Set() });
     this.glyphSelectionController.addKeyListener("selection", (event) => {
@@ -130,8 +131,8 @@ export class GlyphCellView extends HTMLElement {
         this.fontController,
         glyphName,
         codePoints,
-        this.locationController,
-        "fontLocationSourceMapped"
+        this.observer,
+        this.locationKey
       );
       glyphCell.onclick = (event) => {
         this.handleSingleClick(event, glyphCell);

--- a/src/fontra/client/web-components/glyph-cell-view.js
+++ b/src/fontra/client/web-components/glyph-cell-view.js
@@ -6,15 +6,15 @@ import { GlyphCell } from "/web-components/glyph-cell.js";
 import { Accordion } from "/web-components/ui-accordion.js";
 
 export class GlyphCellView extends HTMLElement {
-  constructor(fontController, observer, options) {
+  constructor(fontController, settingsController, options) {
     super();
 
     this.fontController = fontController;
-    this.observer = observer;
+    this.settingsController = settingsController;
     this.locationKey = options?.locationKey || "fontLocationSourceMapped";
     this.glyphSelectionKey = options?.glyphSelectionKey || "glyphSelection";
 
-    this.observer.addKeyListener(this.glyphSelectionKey, (event) => {
+    this.settingsController.addKeyListener(this.glyphSelectionKey, (event) => {
       const selection = event.newValue;
       const diff = symmetricDifference(selection, event.oldValue);
       this.forEachGlyphCell((glyphCell) => {
@@ -130,7 +130,7 @@ export class GlyphCellView extends HTMLElement {
         this.fontController,
         glyphName,
         codePoints,
-        this.observer,
+        this.settingsController,
         this.locationKey
       );
       glyphCell.onclick = (event) => {
@@ -158,11 +158,11 @@ export class GlyphCellView extends HTMLElement {
   }
 
   get glyphSelection() {
-    return this.observer.model[this.glyphSelectionKey];
+    return this.settingsController.model[this.glyphSelectionKey];
   }
 
   set glyphSelection(selection) {
-    this.observer.model[this.glyphSelectionKey] = selection;
+    this.settingsController.model[this.glyphSelectionKey] = selection;
   }
 
   forEachGlyphCell(func) {

--- a/src/fontra/client/web-components/glyph-cell-view.js
+++ b/src/fontra/client/web-components/glyph-cell-view.js
@@ -13,9 +13,9 @@ export class GlyphCellView extends HTMLElement {
     this.fontController = fontController;
     this.observer = observer;
     this.locationKey = options?.locationKey || "fontLocationSourceMapped";
+    this.glyphSelectionKey = options?.glyphSelectionKey || "glyphSelection";
 
-    this.glyphSelectionController = new ObservableController({ selection: new Set() });
-    this.glyphSelectionController.addKeyListener("selection", (event) => {
+    this.observer.addKeyListener(this.glyphSelectionKey, (event) => {
       const selection = event.newValue;
       const diff = symmetricDifference(selection, event.oldValue);
       this.forEachGlyphCell((glyphCell) => {
@@ -159,11 +159,11 @@ export class GlyphCellView extends HTMLElement {
   }
 
   get glyphSelection() {
-    return this.glyphSelectionController.model.selection;
+    return this.observer.model[this.glyphSelectionKey];
   }
 
   set glyphSelection(selection) {
-    this.glyphSelectionController.model.selection = selection;
+    this.observer.model[this.glyphSelectionKey] = selection;
   }
 
   forEachGlyphCell(func) {

--- a/src/fontra/client/web-components/glyph-cell.js
+++ b/src/fontra/client/web-components/glyph-cell.js
@@ -64,8 +64,6 @@ export class GlyphCell extends UnlitElement {
 
   .glyph-name-label {
     font-size: 0.85em;
-    padding-left: 0.3em;
-    padding-right: 0.3em;
     overflow-x: hidden;
     text-overflow: ellipsis;
     text-overflow: ellipsis;

--- a/src/fontra/client/web-components/glyph-search-field.js
+++ b/src/fontra/client/web-components/glyph-search-field.js
@@ -28,7 +28,7 @@ export class GlyphSearchField extends SimpleElement {
     }
   `;
 
-  constructor() {
+  constructor(options) {
     super();
     this.searchField = html.input({
       type: "text",
@@ -37,9 +37,19 @@ export class GlyphSearchField extends SimpleElement {
       oninput: (event) => this._searchFieldChanged(event),
     });
 
-    this._glyphNamesListFilterFunc = (item) => true; // pass all through
+    if (options?.observer) {
+      this._observer = options.observer;
+      this._observerKey = options.observerKey || "searchString";
+      this._observer.addKeyListener(this._observerKey, (event) => {
+        this.searchField.value = event.newValue;
+      });
+    }
 
     this.shadowRoot.appendChild(this.searchField);
+  }
+
+  get searchString() {
+    return this.searchField.value;
   }
 
   focusSearchField() {
@@ -47,66 +57,16 @@ export class GlyphSearchField extends SimpleElement {
   }
 
   _searchFieldChanged(event) {
+    event.preventDefault();
+    event.stopImmediatePropagation();
     const value = event.target.value;
-    const searchItems = value.split(/\s+/).filter((item) => item.length);
-    const hexSearchItems = searchItems
-      .filter((item) => [...item].length === 1) // num chars, not utf16 units!
-      .map((item) => item.codePointAt(0).toString(16).toUpperCase().padStart(4, "0"));
-    searchItems.push(...hexSearchItems);
-    this._glyphNamesListFilterFunc = (item) => glyphFilterFunc(item, searchItems);
+
+    if (this._observer) {
+      this._observer.model[this._observerKey] = value;
+    }
 
     this.onSearchFieldChanged?.(event);
-  }
-
-  sortGlyphs(glyphs) {
-    // This arguably doesn't belong here
-    glyphs = [...glyphs];
-    glyphs.sort(glyphItemSortFunc);
-    return glyphs;
-  }
-
-  filterGlyphs(glyphs) {
-    return glyphs.filter(this._glyphNamesListFilterFunc);
   }
 }
 
 customElements.define("glyph-search-field", GlyphSearchField);
-
-function glyphFilterFunc(item, searchItems) {
-  if (!searchItems.length) {
-    return true;
-  }
-  for (const searchString of searchItems) {
-    if (item.glyphName.indexOf(searchString) >= 0) {
-      return true;
-    }
-    if (item.codePoints[0] !== undefined) {
-      const char = String.fromCodePoint(item.codePoints[0]);
-      if (searchString === char) {
-        return true;
-      }
-    }
-  }
-  return false;
-}
-
-function glyphItemSortFunc(item1, item2) {
-  const uniCmp = compare(item1.codePoints[0], item2.codePoints[0]);
-  const glyphNameCmp = compare(item1.glyphName, item2.glyphName);
-  return uniCmp ? uniCmp : glyphNameCmp;
-}
-
-function compare(a, b) {
-  // sort undefined at the end
-  if (a === b) {
-    return 0;
-  } else if (a === undefined) {
-    return 1;
-  } else if (b === undefined) {
-    return -1;
-  } else if (a < b) {
-    return -1;
-  } else {
-    return 1;
-  }
-}

--- a/src/fontra/client/web-components/glyph-search-field.js
+++ b/src/fontra/client/web-components/glyph-search-field.js
@@ -37,10 +37,10 @@ export class GlyphSearchField extends SimpleElement {
       oninput: (event) => this._searchFieldChanged(event),
     });
 
-    if (options?.observer) {
-      this._observer = options.observer;
-      this._observerKey = options.observerKey || "searchString";
-      this._observer.addKeyListener(this._observerKey, (event) => {
+    if (options?.settingsController) {
+      this._settingsController = options.settingsController;
+      this._searchStringKey = options.searchStringKey || "searchString";
+      this._settingsController.addKeyListener(this._searchStringKey, (event) => {
         this.searchField.value = event.newValue;
       });
     }
@@ -61,8 +61,8 @@ export class GlyphSearchField extends SimpleElement {
     event.stopImmediatePropagation();
     const value = event.target.value;
 
-    if (this._observer) {
-      this._observer.model[this._observerKey] = value;
+    if (this._settingsController) {
+      this._settingsController.model[this._searchStringKey] = value;
     }
 
     this.onSearchFieldChanged?.(event);

--- a/src/fontra/client/web-components/glyph-search-list.js
+++ b/src/fontra/client/web-components/glyph-search-list.js
@@ -1,5 +1,6 @@
 import { GlyphSearchField } from "./glyph-search-field.js";
 import { UIList } from "./ui-list.js";
+import { GlyphOrganizer } from "/core/glyph-organizer.js";
 import * as html from "/core/html-utils.js";
 import { SimpleElement } from "/core/html-utils.js";
 import {
@@ -25,12 +26,14 @@ export class GlyphSearchList extends SimpleElement {
   constructor() {
     super();
 
+    this.glyphOrganizer = new GlyphOrganizer();
+
     this.searchField = new GlyphSearchField();
     this.glyphNamesList = this._makeGlyphNamesList();
 
     this.throttledUpdate = throttleCalls(() => this.update(), 50);
 
-    this.searchField.oninput = (event) => this.throttledUpdate();
+    this.searchField.onSearchFieldChanged = (event) => this.throttledUpdate();
 
     this.shadowRoot.appendChild(this.searchField);
     this.shadowRoot.appendChild(this.glyphNamesList);
@@ -101,14 +104,15 @@ export class GlyphSearchList extends SimpleElement {
   }
 
   updateGlyphNamesListContent() {
-    this.glyphsListItems = this.searchField.sortGlyphs(
+    this.glyphOrganizer.setSearchString(this.searchField.searchString);
+    this.glyphsListItems = this.glyphOrganizer.sortGlyphs(
       glyphMapToItemList(this.glyphMap)
     );
     this._setFilteredGlyphNamesListContent();
   }
 
   _setFilteredGlyphNamesListContent() {
-    const filteredGlyphItems = this.searchField.filterGlyphs(this.glyphsListItems);
+    const filteredGlyphItems = this.glyphOrganizer.filterGlyphs(this.glyphsListItems);
     this.glyphNamesList.setItems(filteredGlyphItems);
   }
 

--- a/src/fontra/views/fontoverview/fontoverview.js
+++ b/src/fontra/views/fontoverview/fontoverview.js
@@ -33,15 +33,15 @@ export class FontOverviewController extends ViewController {
 
     this.fontSources = await this.fontController.getSources();
 
-    this.fontOverviewSettingsObserver = new ObservableController({
+    this.fontOverviewSettingsController = new ObservableController({
       searchString: "",
       fontSourceIdentifier: null,
       fontLocationSourceMapped: {},
       glyphSelection: new Set(),
     });
-    this.fontOverviewSettings = this.fontOverviewSettingsObserver.model;
+    this.fontOverviewSettings = this.fontOverviewSettingsController.model;
 
-    this.fontOverviewSettingsObserver.addKeyListener(
+    this.fontOverviewSettingsController.addKeyListener(
       "fontSourceIdentifier",
       (event) => {
         const sourceLocation = {
@@ -58,7 +58,7 @@ export class FontOverviewController extends ViewController {
     this.fontOverviewSettings.fontSourceIdentifier =
       this.fontController.fontSourcesInstancer.defaultSourceIdentifier;
 
-    this.fontOverviewSettingsObserver.addKeyListener("searchString", (event) => {
+    this.fontOverviewSettingsController.addKeyListener("searchString", (event) => {
       this.glyphOrganizer.setSearchString(event.newValue);
       this.updateGlyphSelection();
     });
@@ -79,7 +79,7 @@ export class FontOverviewController extends ViewController {
 
     this.glyphCellView = new GlyphCellView(
       this.fontController,
-      this.fontOverviewSettingsObserver
+      this.fontOverviewSettingsController
     );
 
     // // This is how we can change the cell size:

--- a/src/fontra/views/fontoverview/fontoverview.js
+++ b/src/fontra/views/fontoverview/fontoverview.js
@@ -44,9 +44,12 @@ export class FontOverviewController extends ViewController {
     this.fontOverviewSettingsObserver.addKeyListener(
       "fontSourceIdentifier",
       (event) => {
-        this.fontOverviewSettings.fontLocationSourceMapped = {
+        const sourceLocation = {
           ...this.fontSources[event.newValue]?.location,
-        }; // A font may not have any font sources, therefore the ?-check.,
+        }; // A font may not have any font sources, therefore the ?-check
+
+        this.fontOverviewSettings.fontLocationSourceMapped =
+          this.fontController.mapSourceLocationToUserLocation(sourceLocation);
       }
     );
     // Note: once we add an axis slider UI, we should do the opposite mapping,

--- a/src/fontra/views/fontoverview/panel-navigation.js
+++ b/src/fontra/views/fontoverview/panel-navigation.js
@@ -12,30 +12,19 @@ export class FontOverviewNavigation extends HTMLElement {
       fontOverviewController.fontOverviewSettingsObserver;
     this.fontOverviewSettings = this.fontOverviewSettingsObserver.model;
     this.glyphOrganizer = new GlyphOrganizer();
-  }
-
-  async start() {
-    this.fontSources = await this.fontController.getSources();
-
-    this.currentFontSourceIdentifier =
-      this.fontController.fontSourcesInstancer.defaultSourceIdentifier;
-    this.fontOverviewSettings.fontLocationSourceMapped = {
-      ...this.fontSources[this.currentFontSourceIdentifier]?.location,
-    }; // Note: a font may not have font sources therefore the ?-check.
 
     this._setupUI();
   }
 
-  _setupUI() {
+  async _setupUI() {
+    this.fontSources = await this.fontController.getSources();
+
     this.fontSourceInput = html.select(
       {
         id: "font-source-select",
         style: "width: 100%;",
         onchange: (event) => {
-          this.currentFontSourceIdentifier = event.target.value;
-          this.fontOverviewSettings.fontLocationSourceMapped = {
-            ...this.fontSources[this.currentFontSourceIdentifier].location,
-          };
+          this.fontOverviewSettings.fontSourceIdentifier = event.target.value;
         },
       },
       []
@@ -47,7 +36,8 @@ export class FontOverviewNavigation extends HTMLElement {
         html.option(
           {
             value: fontSourceIdentifier,
-            selected: this.currentFontSourceIdentifier === fontSourceIdentifier,
+            selected:
+              this.fontOverviewSettings.fontSourceIdentifier === fontSourceIdentifier,
           },
           [sourceName]
         )
@@ -67,7 +57,6 @@ export class FontOverviewNavigation extends HTMLElement {
       ]
     );
 
-    // glyph search
     this.searchField = new GlyphSearchField({
       observer: this.fontOverviewSettingsObserver,
       observerKey: "searchString",
@@ -75,13 +64,6 @@ export class FontOverviewNavigation extends HTMLElement {
 
     this.appendChild(this.searchField);
     this.appendChild(fontSourceSelector);
-  }
-
-  getUserLocation() {
-    const sourceLocation = this.fontSources[this.currentFontSourceIdentifier]
-      ? this.fontSources[this.currentFontSourceIdentifier].location
-      : {};
-    return this.fontController.mapSourceLocationToUserLocation(sourceLocation);
   }
 }
 

--- a/src/fontra/views/fontoverview/panel-navigation.js
+++ b/src/fontra/views/fontoverview/panel-navigation.js
@@ -1,3 +1,4 @@
+import { GlyphOrganizer } from "/core/glyph-organizer.js";
 import * as html from "/core/html-utils.js";
 import { translate } from "/core/localization.js";
 import { GlyphSearchField } from "/web-components/glyph-search-field.js";
@@ -7,7 +8,9 @@ export class FontOverviewNavigation extends HTMLElement {
     super();
 
     this.fontController = fontOverviewController.fontController;
-    this.locationController = fontOverviewController.locationController;
+    this.fontOverviewSettingsObserver =
+      fontOverviewController.fontOverviewSettingsObserver;
+    this.glyphOrganizer = new GlyphOrganizer();
   }
 
   async start() {
@@ -15,7 +18,7 @@ export class FontOverviewNavigation extends HTMLElement {
 
     this.currentFontSourceIdentifier =
       this.fontController.fontSourcesInstancer.defaultSourceIdentifier;
-    this.locationController.model.fontLocationSourceMapped = {
+    this.fontOverviewSettingsObserver.model.fontLocationSourceMapped = {
       ...this.fontSources[this.currentFontSourceIdentifier]?.location,
     }; // Note: a font may not have font sources therefore the ?-check.
 
@@ -30,7 +33,7 @@ export class FontOverviewNavigation extends HTMLElement {
         style: "width: 100%;",
         onchange: (event) => {
           this.currentFontSourceIdentifier = event.target.value;
-          this.locationController.model.fontLocationSourceMapped = {
+          this.fontOverviewSettingsObserver.model.fontLocationSourceMapped = {
             ...this.fontSources[this.currentFontSourceIdentifier].location,
           };
         },
@@ -65,8 +68,10 @@ export class FontOverviewNavigation extends HTMLElement {
     );
 
     // glyph search
-    this.searchField = new GlyphSearchField();
-    this.searchField.onSearchFieldChanged = () => this.onSearchFieldChanged?.();
+    this.searchField = new GlyphSearchField({
+      observer: this.fontOverviewSettingsObserver,
+      observerKey: "searchString",
+    });
 
     this.appendChild(this.searchField);
     this.appendChild(fontSourceSelector);
@@ -77,14 +82,6 @@ export class FontOverviewNavigation extends HTMLElement {
       ? this.fontSources[this.currentFontSourceIdentifier].location
       : {};
     return this.fontController.mapSourceLocationToUserLocation(sourceLocation);
-  }
-
-  sortGlyphs(glyphItems) {
-    return this.searchField.sortGlyphs(glyphItems);
-  }
-
-  filterGlyphs(glyphItems) {
-    return this.searchField.filterGlyphs(glyphItems);
   }
 }
 

--- a/src/fontra/views/fontoverview/panel-navigation.js
+++ b/src/fontra/views/fontoverview/panel-navigation.js
@@ -10,6 +10,7 @@ export class FontOverviewNavigation extends HTMLElement {
     this.fontController = fontOverviewController.fontController;
     this.fontOverviewSettingsObserver =
       fontOverviewController.fontOverviewSettingsObserver;
+    this.fontOverviewSettings = this.fontOverviewSettingsObserver.model;
     this.glyphOrganizer = new GlyphOrganizer();
   }
 
@@ -18,7 +19,7 @@ export class FontOverviewNavigation extends HTMLElement {
 
     this.currentFontSourceIdentifier =
       this.fontController.fontSourcesInstancer.defaultSourceIdentifier;
-    this.fontOverviewSettingsObserver.model.fontLocationSourceMapped = {
+    this.fontOverviewSettings.fontLocationSourceMapped = {
       ...this.fontSources[this.currentFontSourceIdentifier]?.location,
     }; // Note: a font may not have font sources therefore the ?-check.
 
@@ -26,14 +27,13 @@ export class FontOverviewNavigation extends HTMLElement {
   }
 
   _setupUI() {
-    // font source selector
     this.fontSourceInput = html.select(
       {
         id: "font-source-select",
         style: "width: 100%;",
         onchange: (event) => {
           this.currentFontSourceIdentifier = event.target.value;
-          this.fontOverviewSettingsObserver.model.fontLocationSourceMapped = {
+          this.fontOverviewSettings.fontLocationSourceMapped = {
             ...this.fontSources[this.currentFontSourceIdentifier].location,
           };
         },

--- a/src/fontra/views/fontoverview/panel-navigation.js
+++ b/src/fontra/views/fontoverview/panel-navigation.js
@@ -8,9 +8,9 @@ export class FontOverviewNavigation extends HTMLElement {
     super();
 
     this.fontController = fontOverviewController.fontController;
-    this.fontOverviewSettingsObserver =
-      fontOverviewController.fontOverviewSettingsObserver;
-    this.fontOverviewSettings = this.fontOverviewSettingsObserver.model;
+    this.fontOverviewSettingsController =
+      fontOverviewController.fontOverviewSettingsController;
+    this.fontOverviewSettings = this.fontOverviewSettingsController.model;
     this.glyphOrganizer = new GlyphOrganizer();
 
     this._setupUI();
@@ -58,7 +58,7 @@ export class FontOverviewNavigation extends HTMLElement {
     );
 
     this.searchField = new GlyphSearchField({
-      observer: this.fontOverviewSettingsObserver,
+      observer: this.fontOverviewSettingsController,
       observerKey: "searchString",
     });
 

--- a/src/fontra/views/fontoverview/panel-navigation.js
+++ b/src/fontra/views/fontoverview/panel-navigation.js
@@ -58,8 +58,8 @@ export class FontOverviewNavigation extends HTMLElement {
     );
 
     this.searchField = new GlyphSearchField({
-      observer: this.fontOverviewSettingsController,
-      observerKey: "searchString",
+      settingsController: this.fontOverviewSettingsController,
+      searchStringKey: "searchString",
     });
 
     this.appendChild(this.searchField);


### PR DESCRIPTION
- refactor glyph-search once more: move sort/filter functionality to new module
- use an observable settings object for the UI state

This paves the way to store the UI settings in the URL fragment. Part of #1886.