### PR TITLE
Add a conditional statement to ensure the multi-tool mousedown timer only affects the first child

### DIFF
--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -1217,6 +1217,7 @@ export class EditorController extends ViewController {
             window.addEventListener("keydown", globalListener, false);
           }, 650);
           if (toolButton !== editToolsElement.children[0]) {
+            // ensure the multi-tool mousedown timer only affects the first child
             event.stopImmediatePropagation();
           }
         };

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -1216,7 +1216,6 @@ export class EditorController extends ViewController {
             window.addEventListener("mousedown", globalListener, false);
             window.addEventListener("keydown", globalListener, false);
           }, 650);
-          
           if (toolButton !== editToolsElement.children[0]) {
             event.stopImmediatePropagation();
           }

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -1216,6 +1216,10 @@ export class EditorController extends ViewController {
             window.addEventListener("mousedown", globalListener, false);
             window.addEventListener("keydown", globalListener, false);
           }, 650);
+          
+          if (toolButton !== editToolsElement.children[0]) {
+            event.stopImmediatePropagation();
+          }
         };
 
         toolButton.onmouseup = () => {


### PR DESCRIPTION
fix #1762 