### PR TITLE
Move export-as actions to view-controller

### DIFF
--- a/src/fontra/client/core/view-controller.js
+++ b/src/fontra/client/core/view-controller.js
@@ -1,3 +1,4 @@
+import { registerAction } from "./actions.js";
 import { Backend } from "./backend-api.js";
 import { FontController } from "./font-controller.js";
 import { getRemoteProxy } from "./remote.js";
@@ -32,6 +33,7 @@ export class ViewController {
     );
 
     await controller.start();
+    controller.afterStart();
     return controller;
   }
 
@@ -40,7 +42,21 @@ export class ViewController {
   }
 
   async start() {
-    console.error("ViewController.start() not implemented");
+    await this.fontController.initialize();
+  }
+
+  afterStart() {
+    for (const format of this.fontController.backendInfo.projectManagerFeatures[
+      "export-as"
+    ] || []) {
+      registerAction(
+        `action.export-as.${format}`,
+        {
+          topic: "0035-action-topics.export-as",
+        },
+        (event) => this.fontController.exportAs({ format })
+      );
+    }
   }
 
   /**

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -625,17 +625,6 @@ export class EditorController extends ViewController {
   }
 
   initActionsAfterStart() {
-    for (const format of this.fontController.backendInfo.projectManagerFeatures[
-      "export-as"
-    ] || []) {
-      registerAction(
-        `action.export-as.${format}`,
-        {
-          topic: "0035-action-topics.export-as",
-        },
-        (event) => this.fontController.exportAs({ format })
-      );
-    }
     if (this.fontController.backendInfo.features["find-glyphs-that-use-glyph"]) {
       registerAction(
         "action.find-glyphs-that-use",
@@ -773,7 +762,7 @@ export class EditorController extends ViewController {
   }
 
   async _start() {
-    await this.fontController.initialize();
+    await super.start();
     const rootSubscriptionPattern = {};
     for (const rootKey of this.fontController.getRootKeys()) {
       rootSubscriptionPattern[rootKey] = null;

--- a/src/fontra/views/fontinfo/fontinfo.js
+++ b/src/fontra/views/fontinfo/fontinfo.js
@@ -13,7 +13,7 @@ export class FontInfoController extends ViewController {
   }
 
   async start() {
-    await this.fontController.initialize();
+    await super.start();
 
     const url = new URL(window.location);
     this.selectedPanel = url.hash ? url.hash.slice(1) : "font-info-panel";

--- a/src/fontra/views/fontoverview/fontoverview.js
+++ b/src/fontra/views/fontoverview/fontoverview.js
@@ -100,7 +100,7 @@ export class FontOverviewController extends ViewController {
   }
 
   async _start() {
-    await this.fontController.initialize();
+    await super.start();
 
     this.fontSources = await this.fontController.getSources();
 


### PR DESCRIPTION
view-controler.js:
- Add default implementation for start() (subclasses not need to call super.start())
- Move export-as actions to view-controller so all views automatically get this functionality

This fixes #1957