### PR TITLE
Delete points from contours in reverse contour order

### DIFF
--- a/src/fontra/client/core/path-functions.js
+++ b/src/fontra/client/core/path-functions.js
@@ -385,13 +385,12 @@ export function connectContours(path, sourcePointIndex, targetPointIndex) {
 }
 
 export function deleteSelectedPoints(path, pointIndices) {
+  // `pointIndices` must be sorted
   const contourFragmentsToDelete = preparePointDeletion(path, pointIndices);
   const contoursToDelete = [];
-  for (const {
-    contourIndex,
-    fragmentsToDelete,
-    startPoint,
-  } of contourFragmentsToDelete) {
+  for (const { contourIndex, fragmentsToDelete, startPoint } of reversed(
+    contourFragmentsToDelete
+  )) {
     if (!fragmentsToDelete) {
       contoursToDelete.push(contourIndex);
       continue;


### PR DESCRIPTION
This fixes #1910, by processing the contours in reverse order (from back to front).