### PR TITLE
Add reusable css classes to panel view

### DIFF
--- a/src/fontra/client/css/shared.css
+++ b/src/fontra/client/css/shared.css
@@ -36,3 +36,7 @@ button,
 input[type="button"]:focus {
   outline: none;
 }
+
+.text-wrap {
+  white-space: wrap;
+}

--- a/src/fontra/client/web-components/add-remove-buttons.js
+++ b/src/fontra/client/web-components/add-remove-buttons.js
@@ -34,6 +34,7 @@ class AddRemoveButtons extends html.UnlitElement {
       background-color: var(--button-color);
       fill: var(--text-color);
       border: none;
+      line-height: 0;
     }
 
     button > inline-svg {

--- a/src/fontra/client/web-components/icon-button.js
+++ b/src/fontra/client/web-components/icon-button.js
@@ -5,6 +5,10 @@ import { FocusKeeper } from "/core/utils.js";
 
 export class IconButton extends UnlitElement {
   static styles = `
+    :host {
+      line-height: 0;
+    }
+
     button {
       background-color: transparent;
       border: none;
@@ -36,7 +40,6 @@ export class IconButton extends UnlitElement {
     button:disabled svg {
       transform: none;
     }
-
   `;
 
   constructor(src) {

--- a/src/fontra/client/web-components/ui-accordion.js
+++ b/src/fontra/client/web-components/ui-accordion.js
@@ -50,7 +50,7 @@ export class Accordion extends UnlitElement {
 
   .ui-accordion-item-content {
     display: block;
-    overflow: hidden;
+    overflow: auto;
   }
   `;
 

--- a/src/fontra/views/editor/panel-designspace-navigation.js
+++ b/src/fontra/views/editor/panel-designspace-navigation.js
@@ -209,7 +209,9 @@ export default class DesignspaceNavigationPanel extends Panel {
       },
     ];
 
-    return html.div({ style: "height: 100%; padding: 1em;" }, [this.accordion]);
+    return html.div({ class: "panel" }, [
+      html.div({ class: "panel-section panel-section--flex" }, [this.accordion]),
+    ]);
   }
 
   get fontAxesElement() {

--- a/src/fontra/views/editor/panel-designspace-navigation.js
+++ b/src/fontra/views/editor/panel-designspace-navigation.js
@@ -210,7 +210,9 @@ export default class DesignspaceNavigationPanel extends Panel {
     ];
 
     return html.div({ class: "panel" }, [
-      html.div({ class: "panel-section panel-section--flex" }, [this.accordion]),
+      html.div({ class: "panel-section panel-section--flex panel-section--noscroll" }, [
+        this.accordion,
+      ]),
     ]);
   }
 

--- a/src/fontra/views/editor/panel-glyph-note.js
+++ b/src/fontra/views/editor/panel-glyph-note.js
@@ -8,15 +8,6 @@ export default class GlyphNotePanel extends Panel {
   iconPath = "/tabler-icons/notes.svg";
 
   static styles = `
-    .sidebar-glyph-note {
-      height: 100%;
-      width: 100%;
-      display: flex;
-      flex-direction: column;
-      gap: 0.5em;
-      padding: 1em;
-    }
-
     #glyph-note-textarea {
       background-color: var(--text-input-background-color);
       color: var(--text-input-foreground-color);
@@ -36,11 +27,13 @@ export default class GlyphNotePanel extends Panel {
       opacity: 40%;
     }
 
+    .glyph-note-section {
+      display: flex;
+      flex-direction: column;
+    }
+
     .glyph-note-header {
-      overflow-x: unset;
-      text-align: left;
-      text-wrap: wrap;
-      word-break: break-word;
+      margin-bottom: 0.5em;
     }
   `;
 
@@ -65,17 +58,24 @@ export default class GlyphNotePanel extends Panel {
   getContentElement() {
     return html.div(
       {
-        class: "sidebar-glyph-note",
+        class: "panel",
       },
       [
-        html.div({ class: "glyph-note-header", id: "glyph-note-header" }, [
-          translate("sidebar.glyph-note"),
-        ]),
-        html.createDomElement("textarea", {
-          rows: 1,
-          wrap: "off",
-          id: "glyph-note-textarea",
-        }),
+        html.div(
+          {
+            class: "panel-section panel-section--flex glyph-note-section",
+          },
+          [
+            html.div({ class: "glyph-note-header", id: "glyph-note-header" }, [
+              translate("sidebar.glyph-note"),
+            ]),
+            html.createDomElement("textarea", {
+              rows: 1,
+              wrap: "off",
+              id: "glyph-note-textarea",
+            }),
+          ]
+        ),
       ]
     );
   }

--- a/src/fontra/views/editor/panel-glyph-search.js
+++ b/src/fontra/views/editor/panel-glyph-search.js
@@ -7,12 +7,10 @@ export default class GlyphSearchPanel extends Panel {
   iconPath = "/images/magnifyingglass.svg";
 
   static styles = `
-    .glyph-search {
+    .glyph-search-section {
       height: 100%;
-      width: 100%;
-      display: grid;
-      gap: 1em;
-      padding: 1em;
+      display: flex;
+      flex-direction: column;
     }
   `;
 
@@ -62,12 +60,19 @@ export default class GlyphSearchPanel extends Panel {
   getContentElement() {
     return html.div(
       {
-        class: "glyph-search",
+        class: "panel",
       },
       [
-        html.createDomElement("glyph-search-list", {
-          id: "glyph-search-list",
-        }),
+        html.div(
+          {
+            class: "panel-section panel-section--flex glyph-search-section",
+          },
+          [
+            html.createDomElement("glyph-search-list", {
+              id: "glyph-search-list",
+            }),
+          ]
+        ),
       ]
     );
   }

--- a/src/fontra/views/editor/panel-reference-font.js
+++ b/src/fontra/views/editor/panel-reference-font.js
@@ -182,13 +182,10 @@ export default class ReferenceFontPanel extends Panel {
   iconPath = "/images/reference.svg";
 
   static styles = `
-    #reference-font {
-      width: 100%;
+    .reference-font-section {
       display: grid;
       gap: 1em;
-      height: 100%;
       white-space: normal;
-      align-content: start;
     }
 
     .title {
@@ -655,48 +652,41 @@ export default class ReferenceFontPanel extends Panel {
       [
         div(
           {
-            class: "panel-section",
+            class:
+              "panel-section panel-section--flex panel-section--noscroll reference-font-section",
           },
           [
+            div({ class: "title" }, [translate("sidebar.reference-font")]),
+            div({}, [translate("sidebar.reference-font.info")]),
+            this.filesUIList,
             div(
               {
-                id: "reference-font",
-              },
-              [
-                div({ class: "title" }, [translate("sidebar.reference-font")]),
-                div({}, [translate("sidebar.reference-font.info")]),
-                this.filesUIList,
-                div(
-                  {
-                    style: `
+                style: `
                 display: grid;
                 grid-template-columns: max-content auto;
                 align-items: center;
                 gap: 0.666em;
                 `,
-                  },
-                  [
-                    label(
-                      { for: "char-override" },
-                      translate("sidebar.reference-font.custom-character")
-                    ),
-                    input({
-                      type: "text",
-                      id: "char-override",
-                      value: this.model.charOverride,
-                      oninput: (event) =>
-                        (this.model.charOverride = event.target.value),
-                    }),
-                    label(
-                      { for: "language-code" },
-                      translate("sidebar.reference-font.language")
-                    ),
-                    this.languageCodeInput,
-                  ]
+              },
+              [
+                label(
+                  { for: "char-override" },
+                  translate("sidebar.reference-font.custom-character")
                 ),
-                div({ class: "reference-font-preview" }, []),
+                input({
+                  type: "text",
+                  id: "char-override",
+                  value: this.model.charOverride,
+                  oninput: (event) => (this.model.charOverride = event.target.value),
+                }),
+                label(
+                  { for: "language-code" },
+                  translate("sidebar.reference-font.language")
+                ),
+                this.languageCodeInput,
               ]
             ),
+            div({ class: "reference-font-preview" }, []),
           ]
         ),
       ]

--- a/src/fontra/views/editor/panel-reference-font.js
+++ b/src/fontra/views/editor/panel-reference-font.js
@@ -182,16 +182,9 @@ export default class ReferenceFontPanel extends Panel {
   iconPath = "/images/reference.svg";
 
   static styles = `
-    .sidebar-reference-font {
-      width: 100%;
-      height: 100%;
-      display: flex;
-    }
-
     #reference-font {
       width: 100%;
       display: grid;
-      padding: 1em;
       gap: 1em;
       height: 100%;
       white-space: normal;
@@ -657,45 +650,53 @@ export default class ReferenceFontPanel extends Panel {
 
     return div(
       {
-        class: "sidebar-reference-font",
+        class: "panel",
       },
       [
         div(
           {
-            id: "reference-font",
+            class: "panel-section",
           },
           [
-            div({ class: "title" }, [translate("sidebar.reference-font")]),
-            div({}, [translate("sidebar.reference-font.info")]),
-            this.filesUIList,
             div(
               {
-                style: `
+                id: "reference-font",
+              },
+              [
+                div({ class: "title" }, [translate("sidebar.reference-font")]),
+                div({}, [translate("sidebar.reference-font.info")]),
+                this.filesUIList,
+                div(
+                  {
+                    style: `
                 display: grid;
                 grid-template-columns: max-content auto;
                 align-items: center;
                 gap: 0.666em;
                 `,
-              },
-              [
-                label(
-                  { for: "char-override" },
-                  translate("sidebar.reference-font.custom-character")
+                  },
+                  [
+                    label(
+                      { for: "char-override" },
+                      translate("sidebar.reference-font.custom-character")
+                    ),
+                    input({
+                      type: "text",
+                      id: "char-override",
+                      value: this.model.charOverride,
+                      oninput: (event) =>
+                        (this.model.charOverride = event.target.value),
+                    }),
+                    label(
+                      { for: "language-code" },
+                      translate("sidebar.reference-font.language")
+                    ),
+                    this.languageCodeInput,
+                  ]
                 ),
-                input({
-                  type: "text",
-                  id: "char-override",
-                  value: this.model.charOverride,
-                  oninput: (event) => (this.model.charOverride = event.target.value),
-                }),
-                label(
-                  { for: "language-code" },
-                  translate("sidebar.reference-font.language")
-                ),
-                this.languageCodeInput,
+                div({ class: "reference-font-preview" }, []),
               ]
             ),
-            div({ class: "reference-font-preview" }, []),
           ]
         ),
       ]

--- a/src/fontra/views/editor/panel-related-glyphs.js
+++ b/src/fontra/views/editor/panel-related-glyphs.js
@@ -14,22 +14,17 @@ export default class RelatedGlyphPanel extends Panel {
   iconPath = "/tabler-icons/binary-tree-2.svg";
 
   static styles = `
-    .sidebar-glyph-relationships {
-      height: 100%;
-      padding: 1em;
-      display: flex;
-      gap: 1em;
-      flex-direction: column;
-    }
-
-    #related-glyphs-header {
-      text-wrap: wrap;
-    }
-
     glyph-cell-view {
       flex: 1;
       overflow: hidden;
       height: 100%;
+    }
+
+    .related-glyphs-section {
+      height: 100%;
+      display: flex;
+      gap: 1em;
+      flex-direction: column;
     }
 
     .no-related-glyphs {
@@ -80,13 +75,20 @@ export default class RelatedGlyphPanel extends Panel {
 
     return html.div(
       {
-        class: "sidebar-glyph-relationships",
+        class: "panel",
       },
       [
-        html.div({ id: "related-glyphs-header" }, [
-          translate("sidebar.related-glyphs.related-glyphs"),
-        ]),
-        this.glyphCellView,
+        html.div(
+          {
+            class: "panel-section panel-section--flex related-glyphs-section",
+          },
+          [
+            html.div({ id: "related-glyphs-header" }, [
+              translate("sidebar.related-glyphs.related-glyphs"),
+            ]),
+            this.glyphCellView,
+          ]
+        ),
       ]
     );
   }

--- a/src/fontra/views/editor/panel-related-glyphs.js
+++ b/src/fontra/views/editor/panel-related-glyphs.js
@@ -83,7 +83,7 @@ export default class RelatedGlyphPanel extends Panel {
             class: "panel-section panel-section--flex related-glyphs-section",
           },
           [
-            html.div({ id: "related-glyphs-header" }, [
+            html.div({ id: "related-glyphs-header", class: "text-wrap" }, [
               translate("sidebar.related-glyphs.related-glyphs"),
             ]),
             this.glyphCellView,

--- a/src/fontra/views/editor/panel-selection-info.js
+++ b/src/fontra/views/editor/panel-selection-info.js
@@ -23,26 +23,6 @@ export default class SelectionInfoPanel extends Panel {
   identifier = "selection-info";
   iconPath = "/images/info.svg";
 
-  static styles = `
-    .selection-info {
-      display: flex;
-      flex-direction: column;
-      justify-content: space-between;
-      height: 100%;
-      width: 100%;
-      white-space: normal;
-    }
-
-    .selection-info-section {
-      padding: 1em;
-    }
-
-    .selection-info-section--scrollable {
-      flex: 1;
-      overflow: hidden auto;
-    }
-  `;
-
   constructor(editorController) {
     super(editorController);
     this.throttledUpdate = throttleCalls((senderID) => this.update(senderID), 100);
@@ -86,14 +66,14 @@ export default class SelectionInfoPanel extends Panel {
     this.infoForm = new Form();
     return html.div(
       {
-        class: "selection-info",
+        class: "panel",
       },
       [
         html.div(
-          { class: "selection-info-section selection-info-section--scrollable" },
+          { class: "panel-section panel-section--flex panel-section--scrollable" },
           [this.infoForm]
         ),
-        html.div({ class: "selection-info-section" }, this.getBehaviorElements()),
+        html.div({ class: "panel-section" }, this.getBehaviorElements()),
       ]
     );
   }

--- a/src/fontra/views/editor/panel-selection-info.js
+++ b/src/fontra/views/editor/panel-selection-info.js
@@ -98,7 +98,7 @@ export default class SelectionInfoPanel extends Panel {
         },
       }),
       html.label(
-        { for: "behavior-checkbox" },
+        { for: "behavior-checkbox", class: "text-wrap" },
         translate("sidebar.selection-info.multi-source")
       ),
     ];

--- a/src/fontra/views/editor/panel-text-entry.js
+++ b/src/fontra/views/editor/panel-text-entry.js
@@ -7,13 +7,10 @@ export default class TextEntryPanel extends Panel {
   iconPath = "/images/texttool.svg";
 
   static styles = `
-    .sidebar-text-entry {
-      height: 100%;
-      width: 100%;
+    .text-entry-section {
       display: flex;
       flex-direction: column;
       gap: 0.5em;
-      padding: 1em;
     }
 
     #text-align-menu {
@@ -77,32 +74,39 @@ export default class TextEntryPanel extends Panel {
   getContentElement() {
     return html.div(
       {
-        class: "sidebar-text-entry",
+        class: "panel",
       },
       [
-        html.createDomElement("textarea", {
-          rows: 1,
-          wrap: "off",
-          id: "text-entry-textarea",
-        }),
         html.div(
           {
-            id: "text-align-menu",
+            class: "panel-section text-entry-section",
           },
           [
-            html.createDomElement("inline-svg", {
-              "data-align": "left",
-              "src": "/images/alignleft.svg",
+            html.createDomElement("textarea", {
+              rows: 1,
+              wrap: "off",
+              id: "text-entry-textarea",
             }),
-            html.createDomElement("inline-svg", {
-              "class": "selected",
-              "data-align": "center",
-              "src": "/images/aligncenter.svg",
-            }),
-            html.createDomElement("inline-svg", {
-              "data-align": "right",
-              "src": "/images/alignright.svg",
-            }),
+            html.div(
+              {
+                id: "text-align-menu",
+              },
+              [
+                html.createDomElement("inline-svg", {
+                  "data-align": "left",
+                  "src": "/images/alignleft.svg",
+                }),
+                html.createDomElement("inline-svg", {
+                  "class": "selected",
+                  "data-align": "center",
+                  "src": "/images/aligncenter.svg",
+                }),
+                html.createDomElement("inline-svg", {
+                  "data-align": "right",
+                  "src": "/images/alignright.svg",
+                }),
+              ]
+            ),
           ]
         ),
       ]

--- a/src/fontra/views/editor/panel-transformation.js
+++ b/src/fontra/views/editor/panel-transformation.js
@@ -82,7 +82,10 @@ export default class TransformationPanel extends Panel {
     this.infoForm = new Form();
     this.infoForm.appendStyle(TransformationPanel.stylesForm);
     this.contentElement.appendChild(
-      html.div({ class: "selection-transformation-section" }, [this.infoForm])
+      html.div(
+        { class: "panel-section panel-section--flex panel-section--scrollable" },
+        [this.infoForm]
+      )
     );
     this.fontController = this.editorController.fontController;
     this.sceneController = this.editorController.sceneController;
@@ -155,7 +158,7 @@ export default class TransformationPanel extends Panel {
   getContentElement() {
     return html.div(
       {
-        class: "selection-transformation",
+        class: "panel",
       },
       []
     );

--- a/src/fontra/views/editor/panel.js
+++ b/src/fontra/views/editor/panel.js
@@ -17,6 +17,9 @@ export default class Panel extends SimpleElement {
     .panel-section--scrollable {
       overflow: hidden auto;
     }
+    .panel-section--noscroll {
+      overflow: hidden;
+    }
   `;
 
   constructor(editorController) {

--- a/src/fontra/views/editor/panel.js
+++ b/src/fontra/views/editor/panel.js
@@ -1,9 +1,28 @@
 import { SimpleElement } from "/core/html-utils.js";
 
 export default class Panel extends SimpleElement {
+  panelStyles = `
+    .panel {
+      display: flex;
+      flex-direction: column;
+      height: 100%;
+      gap: 0.5em;
+    }
+    .panel-section {
+      padding: 1em;
+    }
+    .panel-section--flex {
+      flex: 1;
+    }
+    .panel-section--scrollable {
+      overflow: hidden auto;
+    }
+  `;
+
   constructor(editorController) {
     super();
     this.editorController = editorController;
+    this._appendStyle(this.panelStyles);
     this.contentElement = this.getContentElement();
     this.shadowRoot.appendChild(this.contentElement);
   }

--- a/src/fontra/views/fontoverview/fontoverview.css
+++ b/src/fontra/views/fontoverview/fontoverview.css
@@ -11,23 +11,23 @@ body {
   height: calc(100vh - var(--top-bar-height));
 }
 
-#sidebar-container {
-  display: grid;
-  align-content: start;
-  gap: 1em;
-  padding: 1em 1em 1em 1em;
+.sidebar-container {
   background-color: var(--ui-element-background-color);
   height: calc(100vh - var(--top-bar-height));
-  overflow: auto;
-}
-
-.font-overview-sidebar-shadow-box {
   box-shadow: 0px 0px 8px #0006;
 }
 
 font-overview-navigation {
-  display: grid;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  padding: 1em;
   gap: 1em;
+}
+
+.font-overview-navigation-section {
+  flex: 1;
+  overflow: hidden;
 }
 
 #glyph-cell-view-container {

--- a/src/fontra/views/fontoverview/fontoverview.html
+++ b/src/fontra/views/fontoverview/fontoverview.html
@@ -13,7 +13,7 @@
     <div id="global-loader-spinner"></div>
     <div class="top-bar-container"></div>
     <div class="main-container">
-      <div id="sidebar-container" class="font-overview-sidebar-shadow-box"></div>
+      <div id="sidebar-container" class="sidebar-container"></div>
       <div id="glyph-cell-view-container"></div>
     </div>
   </body>

--- a/src/fontra/views/fontoverview/panel-navigation.js
+++ b/src/fontra/views/fontoverview/panel-navigation.js
@@ -165,7 +165,9 @@ export class FontOverviewNavigation extends HTMLElement {
 
     accordion.items = accordionItems;
 
-    this.appendChild(accordion);
+    this.appendChild(
+      html.div({ class: "font-overview-navigation-section" }, [accordion])
+    );
 
     this.fontOverviewSettingsController.addKeyListener("projectGlyphSets", (event) =>
       this._updateProjectGlyphSets()


### PR DESCRIPTION
Another attempt to make panel styles more consistent.
This time logic of `panel.js` did not change, but only reusable styles were added.
The node structure of all inheriting panels got harmonized to `.panel` wrapper containing `panel-section` and made a lot of styles redundant.