### PR TITLE
[font overview] When overlaying multiple glyph sets, sort according to the builtin rules

### DIFF
--- a/src/fontra/client/core/parse-glyphset.js
+++ b/src/fontra/client/core/parse-glyphset.js
@@ -20,7 +20,7 @@ export function parseGlyphSet(sourceData, dataFormat, dataOptions) {
     case "tsv/csv":
       return parseGlyphSetGlyphTable(sourceLines, dataOptions);
     default:
-      throw new Error(`unknow data format: ${dataFormat}`);
+      throw new Error(`unknown data format: ${dataFormat}`);
   }
 }
 

--- a/src/fontra/views/fontoverview/fontoverview.js
+++ b/src/fontra/views/fontoverview/fontoverview.js
@@ -445,6 +445,8 @@ export class FontOverviewController extends ViewController {
     }
 
     const combinedItemList = glyphMapToItemList(combinedGlyphMap);
+    // When overlaying multiple glyph sets, sort the list, or else we
+    // may end up with a garbled mess of ordering
     return glyphSetKeys.length > 1
       ? this.glyphOrganizer.sortGlyphs(combinedItemList)
       : combinedItemList;

--- a/src/fontra/views/fontoverview/fontoverview.js
+++ b/src/fontra/views/fontoverview/fontoverview.js
@@ -413,8 +413,10 @@ export class FontOverviewController extends ViewController {
     const combinedGlyphMap = getGlyphMapProxy({}, combinedCharacterMap);
 
     const glyphSetKeys = [
-      ...this.fontOverviewSettings.projectGlyphSetSelection,
-      ...this.fontOverviewSettings.myGlyphSetSelection,
+      ...new Set([
+        ...this.fontOverviewSettings.projectGlyphSetSelection,
+        ...this.fontOverviewSettings.myGlyphSetSelection,
+      ]),
     ];
     glyphSetKeys.sort();
 

--- a/src/fontra/views/fontoverview/fontoverview.js
+++ b/src/fontra/views/fontoverview/fontoverview.js
@@ -444,7 +444,10 @@ export class FontOverviewController extends ViewController {
       }
     }
 
-    return glyphMapToItemList(combinedGlyphMap);
+    const combinedItemList = glyphMapToItemList(combinedGlyphMap);
+    return glyphSetKeys.length > 1
+      ? this.glyphOrganizer.sortGlyphs(combinedItemList)
+      : combinedItemList;
   }
 
   async _loadGlyphSet(glyphSetKey) {

--- a/src/fontra/views/fontoverview/fontoverview.js
+++ b/src/fontra/views/fontoverview/fontoverview.js
@@ -358,9 +358,9 @@ export class FontOverviewController extends ViewController {
     ) {
       this.fontOverviewSettings.projectGlyphSetSelection = [
         THIS_FONTS_GLYPHSET,
-        ...Object.values(this.fontOverviewSettings.projectGlyphSets).map(
-          ({ url }) => url
-        ),
+        ...Object.values(this.fontOverviewSettings.projectGlyphSets)
+          .map(({ url }) => url)
+          .filter((url) => url),
       ];
     }
   }
@@ -418,15 +418,13 @@ export class FontOverviewController extends ViewController {
     ];
     glyphSetKeys.sort();
 
-    const glyphSets = await Promise.all(
-      glyphSetKeys.map((glyphSetKey) => this._loadGlyphSet(glyphSetKey))
-    );
+    const glyphSets = (
+      await Promise.all(
+        glyphSetKeys.map((glyphSetKey) => this._loadGlyphSet(glyphSetKey))
+      )
+    ).filter((glyphSet) => glyphSet);
 
     for (const glyphSet of glyphSets) {
-      if (!glyphSet) {
-        continue;
-      }
-
       for (const { glyphName, codePoints } of glyphSet) {
         const singleCodePoint = codePoints.length === 1 ? codePoints[0] : null;
         const foundGlyphName =


### PR DESCRIPTION
When only a single glyphset it selected, we show the order of that glyph set.

This fixes #1971, to some extent at least.

This may need more thought and/or discussion.