### PR TITLE
[font overview] misc refactoring

### DIFF
--- a/src/fontra/client/web-components/glyph-cell-view.js
+++ b/src/fontra/client/web-components/glyph-cell-view.js
@@ -61,21 +61,21 @@ export class GlyphCellView extends HTMLElement {
     }
     `);
 
-    // TODO: refactor this if we implement different sections. For now only one section.
-    this.accordion.items = [
-      {
-        label: "Glyphs",
-        open: true,
-        content: html.div({ class: "font-overview-accordion-item" }, []),
-        section: "Glyphs",
-      },
-    ];
-
     return html.div({}, [this.accordion]); // wrap in div for scroll behavior
   }
 
-  setGlyphItems(glyphs) {
-    this.glyphs = glyphs;
+  setGlyphSections(glyphSections) {
+    this.glyphSections = glyphSections;
+
+    const accordionItems = glyphSections.map((section) => ({
+      label: section.label,
+      open: true,
+      content: html.div({ class: "font-overview-accordion-item" }, []),
+      glyphs: section.glyphs,
+    }));
+
+    this.accordion.items = accordionItems;
+
     const results = [];
     for (const item of this.accordion.items) {
       this._updateAccordionItem(item).then((hasResult) => {
@@ -96,11 +96,10 @@ export class GlyphCellView extends HTMLElement {
         translate("sidebar.related-glyphs.loading"), // TODO: general loading key.
       ])
     );
-    const glyphs = await this.getGlyphs(item.section);
 
-    item.glyphsToAdd = [...glyphs];
+    item.glyphsToAdd = [...item.glyphs];
 
-    if (glyphs?.length) {
+    if (item.glyphs.length) {
       element.innerHTML = "";
       this._addCellsIfNeeded(item);
       // At least in Chrome, we need to reset the scroll position, but it doesn't
@@ -152,9 +151,12 @@ export class GlyphCellView extends HTMLElement {
   }
 
   getSelectedGlyphInfo() {
-    return this.glyphs.filter((glyphInfo) =>
-      this.glyphSelection.has(glyphInfo.glyphName)
-    );
+    const glyphSelection = this.glyphSelection;
+    return this.glyphSections
+      .map((section) =>
+        section.glyphs.filter((glyphInfo) => glyphSelection.has(glyphInfo.glyphName))
+      )
+      .flat();
   }
 
   get glyphSelection() {
@@ -197,11 +199,6 @@ export class GlyphCellView extends HTMLElement {
         this.glyphSelection = new Set([glyphName]);
       }
     }
-  }
-
-  async getGlyphs(section) {
-    // TODO: section. For now return all glyphs
-    return this.glyphs;
   }
 }
 

--- a/src/fontra/views/fontoverview/fontoverview.js
+++ b/src/fontra/views/fontoverview/fontoverview.js
@@ -111,7 +111,7 @@ export class FontOverviewController extends ViewController {
     this.glyphCellView.parentElement.scrollTop = 0;
 
     const glyphItemList = this.glyphOrganizer.filterGlyphs(this._glyphItemList);
-    this.glyphCellView.setGlyphItems(glyphItemList);
+    this.glyphCellView.setGlyphSections([{ label: "Glyphs", glyphs: glyphItemList }]);
   }
 
   handleDoubleClick(event) {

--- a/src/fontra/views/fontoverview/fontoverview.js
+++ b/src/fontra/views/fontoverview/fontoverview.js
@@ -111,7 +111,9 @@ export class FontOverviewController extends ViewController {
     this.glyphCellView.parentElement.scrollTop = 0;
 
     const glyphItemList = this.glyphOrganizer.filterGlyphs(this._glyphItemList);
-    this.glyphCellView.setGlyphSections([{ label: "Glyphs", glyphs: glyphItemList }]);
+    this.glyphCellView.setGlyphSections([
+      { label: "All glyphs", glyphs: glyphItemList },
+    ]);
   }
 
   handleDoubleClick(event) {

--- a/src/fontra/views/fontoverview/fontoverview.js
+++ b/src/fontra/views/fontoverview/fontoverview.js
@@ -36,6 +36,7 @@ export class FontOverviewController extends ViewController {
     this.fontOverviewSettingsController = new ObservableController({
       searchString: "",
       fontSourceIdentifier: null,
+      fontLocationUser: {},
       fontLocationSourceMapped: {},
       glyphSelection: new Set(),
     });
@@ -48,7 +49,9 @@ export class FontOverviewController extends ViewController {
           ...this.fontSources[event.newValue]?.location,
         }; // A font may not have any font sources, therefore the ?-check
 
-        this.fontOverviewSettings.fontLocationSourceMapped =
+        this.fontOverviewSettings.fontLocationSourceMapped = sourceLocation;
+
+        this.fontOverviewSettings.fontLocationUser =
           this.fontController.mapSourceLocationToUserLocation(sourceLocation);
       }
     );

--- a/src/fontra/views/fontoverview/fontoverview.js
+++ b/src/fontra/views/fontoverview/fontoverview.js
@@ -121,7 +121,7 @@ export class FontOverviewController extends ViewController {
   openSelectedGlyphs() {
     openGlyphsInEditor(
       this.glyphCellView.getSelectedGlyphInfo(),
-      this.fontOverviewSettings.fontLocationSourceMapped,
+      this.fontOverviewSettings.fontLocationUser,
       this.fontController.glyphMap
     );
   }


### PR DESCRIPTION
This PR does three independent things:
- Rework glyph-cell-view for "sections" (multiple accordion items), in preparation for #1887 
- Use a single IntersectionObserver instance for all cells instead of one per cell, in the hope that this is more efficient (still questionable)
- Fix location confusion between "user coordinates" and "source coordinates"
