### PR TITLE
[font overview] improve grouping of unencoded glyphs

### DIFF
--- a/src/fontra/client/core/glyph-organizer.js
+++ b/src/fontra/client/core/glyph-organizer.js
@@ -1,29 +1,34 @@
 import { getGlyphInfoFromCodePoint, getGlyphInfoFromGlyphName } from "./glyph-data.js";
 import { block, script, scriptNames } from "./unicode-scripts-blocks.js";
-import { capitalizeFirstLetter } from "./utils.js";
+import {
+  capitalizeFirstLetter,
+  getBaseGlyphName,
+  getCodePointFromGlyphItem,
+  getGlyphNameExtension,
+} from "./utils.js";
 
-function getGlyphInfo(glyph) {
-  const codePoint = glyph.codePoints[0];
+function getGlyphInfo(codePoint, glyphName) {
   return (
     getGlyphInfoFromCodePoint(codePoint) ||
-    getGlyphInfoFromGlyphName(glyph.glyphName) ||
-    getGlyphInfoFromGlyphName(getBaseGlyphName(glyph.glyphName))
+    getGlyphInfoFromGlyphName(glyphName) ||
+    getGlyphInfoFromGlyphName(getBaseGlyphName(glyphName))
   );
 }
 
-function getGroupByInfo(glyph, options) {
-  const glyphInfo = getGlyphInfo(glyph) || {};
+function getGroupByInfo(glyphItem, options) {
+  const codePoint = getCodePointFromGlyphItem(glyphItem);
+
+  const glyphInfo = getGlyphInfo(codePoint, glyphItem.glyphName) || {};
 
   const groupByInfo = {
     ...Object.fromEntries(
       Object.entries(glyphInfo).filter(([key, value]) => options[key])
     ),
     glyphNameExtension: options.glyphNameExtension
-      ? getGlyphNameExtension(glyph.glyphName)
+      ? getGlyphNameExtension(glyphItem.glyphName)
       : undefined,
   };
 
-  const codePoint = glyph.codePoints[0];
   if (codePoint) {
     if (options.script) {
       // Override script from unicode-scripts-blocks.js
@@ -172,16 +177,6 @@ function compare(a, b) {
   } else {
     return 1;
   }
-}
-
-function getGlyphNameExtension(glyphName) {
-  const i = glyphName.lastIndexOf(".");
-  return i >= 1 ? glyphName.slice(i) : "";
-}
-
-function getBaseGlyphName(glyphName) {
-  const i = glyphName.indexOf(".");
-  return i >= 1 ? glyphName.slice(0, i) : "";
 }
 
 function getGroupByKey(glyph, options) {

--- a/src/fontra/client/core/utils.js
+++ b/src/fontra/client/core/utils.js
@@ -495,7 +495,7 @@ export function splitGlyphNameExtension(glyphName) {
 
 export function getBaseGlyphName(glyphName) {
   const i = glyphName.indexOf(".");
-  return i >= 1 ? glyphName.slice(0, i) : "";
+  return i >= 1 ? glyphName.slice(0, i) : glyphName;
 }
 
 export function getGlyphNameExtension(glyphName) {
@@ -703,8 +703,11 @@ export function glyphMapToItemList(glyphMap) {
 }
 
 export function getAssociatedCodePoints(glyphName, glyphMap) {
-  const baseGlyphName = getBaseGlyphName(glyphName);
-  return baseGlyphName != glyphName ? glyphMap[baseGlyphName] || [] : [];
+  return getBaseGlyphName(glyphName)
+    .split("_")
+    .filter((baseGlyphName) => baseGlyphName !== glyphName)
+    .map((baseGlyphName) => glyphMap[baseGlyphName]?.[0])
+    .filter((codePoint) => codePoint);
 }
 
 export function getCodePointFromGlyphItem(glyphItem) {

--- a/src/fontra/client/core/utils.js
+++ b/src/fontra/client/core/utils.js
@@ -493,6 +493,16 @@ export function splitGlyphNameExtension(glyphName) {
   return [baseGlyphName, extension];
 }
 
+export function getBaseGlyphName(glyphName) {
+  const i = glyphName.indexOf(".");
+  return i >= 1 ? glyphName.slice(0, i) : "";
+}
+
+export function getGlyphNameExtension(glyphName) {
+  const i = glyphName.lastIndexOf(".");
+  return i >= 1 ? glyphName.slice(i) : "";
+}
+
 export function isObjectEmpty(obj) {
   // Return true if `obj` has no properties
   for (const _ in obj) {
@@ -688,7 +698,17 @@ export function glyphMapToItemList(glyphMap) {
   return Object.entries(glyphMap).map(([glyphName, codePoints]) => ({
     glyphName,
     codePoints,
+    associatedCodePoints: getAssociatedCodePoints(glyphName, glyphMap),
   }));
+}
+
+export function getAssociatedCodePoints(glyphName, glyphMap) {
+  const baseGlyphName = getBaseGlyphName(glyphName);
+  return baseGlyphName != glyphName ? glyphMap[baseGlyphName] || [] : [];
+}
+
+export function getCodePointFromGlyphItem(glyphItem) {
+  return glyphItem.codePoints[0] || glyphItem.associatedCodePoints[0];
 }
 
 export function bisect_right(a, x) {

--- a/test-js/test-utils.js
+++ b/test-js/test-utils.js
@@ -688,10 +688,10 @@ describe("glyphMapToItemList", () => {
     {
       glyphMap: { "A.alt": [], "A": [65], "a": [97], "B": [66, 98] },
       result: [
-        { glyphName: "A.alt", codePoints: [] },
-        { glyphName: "A", codePoints: [65] },
-        { glyphName: "a", codePoints: [97] },
-        { glyphName: "B", codePoints: [66, 98] },
+        { glyphName: "A", codePoints: [65], associatedCodePoints: [] },
+        { glyphName: "A.alt", codePoints: [], associatedCodePoints: [65] },
+        { glyphName: "a", codePoints: [97], associatedCodePoints: [] },
+        { glyphName: "B", codePoints: [66, 98], associatedCodePoints: [] },
       ],
     },
   ];

--- a/test-js/test-utils.js
+++ b/test-js/test-utils.js
@@ -688,8 +688,8 @@ describe("glyphMapToItemList", () => {
     {
       glyphMap: { "A.alt": [], "A": [65], "a": [97], "B": [66, 98] },
       result: [
-        { glyphName: "A", codePoints: [65], associatedCodePoints: [] },
         { glyphName: "A.alt", codePoints: [], associatedCodePoints: [65] },
+        { glyphName: "A", codePoints: [65], associatedCodePoints: [] },
         { glyphName: "a", codePoints: [97], associatedCodePoints: [] },
         { glyphName: "B", codePoints: [66, 98], associatedCodePoints: [] },
       ],


### PR DESCRIPTION
- Look up the code points for the base glyph name (anything before the first dot in the name)
- Split the base glyph name by underscore so we can attempt to classify ligature glyphs (that use the underscore naming convention)