### PR TITLE
[font overview] implement arrow key selection

### DIFF
--- a/src/fontra/client/web-components/glyph-cell-view.js
+++ b/src/fontra/client/web-components/glyph-cell-view.js
@@ -258,7 +258,7 @@ export class GlyphCellView extends HTMLElement {
     const [deltaX, deltaY] = arrowKeyDeltas[event.key];
     if (deltaX) {
       this._cellCenterForArrowUpDown = null;
-      nextCell = nextGlyphCell(this._firstClickedCell, deltaX);
+      nextCell = nextGlyphCellHorizontal(this._firstClickedCell, deltaX);
     } else {
       if (this._cellCenterForArrowUpDown === null) {
         this._cellCenterForArrowUpDown = boundsCenterX(
@@ -287,7 +287,7 @@ export class GlyphCellView extends HTMLElement {
 
 customElements.define("glyph-cell-view", GlyphCellView);
 
-function nextGlyphCell(glyphCell, direction) {
+function nextGlyphCellHorizontal(glyphCell, direction) {
   let nextCell = nextSibling(glyphCell, direction);
   if (!nextCell) {
     const accordionItem = glyphCell.parentNode.parentNode.parentNode;
@@ -312,7 +312,7 @@ function nextGlyphCellVertical(firstCell, direction, cellCenter) {
 
   const matches = [];
   while (true) {
-    nextCell = nextGlyphCell(nextCell, direction);
+    nextCell = nextGlyphCellHorizontal(nextCell, direction);
     if (!nextCell) {
       break;
     }
@@ -339,7 +339,7 @@ function nextGlyphCellVertical(firstCell, direction, cellCenter) {
 function findFirstLastGlyphCell(firstCell, direction) {
   let firstLastCell = firstCell;
   while (true) {
-    const nextCell = nextGlyphCell(firstLastCell, direction);
+    const nextCell = nextGlyphCellHorizontal(firstLastCell, direction);
     if (!nextCell) {
       break;
     }

--- a/src/fontra/client/web-components/glyph-cell-view.js
+++ b/src/fontra/client/web-components/glyph-cell-view.js
@@ -229,6 +229,9 @@ export class GlyphCellView extends HTMLElement {
 
     if (this.glyphSelection.has(glyphName)) {
       if (event.shiftKey) {
+        if (glyphCell.selected) {
+          this._resetSelectionHelpers();
+        }
         this.glyphSelection = difference(this.glyphSelection, [glyphName]);
       }
     } else {
@@ -256,21 +259,27 @@ export class GlyphCellView extends HTMLElement {
 
     let nextCell;
     const [deltaX, deltaY] = arrowKeyDeltas[event.key];
-    if (deltaX) {
-      this._cellCenterForArrowUpDown = null;
-      nextCell = nextGlyphCellHorizontal(this._firstClickedCell, deltaX);
+
+    if (!this._firstClickedCell) {
+      const itemContent = this.accordion.items[0].content;
+      nextCell = itemContent.firstElementChild;
     } else {
-      if (this._cellCenterForArrowUpDown === null) {
-        this._cellCenterForArrowUpDown = boundsCenterX(
-          this._firstClickedCell.getBoundingClientRect()
+      if (deltaX) {
+        this._cellCenterForArrowUpDown = null;
+        nextCell = nextGlyphCellHorizontal(this._firstClickedCell, deltaX);
+      } else {
+        if (this._cellCenterForArrowUpDown === null) {
+          this._cellCenterForArrowUpDown = boundsCenterX(
+            this._firstClickedCell.getBoundingClientRect()
+          );
+        }
+
+        nextCell = nextGlyphCellVertical(
+          this._firstClickedCell,
+          -deltaY,
+          this._cellCenterForArrowUpDown
         );
       }
-
-      nextCell = nextGlyphCellVertical(
-        this._firstClickedCell,
-        -deltaY,
-        this._cellCenterForArrowUpDown
-      );
     }
 
     if (nextCell) {

--- a/src/fontra/client/web-components/glyph-cell-view.js
+++ b/src/fontra/client/web-components/glyph-cell-view.js
@@ -239,6 +239,11 @@ export class GlyphCellView extends HTMLElement {
     if (nextCell) {
       this._firstClickedCell = nextCell;
       this.glyphSelection = new Set([nextCell.glyphName]);
+      nextCell.scrollIntoView({
+        behavior: "auto",
+        block: "nearest",
+        inline: "nearest",
+      });
     }
   }
 }

--- a/src/fontra/client/web-components/glyph-cell-view.js
+++ b/src/fontra/client/web-components/glyph-cell-view.js
@@ -241,35 +241,17 @@ export class GlyphCellView extends HTMLElement {
       this._cellCenterForArrowUpDown = null;
       nextCell = nextGlyphCell(this._firstClickedCell, deltaX);
     } else {
-      const firstCellBounds = this._firstClickedCell.getBoundingClientRect();
       if (this._cellCenterForArrowUpDown === null) {
-        this._cellCenterForArrowUpDown = boundsCenterX(firstCellBounds);
+        this._cellCenterForArrowUpDown = boundsCenterX(
+          this._firstClickedCell.getBoundingClientRect()
+        );
       }
 
-      nextCell = this._firstClickedCell;
-
-      const matches = [];
-      while (true) {
-        nextCell = nextGlyphCell(nextCell, -deltaY);
-        if (!nextCell) {
-          break;
-        }
-
-        const nextCellBounds = nextCell.getBoundingClientRect();
-        const overlap = horizontalOverlap(firstCellBounds, nextCellBounds);
-
-        if (overlap) {
-          matches.push({ cell: nextCell, center: boundsCenterX(nextCellBounds) });
-        } else if (matches.length) {
-          break;
-        }
-      }
-      matches.sort(
-        (a, b) =>
-          Math.abs(this._cellCenterForArrowUpDown - a.center) -
-          Math.abs(this._cellCenterForArrowUpDown - b.center)
+      nextCell = nextGlyphCellVertical(
+        this._firstClickedCell,
+        -deltaY,
+        this._cellCenterForArrowUpDown
       );
-      nextCell = matches[0]?.cell;
     }
 
     if (nextCell) {
@@ -303,6 +285,32 @@ function nextGlyphCell(glyphCell, direction) {
 
 function nextSibling(element, direction) {
   return direction == 1 ? element.nextElementSibling : element.previousElementSibling;
+}
+
+function nextGlyphCellVertical(firstCell, direction, cellCenter) {
+  const firstCellBounds = firstCell.getBoundingClientRect();
+  let nextCell = firstCell;
+
+  const matches = [];
+  while (true) {
+    nextCell = nextGlyphCell(nextCell, direction);
+    if (!nextCell) {
+      break;
+    }
+
+    const nextCellBounds = nextCell.getBoundingClientRect();
+    const overlap = horizontalOverlap(firstCellBounds, nextCellBounds);
+
+    if (overlap) {
+      matches.push({ cell: nextCell, center: boundsCenterX(nextCellBounds) });
+    } else if (matches.length) {
+      break;
+    }
+  }
+  matches.sort(
+    (a, b) => Math.abs(cellCenter - a.center) - Math.abs(cellCenter - b.center)
+  );
+  return matches[0]?.cell;
 }
 
 function horizontalOverlap(rect1, rect2) {

--- a/src/fontra/client/web-components/glyph-cell-view.js
+++ b/src/fontra/client/web-components/glyph-cell-view.js
@@ -1,7 +1,7 @@
 import * as html from "/core/html-utils.js";
 import { translate } from "/core/localization.js";
 import { difference, intersection, symmetricDifference, union } from "/core/set-ops.js";
-import { enumerate } from "/core/utils.js";
+import { arrowKeyDeltas, enumerate } from "/core/utils.js";
 import { GlyphCell } from "/web-components/glyph-cell.js";
 import { Accordion } from "/web-components/ui-accordion.js";
 
@@ -13,6 +13,9 @@ export class GlyphCellView extends HTMLElement {
     this.settingsController = settingsController;
     this.locationKey = options?.locationKey || "fontLocationSourceMapped";
     this.glyphSelectionKey = options?.glyphSelectionKey || "glyphSelection";
+
+    this._firstClickedCell = null;
+    this._secondClickedCell = null;
 
     this.settingsController.addKeyListener(this.glyphSelectionKey, (event) => {
       const selection = event.newValue;
@@ -42,6 +45,8 @@ export class GlyphCellView extends HTMLElement {
     });
 
     this.appendChild(this.getContentElement());
+
+    this.addEventListener("keydown", (event) => this.handleKeyDown(event));
   }
 
   getContentElement() {
@@ -193,6 +198,8 @@ export class GlyphCellView extends HTMLElement {
       return;
     }
 
+    this._firstClickedCell = glyphCell;
+
     const glyphName = glyphCell.glyphName;
 
     if (this.glyphSelection.has(glyphName)) {
@@ -207,6 +214,36 @@ export class GlyphCellView extends HTMLElement {
       }
     }
   }
+
+  handleKeyDown(event) {
+    if (event.key in arrowKeyDeltas) {
+      this.handleArrowKeys(event);
+    }
+  }
+
+  handleArrowKeys(event) {
+    event.preventDefault();
+    event.stopImmediatePropagation();
+
+    if (!this._firstClickedCell) {
+      return;
+    }
+
+    let nextCell;
+    const [deltaX, deltaY] = arrowKeyDeltas[event.key];
+    if (deltaX) {
+      nextCell = nextSibling(this._firstClickedCell, deltaX);
+    } else {
+    }
+    if (nextCell) {
+      this._firstClickedCell = nextCell;
+      this.glyphSelection = new Set([nextCell.glyphName]);
+    }
+  }
 }
 
 customElements.define("glyph-cell-view", GlyphCellView);
+
+function nextSibling(element, direction) {
+  return direction == 1 ? element.nextElementSibling : element.previousElementSibling;
+}

--- a/src/fontra/client/web-components/glyph-cell-view.js
+++ b/src/fontra/client/web-components/glyph-cell-view.js
@@ -67,11 +67,14 @@ export class GlyphCellView extends HTMLElement {
   setGlyphSections(glyphSections) {
     this.glyphSections = glyphSections;
 
+    let sectionIndex = 0;
     const accordionItems = glyphSections.map((section) => ({
       label: section.label,
       open: true,
       content: html.div({ class: "font-overview-accordion-item" }, []),
       glyphs: section.glyphs,
+      sectionIndex: sectionIndex++,
+      nextCellIndex: 0,
     }));
 
     this.accordion.items = accordionItems;
@@ -132,6 +135,9 @@ export class GlyphCellView extends HTMLElement {
         this.settingsController,
         this.locationKey
       );
+      glyphCell._sectionIndex = item.sectionIndex;
+      glyphCell._cellIndex = item.nextCellIndex++;
+
       glyphCell.onclick = (event) => {
         this.handleSingleClick(event, glyphCell);
       };

--- a/src/fontra/client/web-components/glyph-cell-view.js
+++ b/src/fontra/client/web-components/glyph-cell-view.js
@@ -14,9 +14,7 @@ export class GlyphCellView extends HTMLElement {
     this.locationKey = options?.locationKey || "fontLocationSourceMapped";
     this.glyphSelectionKey = options?.glyphSelectionKey || "glyphSelection";
 
-    this._firstClickedCell = null;
-    this._secondClickedCell = null;
-    this._cellCenterForArrowUpDown = null;
+    this._resetSelectionHelpers();
 
     this.settingsController.addKeyListener(this.glyphSelectionKey, (event) => {
       const selection = event.newValue;
@@ -54,6 +52,12 @@ export class GlyphCellView extends HTMLElement {
     this.addEventListener("keydown", (event) => this.handleKeyDown(event));
   }
 
+  _resetSelectionHelpers() {
+    this._firstClickedCell = null;
+    this._secondClickedCell = null;
+    this._cellCenterForArrowUpDown = null;
+  }
+
   getContentElement() {
     this.accordion = new Accordion();
 
@@ -75,6 +79,7 @@ export class GlyphCellView extends HTMLElement {
   }
 
   setGlyphSections(glyphSections) {
+    this._resetSelectionHelpers();
     this.glyphSections = glyphSections;
 
     let sectionIndex = 0;

--- a/src/fontra/client/web-components/glyph-cell-view.js
+++ b/src/fontra/client/web-components/glyph-cell-view.js
@@ -210,7 +210,7 @@ export class GlyphCellView extends HTMLElement {
   }
 
   *iterGlyphCells() {
-    for (const glyphCell of this.accordion.shadowRoot.querySelectorAll("glyph-cell")) {
+    for (const glyphCell of this.accordion.querySelectorAll("glyph-cell")) {
       yield glyphCell;
     }
   }

--- a/src/fontra/client/web-components/glyph-cell-view.js
+++ b/src/fontra/client/web-components/glyph-cell-view.js
@@ -329,7 +329,23 @@ function nextGlyphCellVertical(firstCell, direction, cellCenter) {
   matches.sort(
     (a, b) => Math.abs(cellCenter - a.center) - Math.abs(cellCenter - b.center)
   );
-  return matches[0]?.cell;
+  nextCell = matches[0]?.cell;
+  if (!nextCell) {
+    nextCell = findFirstLastGlyphCell(firstCell, direction);
+  }
+  return nextCell;
+}
+
+function findFirstLastGlyphCell(firstCell, direction) {
+  let firstLastCell = firstCell;
+  while (true) {
+    const nextCell = nextGlyphCell(firstLastCell, direction);
+    if (!nextCell) {
+      break;
+    }
+    firstLastCell = nextCell;
+  }
+  return firstLastCell;
 }
 
 function horizontalOverlap(rect1, rect2) {

--- a/src/fontra/client/web-components/glyph-cell-view.js
+++ b/src/fontra/client/web-components/glyph-cell-view.js
@@ -1,7 +1,7 @@
 import * as html from "/core/html-utils.js";
 import { translate } from "/core/localization.js";
 import { difference, intersection, symmetricDifference, union } from "/core/set-ops.js";
-import { arrowKeyDeltas, enumerate } from "/core/utils.js";
+import { arrowKeyDeltas, assert, enumerate } from "/core/utils.js";
 import { GlyphCell } from "/web-components/glyph-cell.js";
 import { Accordion } from "/web-components/ui-accordion.js";
 
@@ -232,9 +232,10 @@ export class GlyphCellView extends HTMLElement {
     let nextCell;
     const [deltaX, deltaY] = arrowKeyDeltas[event.key];
     if (deltaX) {
-      nextCell = nextSibling(this._firstClickedCell, deltaX);
+      nextCell = nextGlyphCell(this._firstClickedCell, deltaX);
     } else {
     }
+
     if (nextCell) {
       this._firstClickedCell = nextCell;
       this.glyphSelection = new Set([nextCell.glyphName]);
@@ -243,6 +244,21 @@ export class GlyphCellView extends HTMLElement {
 }
 
 customElements.define("glyph-cell-view", GlyphCellView);
+
+function nextGlyphCell(glyphCell, direction) {
+  let nextCell = nextSibling(glyphCell, direction);
+  if (!nextCell) {
+    const accordionItem = glyphCell.parentNode.parentNode.parentNode;
+    assert(accordionItem.classList.contains("ui-accordion-item"));
+    const nextAccordionItem = nextSibling(accordionItem, direction);
+    if (nextAccordionItem) {
+      nextCell = nextAccordionItem.querySelector(
+        `glyph-cell:${direction == 1 ? "first" : "last"}-child`
+      );
+    }
+  }
+  return nextCell;
+}
 
 function nextSibling(element, direction) {
   return direction == 1 ? element.nextElementSibling : element.previousElementSibling;

--- a/src/fontra/client/web-components/glyph-cell-view.js
+++ b/src/fontra/client/web-components/glyph-cell-view.js
@@ -189,6 +189,20 @@ export class GlyphCellView extends HTMLElement {
     this.settingsController.model[this.glyphSelectionKey] = selection;
   }
 
+  findFirstSelectedCell() {
+    let firstSelectedCell = undefined;
+    if (!this.glyphSelection.size) {
+      return firstSelectedCell;
+    }
+    for (const glyphCell of this.iterGlyphCells()) {
+      if (this.glyphSelection.has(glyphCell.glyphName)) {
+        firstSelectedCell = glyphCell;
+        break;
+      }
+    }
+    return firstSelectedCell;
+  }
+
   forEachGlyphCell(func) {
     for (const glyphCell of this.iterGlyphCells()) {
       func(glyphCell);
@@ -237,7 +251,7 @@ export class GlyphCellView extends HTMLElement {
     event.stopImmediatePropagation();
 
     if (!this._firstClickedCell) {
-      return;
+      this._firstClickedCell = this.findFirstSelectedCell();
     }
 
     let nextCell;

--- a/src/fontra/client/web-components/glyph-cell-view.js
+++ b/src/fontra/client/web-components/glyph-cell-view.js
@@ -258,12 +258,12 @@ export class GlyphCellView extends HTMLElement {
     }
 
     let nextCell;
-    const [deltaX, deltaY] = arrowKeyDeltas[event.key];
 
     if (!this._firstClickedCell) {
       const itemContent = this.accordion.items[0].content;
       nextCell = itemContent.firstElementChild;
     } else {
+      const [deltaX, deltaY] = arrowKeyDeltas[event.key];
       if (deltaX) {
         this._cellCenterForArrowUpDown = null;
         nextCell = nextGlyphCellHorizontal(this._firstClickedCell, deltaX);

--- a/src/fontra/views/fontoverview/fontoverview.js
+++ b/src/fontra/views/fontoverview/fontoverview.js
@@ -114,8 +114,7 @@ export class FontOverviewController extends ViewController {
 
     const glyphItemList = this.glyphOrganizer.filterGlyphs(this._glyphItemList);
     this.glyphCellView.setGlyphSections([
-      { label: "Some glyphs", glyphs: glyphItemList.slice(0, 40) },
-      { label: "All glyphs", glyphs: glyphItemList.slice(40) },
+      { label: "All glyphs", glyphs: glyphItemList },
     ]);
   }
 

--- a/src/fontra/views/fontoverview/fontoverview.js
+++ b/src/fontra/views/fontoverview/fontoverview.js
@@ -114,7 +114,8 @@ export class FontOverviewController extends ViewController {
 
     const glyphItemList = this.glyphOrganizer.filterGlyphs(this._glyphItemList);
     this.glyphCellView.setGlyphSections([
-      { label: "All glyphs", glyphs: glyphItemList },
+      { label: "Some glyphs", glyphs: glyphItemList.slice(0, 40) },
+      { label: "All glyphs", glyphs: glyphItemList.slice(40) },
     ]);
   }
 

--- a/src/fontra/views/fontoverview/fontoverview.js
+++ b/src/fontra/views/fontoverview/fontoverview.js
@@ -5,8 +5,6 @@ import { loaderSpinner } from "/core/loader-spinner.js";
 import { translate } from "/core/localization.js";
 import { ObservableController } from "/core/observable-object.js";
 import {
-  arrowKeyDeltas,
-  commandKeyProperty,
   dumpURLFragment,
   glyphMapToItemList,
   isActiveElementTypeable,
@@ -97,6 +95,9 @@ export class FontOverviewController extends ViewController {
     this.fontController.addChangeListener({ glyphMap: null }, () => {
       this._updateGlyphItemList();
     });
+
+    document.addEventListener("keydown", (event) => this.handleKeyDown(event));
+
     this._updateGlyphItemList();
   }
 
@@ -136,14 +137,7 @@ export class FontOverviewController extends ViewController {
       // The cell area for sure doesn't have the focus
       return;
     }
-    // if (event.key in arrowKeyDeltas) {
-    //   this.handleArrowKeys(event);
-    //   event.preventDefault();
-    //   return;
-    // }
-    // TODO: maybe:
-    // select all via command + a
-    // and unselect all via command + shift + a
+    this.glyphCellView.handleKeyDown(event);
   }
 
   handleRemoteClose(event) {

--- a/src/fontra/views/fontoverview/fontoverview.js
+++ b/src/fontra/views/fontoverview/fontoverview.js
@@ -126,6 +126,9 @@ export class FontOverviewController extends ViewController {
   }
 
   openSelectedGlyphs() {
+    if (!this.fontOverviewSettings.glyphSelection.size) {
+      return;
+    }
     openGlyphsInEditor(
       this.glyphCellView.getSelectedGlyphInfo(),
       this.fontOverviewSettings.fontLocationUser,
@@ -138,7 +141,11 @@ export class FontOverviewController extends ViewController {
       // The cell area for sure doesn't have the focus
       return;
     }
-    this.glyphCellView.handleKeyDown(event);
+    if (event.key == "Enter") {
+      this.openSelectedGlyphs();
+    } else {
+      this.glyphCellView.handleKeyDown(event);
+    }
   }
 
   handleRemoteClose(event) {


### PR DESCRIPTION
This fixes #1897 

This PR adds:
- Arrow key selection (not yet with shift)
- Enter key to open the selection