### PR TITLE
Add location sliders to font overview

### DIFF
--- a/src/fontra/views/fontoverview/fontoverview.css
+++ b/src/fontra/views/fontoverview/fontoverview.css
@@ -18,6 +18,7 @@ body {
   padding: 1em 1em 1em 1em;
   background-color: var(--ui-element-background-color);
   height: calc(100vh - var(--top-bar-height));
+  overflow: auto;
 }
 
 .font-overview-sidebar-shadow-box {

--- a/src/fontra/views/fontoverview/fontoverview.html
+++ b/src/fontra/views/fontoverview/fontoverview.html
@@ -8,6 +8,7 @@
     <link href="/css/tooltip.css" rel="stylesheet" />
     <title>Fontra Font Overview</title>
     <script type="module" src="/web-components/modal-dialog.js"></script>
+    <script type="module" src="/web-components/designspace-location.js"></script>
     <script type="module" src="/web-components/glyph-search-field.js"></script>
     <script type="module" src="/core/theme-settings.js"></script>
   </head>

--- a/src/fontra/views/fontoverview/fontoverview.html
+++ b/src/fontra/views/fontoverview/fontoverview.html
@@ -8,8 +8,6 @@
     <link href="/css/tooltip.css" rel="stylesheet" />
     <title>Fontra Font Overview</title>
     <script type="module" src="/web-components/modal-dialog.js"></script>
-    <script type="module" src="/web-components/designspace-location.js"></script>
-    <script type="module" src="/web-components/glyph-search-field.js"></script>
     <script type="module" src="/core/theme-settings.js"></script>
   </head>
   <body>

--- a/src/fontra/views/fontoverview/fontoverview.js
+++ b/src/fontra/views/fontoverview/fontoverview.js
@@ -278,12 +278,10 @@ export class FontOverviewController extends ViewController {
       "fontLocationSource",
       (event) => {
         if (!event.senderInfo?.fromFontLocationUser) {
-          this.fontOverviewSettingsController.withSenderInfo(
-            { fromFontLocationSource: true },
-            () => {
-              this.fontOverviewSettingsController.model.fontLocationUser =
-                this.fontController.mapSourceLocationToUserLocation(event.newValue);
-            }
+          this.fontOverviewSettingsController.setItem(
+            "fontLocationUser",
+            this.fontController.mapSourceLocationToUserLocation(event.newValue),
+            { fromFontLocationSource: true }
           );
         }
       }
@@ -291,12 +289,10 @@ export class FontOverviewController extends ViewController {
 
     this.fontOverviewSettingsController.addKeyListener("fontLocationUser", (event) => {
       if (!event.senderInfo?.fromFontLocationSource) {
-        this.fontOverviewSettingsController.withSenderInfo(
-          { fromFontLocationUser: true },
-          () => {
-            this.fontOverviewSettingsController.model.fontLocationSource =
-              this.fontController.mapUserLocationToSourceLocation(event.newValue);
-          }
+        this.fontOverviewSettingsController.setItem(
+          "fontLocationSource",
+          this.fontController.mapUserLocationToSourceLocation(event.newValue),
+          { fromFontLocationUser: true }
         );
       }
     });

--- a/src/fontra/views/fontoverview/panel-navigation.js
+++ b/src/fontra/views/fontoverview/panel-navigation.js
@@ -15,6 +15,7 @@ import {
   popupSelect,
 } from "/core/ui-utils.js";
 import { scheduleCalls } from "/core/utils.js";
+import { DesignspaceLocation } from "/web-components/designspace-location.js";
 import { GlyphSearchField } from "/web-components/glyph-search-field.js";
 import { IconButton } from "/web-components/icon-button.js"; // required for the icon buttons
 import { showMenu } from "/web-components/menu-panel.js";
@@ -228,13 +229,7 @@ export class FontOverviewNavigation extends HTMLElement {
   }
 
   async _makeFontSourceSliders() {
-    const locationElement = html.createDomElement("designspace-location", {
-      style: `grid-column: 1 / -1;
-        min-height: 0;
-        overflow: auto;
-        height: 100%;
-      `,
-    });
+    const locationElement = new DesignspaceLocation();
     locationElement.axes = this.fontController.axes.axes;
     locationElement.values = { ...this.fontOverviewSettings.fontLocationUser };
 

--- a/src/fontra/views/fontoverview/panel-navigation.js
+++ b/src/fontra/views/fontoverview/panel-navigation.js
@@ -135,7 +135,7 @@ export class FontOverviewNavigation extends HTMLElement {
         id: "location",
         content: html.div({ class: "font-source-location-container" }, [
           await this._makeFontSourcePopup(),
-          await this._makeFontSourceSliders(),
+          this._makeFontSourceSliders(),
         ]),
       },
       {
@@ -224,7 +224,7 @@ export class FontOverviewNavigation extends HTMLElement {
     return popupSelect(controller, "value", options);
   }
 
-  async _makeFontSourceSliders() {
+  _makeFontSourceSliders() {
     const locationElement = new DesignspaceLocation();
     locationElement.axes = this.fontController.axes.axes;
     locationElement.values = { ...this.fontOverviewSettings.fontLocationUser };

--- a/src/fontra/views/fontoverview/panel-navigation.js
+++ b/src/fontra/views/fontoverview/panel-navigation.js
@@ -209,14 +209,14 @@ export class FontOverviewNavigation extends HTMLElement {
 
     this.locationControllerPopup.addKeyListener("value", (event) => {
       const fontSourceIdentifier = event.newValue;
-      this.sourceLocation = {
+      const sourceLocation = {
         ...fontSources[fontSourceIdentifier]?.location,
       }; // A font may not have any font sources, therefore the ?-check
       // TODO: set the sliders controller. The following does not work:
-      //this.locationControllerSliders.setItem(this.sourceLocation);
+      // this.locationControllerSliders.setItem(sourceLocation);
       this.fontOverviewSettingsController.setItem(
         "fontLocationSource",
-        this.sourceLocation,
+        sourceLocation,
         { sentFromInput: true }
       );
     });
@@ -229,9 +229,7 @@ export class FontOverviewNavigation extends HTMLElement {
       this.fontController.axes.axes
     );
 
-    this.locationControllerSliders = new ObservableController({
-      ...this.sourceLocation,
-    });
+    this.locationControllerSliders = new ObservableController({});
 
     const locationElement = html.createDomElement("designspace-location", {
       style: `grid-column: 1 / -1;

--- a/src/fontra/views/fontoverview/panel-navigation.js
+++ b/src/fontra/views/fontoverview/panel-navigation.js
@@ -213,7 +213,7 @@ export class FontOverviewNavigation extends HTMLElement {
         ...fontSources[fontSourceIdentifier]?.location,
       }; // A font may not have any font sources, therefore the ?-check
       // TODO: set the sliders controller. The following does not work:
-      // this.locationControllerSilders.setItem(this.sourceLocation);
+      //this.locationControllerSliders.setItem(this.sourceLocation);
       this.fontOverviewSettingsController.setItem(
         "fontLocationSource",
         this.sourceLocation,
@@ -229,7 +229,7 @@ export class FontOverviewNavigation extends HTMLElement {
       this.fontController.axes.axes
     );
 
-    this.locationControllerSilders = new ObservableController({
+    this.locationControllerSliders = new ObservableController({
       ...this.sourceLocation,
     });
 
@@ -241,10 +241,10 @@ export class FontOverviewNavigation extends HTMLElement {
       `,
     });
     locationElement.axes = locationAxes;
-    locationElement.controller = this.locationControllerSilders;
+    locationElement.controller = this.locationControllerSliders;
 
-    this.locationControllerSilders.addListener((event) => {
-      const sourceLocation = { ...this.locationControllerSilders.model };
+    this.locationControllerSliders.addListener((event) => {
+      const sourceLocation = { ...this.locationControllerSliders.model };
       const fontSourceIdentifier =
         this.fontController.fontSourcesInstancer.getLocationIdentifierForLocation(
           sourceLocation

--- a/src/fontra/views/fontoverview/panel-navigation.js
+++ b/src/fontra/views/fontoverview/panel-navigation.js
@@ -1,7 +1,3 @@
-import {
-  makeSparseLocation,
-  mapAxesFromUserSpaceToSourceSpace,
-} from "../core/var-model.js";
 import { groupByKeys, groupByProperties } from "/core/glyph-organizer.js";
 import * as html from "/core/html-utils.js";
 import { translate } from "/core/localization.js";


### PR DESCRIPTION
Fixes #1948

Draft PR for feedback.

Do you mind to give me a hint how I can make the sliders change when changing the font source via the dropdown? It should work equal to the editor view when changing the source of a glyph, but I was not able to figure out how you implemented it.