### PR TITLE
Adjust related glyphs panel css

### DIFF
--- a/src/fontra/views/editor/panel-related-glyphs.js
+++ b/src/fontra/views/editor/panel-related-glyphs.js
@@ -16,13 +16,19 @@ export default class RelatedGlyphPanel extends Panel {
   static styles = `
     .sidebar-glyph-relationships {
       box-sizing: border-box;
-      height: calc(100% - 2em); // Would be nice to do without the calc
-      width: 100%;
+      height: 100%;
+      display: flex;
+      flex-direction: column;
     }
 
     #related-glyphs-header {
       padding: 1em 1em 0 1em;
       text-wrap: wrap;
+    }
+
+    .related-glyphs-accordion {
+      flex: 1;
+      overflow: hidden;
     }
 
     .no-related-glyphs {
@@ -51,7 +57,7 @@ export default class RelatedGlyphPanel extends Panel {
 
   getContentElement() {
     this.accordion = new Accordion();
-
+    this.accordion.classList.add("related-glyphs-accordion");
     this.accordion.appendStyle(`
     .placeholder-label {
       font-size: 0.9em;


### PR DESCRIPTION
This is the follow-up of https://github.com/googlefonts/fontra/pull/1877

The change adjusts the box behavior of related glyphs panel so `calc(100% - 2em)` could be removed.

@justvanrossum I would suggest to set border-box globally. (read here https://css-tricks.com/almanac/properties/b/box-sizing/) I could improve this in a follow-up if you like.

