### PR TITLE
[landing page] Launch the font overview, not the editor

### DIFF
--- a/src/fontra/filesystem/landing.js
+++ b/src/fontra/filesystem/landing.js
@@ -13,7 +13,7 @@ export async function startupLandingPage(authenticateFunc) {
 
   for (const project of projectList) {
     const projectElement = document.createElement("a");
-    projectElement.href = "/editor/-/" + project;
+    projectElement.href = "/fontoverview/-/" + project;
     projectElement.className = "project-item";
     projectElement.append(project);
     projectListContainer.appendChild(projectElement);


### PR DESCRIPTION
Even though the font overview isn't quite done, it is already very useful, so it's time to start using it from the landing page.