### PR TITLE
Use ?project= instead of /-/

### DIFF
--- a/src/fontra/client/core/view-controller.js
+++ b/src/fontra/client/core/view-controller.js
@@ -11,7 +11,7 @@ export class ViewController {
     return `Fontra — ${decodeURI(displayPath)}`;
   }
   static async fromBackend() {
-    const pathItems = window.location.pathname.split("/").slice(3);
+    const pathItems = new URL(window.location).searchParams.get("project").split("/");
     const displayPath = makeDisplayPath(pathItems);
     document.title = this.titlePattern(displayPath);
     const projectPath = pathItems.join("/");

--- a/src/fontra/core/server.py
+++ b/src/fontra/core/server.py
@@ -78,10 +78,7 @@ class FontraServer:
             )
         for viewName, viewPackage in self.viewEntryPoints.items():
             routes.append(
-                web.get(
-                    f"/{viewName}/-/{{path:.*}}",
-                    partial(self.viewPathHandler, viewName),
-                )
+                web.get(f"/{viewName}/-/{{path:.*}}", self.viewRedirectHandler)
             )
             routes.append(
                 web.get(
@@ -294,6 +291,9 @@ class FontraServer:
         html = self._addVersionTokenToReferences(html, "text/html")
 
         return web.Response(body=html, content_type="text/html")
+
+    async def viewRedirectHandler(self, request: web.Request) -> web.Response:
+        raise web.HTTPFound(request.path.replace("/-/", "/?project="))
 
     def _addVersionTokenToReferences(self, data: bytes, contentType: str) -> bytes:
         if self.versionToken is None:

--- a/src/fontra/core/server.py
+++ b/src/fontra/core/server.py
@@ -283,7 +283,9 @@ class FontraServer:
             )
 
         project = request.query.get("project")
-        if not await self.projectManager.projectAvailable(project, authToken):
+        if project and not await self.projectManager.projectAvailable(
+            project, authToken
+        ):
             raise web.HTTPNotFound()
 
         try:

--- a/src/fontra/core/server.py
+++ b/src/fontra/core/server.py
@@ -83,7 +83,7 @@ class FontraServer:
             routes.append(
                 web.get(
                     f"/{viewName}/{{path:.*}}",
-                    partial(self.staticContentHandler, viewPackage),
+                    partial(self.viewPathHandler, viewName),
                 )
             )
         routes.append(
@@ -277,8 +277,13 @@ class FontraServer:
             qs = quote(request.path_qs, safe="")
             raise web.HTTPFound(f"/?ref={qs}")
 
-        path = request.match_info["path"]
-        if not await self.projectManager.projectAvailable(path, authToken):
+        if not request.query:
+            return await self.staticContentHandler(
+                self.viewEntryPoints[viewName], request
+            )
+
+        project = request.query.get("project")
+        if not await self.projectManager.projectAvailable(project, authToken):
             raise web.HTTPNotFound()
 
         try:

--- a/src/fontra/core/server.py
+++ b/src/fontra/core/server.py
@@ -283,7 +283,7 @@ class FontraServer:
             )
 
         project = request.query.get("project")
-        if project and not await self.projectManager.projectAvailable(
+        if project is None or not await self.projectManager.projectAvailable(
             project, authToken
         ):
             raise web.HTTPNotFound()

--- a/src/fontra/filesystem/landing.js
+++ b/src/fontra/filesystem/landing.js
@@ -13,7 +13,7 @@ export async function startupLandingPage(authenticateFunc) {
 
   for (const project of projectList) {
     const projectElement = document.createElement("a");
-    projectElement.href = "/fontoverview/-/" + project;
+    projectElement.href = "/fontoverview/?project=" + project;
     projectElement.className = "project-item";
     projectElement.append(project);
     projectListContainer.appendChild(projectElement);


### PR DESCRIPTION
This fixes #1960, part of #1952. Supports redirecting existing URLs. I've chosen `?project=` as the query string parameter to hold the project ID. Assumes that URLs requesting static assets do not have a query string attached.