### PR TITLE
Allow actions to have a callback for a dynamic title

### DIFF
--- a/src/fontra/client/core/actions.js
+++ b/src/fontra/client/core/actions.js
@@ -28,9 +28,15 @@ actionInfoController.addListener((event) => {
   actionsByBaseKey = undefined;
 });
 
-export function registerAction(actionIdentifier, actionInfo, callback, enabled = null) {
+export function registerAction(
+  actionIdentifier,
+  actionInfo,
+  callback,
+  enabled = null,
+  title = null
+) {
   registerActionInfo(actionIdentifier, actionInfo);
-  registerActionCallbacks(actionIdentifier, callback, enabled);
+  registerActionCallbacks(actionIdentifier, callback, enabled, title);
 }
 
 const topicSortIndices = {};
@@ -55,8 +61,13 @@ export function registerActionInfo(actionIdentifier, actionInfo) {
   topicSortIndices[actionInfo.topic] = sortIndex + 1;
 }
 
-export function registerActionCallbacks(actionIdentifier, callback, enabled = null) {
-  actionCallbacks[actionIdentifier] = { callback, enabled };
+export function registerActionCallbacks(
+  actionIdentifier,
+  callback,
+  enabled = null,
+  title = null
+) {
+  actionCallbacks[actionIdentifier] = { callback, enabled, title };
 }
 
 export function setCustomShortCuts(actionIdentifier, customShortCuts) {
@@ -75,7 +86,11 @@ export function getActionInfo(actionIdentifier) {
 
 export function getActionTitle(actionIdentifier, args = "") {
   const actionInfo = getActionInfo(actionIdentifier);
-  return translate(actionInfo?.titleKey || actionIdentifier, args);
+  const callbacks = actionCallbacks[actionIdentifier];
+  return translate(
+    callbacks?.title?.() || actionInfo?.titleKey || actionIdentifier,
+    args
+  );
 }
 
 // reference: https://www.toptal.com/developers/keycode/table


### PR DESCRIPTION
It makes more sense to let the action machinery handle this than to add a dynamic title to a menu. 

It will allow us to differentiate between:

- registering a default title & default short cut for an action
- registering the implementation for an action that includes a dynamic title

We need this in #1925, where we need to register generic menu items without implementation (but with a default title), and views will provide their own implementations, with an optional dynamic title. This reduces the need to duplicate default shortcut definitions, and makes using a dynamic title clearer.