### PR TITLE
[font overview] When no glyph sets are selected (including the font's own set), select all project sets

### DIFF
--- a/src/fontra/views/fontoverview/fontoverview.js
+++ b/src/fontra/views/fontoverview/fontoverview.js
@@ -227,7 +227,7 @@ export class FontOverviewController extends ViewController {
           "customData",
           (root) => {
             const projectGlyphSets = Object.values(event.newValue).filter(
-              (glyphSet) => glyphSet.url
+              (glyphSet) => glyphSet.url !== THIS_FONTS_GLYPHSET
             );
             root.customData[PROJECT_GLYPH_SETS_CUSTOM_DATA_KEY] = projectGlyphSets;
           },

--- a/src/fontra/views/fontoverview/fontoverview.js
+++ b/src/fontra/views/fontoverview/fontoverview.js
@@ -58,7 +58,7 @@ function getDefaultFontOverviewSettings() {
     groupByKeys: [],
     projectGlyphSets: {},
     myGlyphSets: {},
-    projectGlyphSetSelection: [THIS_FONTS_GLYPHSET],
+    projectGlyphSetSelection: [],
     myGlyphSetSelection: [],
     glyphSetErrors: {},
     cellMagnification: 1,
@@ -315,6 +315,16 @@ export class FontOverviewController extends ViewController {
         }
       }
     });
+    if (
+      !this.fontOverviewSettings.myGlyphSetSelection.length &&
+      !this.fontOverviewSettings.projectGlyphSetSelection.length
+    ) {
+      this.fontOverviewSettings.projectGlyphSetSelection = [
+        THIS_FONTS_GLYPHSET,
+        ...Object.keys(this.fontOverviewSettings.projectGlyphSets),
+      ];
+      console.log("maybe enable some glyph sets");
+    }
   }
 
   _updateWindowLocation() {
@@ -554,7 +564,7 @@ function openGlyphsInEditor(glyphsInfo, userLocation, glyphMap) {
 function readProjectGlyphSets(fontController) {
   return Object.fromEntries(
     [
-      { name: "This font's glyphs", url: "" },
+      { name: "This font's glyphs", url: THIS_FONTS_GLYPHSET },
       ...(fontController.customData[PROJECT_GLYPH_SETS_CUSTOM_DATA_KEY] || []),
     ].map((glyphSet) => [glyphSet.url, glyphSet])
   );

--- a/src/fontra/views/fontoverview/fontoverview.js
+++ b/src/fontra/views/fontoverview/fontoverview.js
@@ -323,7 +323,6 @@ export class FontOverviewController extends ViewController {
         THIS_FONTS_GLYPHSET,
         ...Object.keys(this.fontOverviewSettings.projectGlyphSets),
       ];
-      console.log("maybe enable some glyph sets");
     }
   }
 

--- a/src/fontra/views/fontoverview/fontoverview.js
+++ b/src/fontra/views/fontoverview/fontoverview.js
@@ -321,7 +321,9 @@ export class FontOverviewController extends ViewController {
     ) {
       this.fontOverviewSettings.projectGlyphSetSelection = [
         THIS_FONTS_GLYPHSET,
-        ...Object.keys(this.fontOverviewSettings.projectGlyphSets),
+        ...Object.values(this.fontOverviewSettings.projectGlyphSets).map(
+          ({ url }) => url
+        ),
       ];
     }
   }


### PR DESCRIPTION
To avoid showing no glyphs at all, select all project glyph sets. This fixes #1944.