### PR TITLE
Remove padding from Accorion, and let clients deal with that

### DIFF
--- a/src/fontra/client/web-components/ui-accordion.js
+++ b/src/fontra/client/web-components/ui-accordion.js
@@ -5,7 +5,6 @@ import { enumerate } from "/core/utils.js";
 export class Accordion extends UnlitElement {
   static styles = `
   .ui-accordion-contents {
-    padding: 1em;
     display: grid;
     grid-template-rows: auto;
     align-content: start;

--- a/src/fontra/views/editor/panel-designspace-navigation.js
+++ b/src/fontra/views/editor/panel-designspace-navigation.js
@@ -98,8 +98,8 @@ export default class DesignspaceNavigationPanel extends Panel {
   }
 
   getContentElement() {
-    const accordion = new Accordion();
-    accordion.appendStyle(`
+    this.accordion = new Accordion();
+    this.accordion.appendStyle(`
       .interpolation-error-icon {
         display: inline-block;
         height: 1.35em;
@@ -109,7 +109,7 @@ export default class DesignspaceNavigationPanel extends Panel {
         margin-right: 0.25em;
       }
     `);
-    accordion.items = [
+    this.accordion.items = [
       {
         id: "font-axes-accordion-item",
         label: translate("sidebar.designspace-navigation.font-axes"),
@@ -208,27 +208,27 @@ export default class DesignspaceNavigationPanel extends Panel {
       },
     ];
 
-    return accordion;
+    return html.div({ style: "height: 100%; padding: 1em;" }, [this.accordion]);
   }
 
   get fontAxesElement() {
-    return this.contentElement.querySelector("#font-axes");
+    return this.accordion.querySelector("#font-axes");
   }
 
   get glyphAxesElement() {
-    return this.contentElement.querySelector("#glyph-axes");
+    return this.accordion.querySelector("#glyph-axes");
   }
 
   get glyphAxesAccordionItem() {
-    return this.contentElement.querySelector("#glyph-axes-accordion-item");
+    return this.accordion.querySelector("#glyph-axes-accordion-item");
   }
 
   get glyphSourcesAccordionItem() {
-    return this.contentElement.querySelector("#glyph-sources-accordion-item");
+    return this.accordion.querySelector("#glyph-sources-accordion-item");
   }
 
   get glyphLayersAccordionItem() {
-    return this.contentElement.querySelector("#glyph-layers-accordion-item");
+    return this.accordion.querySelector("#glyph-layers-accordion-item");
   }
 
   setup() {
@@ -364,7 +364,7 @@ export default class DesignspaceNavigationPanel extends Panel {
 
     const columnDescriptions = this._setupSourceListColumnDescriptions();
 
-    this.sourcesList = this.contentElement.querySelector("#sources-list");
+    this.sourcesList = this.accordion.querySelector("#sources-list");
     this.sourcesList.appendStyle(`
       .clickable-icon-header {
         transition: 150ms;
@@ -379,7 +379,7 @@ export default class DesignspaceNavigationPanel extends Panel {
     this.sourcesList.showHeader = true;
     this.sourcesList.columnDescriptions = columnDescriptions;
 
-    this.addRemoveSourceButtons = this.contentElement.querySelector(
+    this.addRemoveSourceButtons = this.accordion.querySelector(
       "#sources-list-add-remove-buttons"
     );
 
@@ -412,7 +412,7 @@ export default class DesignspaceNavigationPanel extends Panel {
       this.editSourceProperties(sourceIndex);
     });
 
-    this.sourceLayersList = this.contentElement.querySelector("#layers-list");
+    this.sourceLayersList = this.accordion.querySelector("#layers-list");
     this.sourceLayersList.columnDescriptions = [{ key: "shortName" }];
     this.sourceLayersList.addEventListener("listSelectionChanged", (event) => {
       const sourceItem = this.sourcesList.getSelectedItem();
@@ -607,7 +607,7 @@ export default class DesignspaceNavigationPanel extends Panel {
       },
     ];
 
-    const button = this.contentElement.querySelector("#font-axes-view-options-button");
+    const button = this.accordion.querySelector("#font-axes-view-options-button");
     const buttonRect = button.getBoundingClientRect();
     showMenu(menuItems, { x: buttonRect.left, y: buttonRect.bottom });
   }
@@ -623,12 +623,12 @@ export default class DesignspaceNavigationPanel extends Panel {
   _updateResetAllAxesButtonState() {
     let button;
     const fontAxesSourceSpace = mapAxesFromUserSpaceToSourceSpace(this.fontAxes);
-    button = this.contentElement.querySelector("#reset-font-axes-button");
+    button = this.accordion.querySelector("#reset-font-axes-button");
     button.disabled = isLocationAtDefault(
       this.sceneSettings.fontLocationSourceMapped,
       fontAxesSourceSpace
     );
-    button = this.contentElement.querySelector("#reset-glyph-axes-button");
+    button = this.accordion.querySelector("#reset-glyph-axes-button");
     button.disabled = isLocationAtDefault(
       this.sceneSettings.glyphLocation,
       this.glyphAxesElement.axes
@@ -1416,7 +1416,7 @@ export default class DesignspaceNavigationPanel extends Panel {
   }
 
   async _updateInterpolationErrorInfo() {
-    const infoElement = this.contentElement.querySelector("#interpolation-error-info");
+    const infoElement = this.accordion.querySelector("#interpolation-error-info");
     const varGlyphController =
       await this.sceneModel.getSelectedVariableGlyphController();
     const glyphController = await this.sceneModel.getSelectedStaticGlyphController();

--- a/src/fontra/views/editor/panel-related-glyphs.js
+++ b/src/fontra/views/editor/panel-related-glyphs.js
@@ -16,12 +16,13 @@ export default class RelatedGlyphPanel extends Panel {
   static styles = `
     .sidebar-glyph-relationships {
       height: 100%;
+      padding: 1em;
       display: flex;
+      gap: 1em;
       flex-direction: column;
     }
 
     #related-glyphs-header {
-      padding: 1em 1em 0 1em;
       text-wrap: wrap;
     }
 

--- a/src/fontra/views/fontoverview/fontoverview.css
+++ b/src/fontra/views/fontoverview/fontoverview.css
@@ -31,6 +31,7 @@ font-overview-navigation {
 
 #glyph-cell-view-container {
   overflow: auto;
+  padding: 1em;
 }
 
 .font-source-selector {


### PR DESCRIPTION
Hey @giovanniTramonto, I was just running into a situation where it's undesirable to have Accordion do its own padding. I think this fixes it. Just in case you'd like to have a look? I immediately benefitted from the border-box improvement.