### PR TITLE
Panel component

### DIFF
--- a/src/fontra/client/core/html-utils.js
+++ b/src/fontra/client/core/html-utils.js
@@ -148,11 +148,13 @@ export function htmlToElements(html) {
   return template.content.childNodes;
 }
 
-export function addStyleSheet(cssText, element = null) {
+export function addStyleSheet(cssText, element = null, id = null) {
   if (!element) {
     element = document.head;
   }
-  element.appendChild(style({}, [cssText]));
+  if (!document.querySelector(`style#css-${id}`)) {
+    element.appendChild(style(id ? { id: `css-${id}` } : {}, [cssText]));
+  }
 }
 
 export function addStyleSheetLink(href, element = null) {

--- a/src/fontra/client/web-components/panel.js
+++ b/src/fontra/client/web-components/panel.js
@@ -1,0 +1,56 @@
+import { addStyleSheet, div } from "/core/html-utils.js";
+
+export default class Panel extends HTMLElement {
+  #cssName = "panel";
+  #styles = `
+    .panel {
+      display: flex;
+      height: 100%;
+      gap: 0.5rem;
+    }
+    .panel__section {
+      padding: 1rem;
+    }
+    .panel__section--flex {
+      flex: 1;
+    }
+    .panel__section--overflow {
+      overflow: hidden auto;
+    }
+  `;
+
+  constructor(editorController) {
+    super();
+    this.editorController = editorController;
+    addStyleSheet(this.#styles, null, this.#cssName);
+    this.classList.add(this.#cssName);
+    this.#createSections();
+  }
+
+  #createSections() {
+    const sectionClass = `${this.#cssName}__section`;
+    for (const { children, modifiers } of this.panelSections) {
+      this.appendChild(
+        div(
+          {
+            class: [
+              sectionClass,
+              ...(modifiers ?? []).map((modifier) => `${sectionClass}--${modifier}`),
+            ].join(" "),
+          },
+          children
+        )
+      );
+    }
+  }
+
+  // overridable
+  // example: [{ modifiers: ["flex", "overflow"], children: [] }]
+  get panelSections() {
+    return [];
+  }
+
+  // overridable
+  // @params (on, focus)
+  async toggle() {}
+}

--- a/src/fontra/views/editor/panel-designspace-navigation.js
+++ b/src/fontra/views/editor/panel-designspace-navigation.js
@@ -4,7 +4,7 @@ import * as html from "/core/html-utils.js";
 import { htmlToElement } from "/core/html-utils.js";
 import { translate } from "/core/localization.js";
 import { controllerKey, ObservableController } from "/core/observable-object.js";
-import { labeledTextInput } from "/core/ui-utils.js";
+import { labeledTextInput, NumberFormatter } from "/core/ui-utils.js";
 import {
   boolInt,
   enumerate,
@@ -30,10 +30,8 @@ import { IconButton } from "/web-components/icon-button.js";
 import { InlineSVG } from "/web-components/inline-svg.js";
 import { showMenu } from "/web-components/menu-panel.js";
 import { dialog, dialogSetup, message } from "/web-components/modal-dialog.js";
+import Panel from "/web-components/panel.js";
 import { Accordion } from "/web-components/ui-accordion.js";
-
-import Panel from "./panel.js";
-import { NumberFormatter } from "/core/ui-utils.js";
 
 const FONTRA_STATUS_KEY = "fontra.development.status";
 const FONTRA_STATUS_DEFINITIONS_KEY = "fontra.sourceStatusFieldDefinitions";
@@ -97,7 +95,7 @@ export default class DesignspaceNavigationPanel extends Panel {
     }
   }
 
-  getContentElement() {
+  get panelSections() {
     this.accordion = new Accordion();
     this.accordion.appendStyle(`
       .interpolation-error-icon {
@@ -208,7 +206,7 @@ export default class DesignspaceNavigationPanel extends Panel {
       },
     ];
 
-    return html.div({ style: "height: 100%; padding: 1em;" }, [this.accordion]);
+    return [{ modifiers: ["flex"], children: [this.accordion] }];
   }
 
   get fontAxesElement() {


### PR DESCRIPTION
Here is the proposal for panel-sections that I mentioned here https://github.com/googlefonts/fontra/pull/1920

I placed it in `/web-componets` to not conflict with `/views`, but could be moved later if preferred, of course.
Its a custom element instead of shadow. CSS inheritance persists.
I adjusted `addStyleSheet` in utils so using custom-elements multiple times loads the style only once. 
Actually wondering if the use of private properties in classes meets the project conventions, but found it useful to isolate local styles from extends.

I applied it only to DesignSpace-Navigation for now for this proposal. But using it all across the sidebars will improve consistency and make a lot of style repetitions redundant.