### PR TITLE
[font overview] tweak no glyphs message

### DIFF
--- a/src/fontra/views/editor/panel-related-glyphs.js
+++ b/src/fontra/views/editor/panel-related-glyphs.js
@@ -32,7 +32,7 @@ export default class RelatedGlyphPanel extends Panel {
     }
 
     .no-related-glyphs {
-      color: #AAA;
+      color: #999;
       padding-top: 1em;
     }
   `;

--- a/src/fontra/views/fontoverview/fontoverview.css
+++ b/src/fontra/views/fontoverview/fontoverview.css
@@ -46,11 +46,12 @@ font-overview-navigation {
 }
 
 #font-overview-no-glyphs {
-  color: #aaa;
+  display: none;
+  color: #999;
   width: 100%;
   text-align: center;
 }
 
-.hidden {
-  display: none;
+#font-overview-no-glyphs.shown {
+  display: block;
 }

--- a/src/fontra/views/fontoverview/fontoverview.js
+++ b/src/fontra/views/fontoverview/fontoverview.js
@@ -348,10 +348,8 @@ export class FontOverviewController extends ViewController {
     this.glyphCellView.setGlyphSections(glyphSections);
 
     // Show placeholder if no glyphs are found
-    const fontOverviewNoGlyphsContainer = document.querySelector(
-      "#font-overview-no-glyphs"
-    );
-    fontOverviewNoGlyphsContainer.classList.toggle("hidden", glyphSections.length > 0);
+    const noGlyphsElement = document.querySelector("#font-overview-no-glyphs");
+    noGlyphsElement.classList.toggle("shown", !glyphSections.length);
   }
 
   async _getCombineGlyphItemList() {


### PR DESCRIPTION
- It should be _invisible_ by default, or you'll see it flash by before the glyph cells are made
- reversed the on/off logic, use class named 'shown'
- tweaked the color (made related glyphs equivalent match), so it looks better in dark mode
- shortened an overly long local variable

Followup to #1947.