### PR TITLE
Recover more gracefully from glyph delete backend error

### DIFF
--- a/src/fontra/client/core/font-controller.js
+++ b/src/fontra/client/core/font-controller.js
@@ -20,6 +20,7 @@ import {
   colorizeImage,
   getCharFromCodePoint,
   mapObjectValues,
+  sleepAsync,
   throttleCalls,
   uniqueID,
 } from "./utils.js";
@@ -850,6 +851,12 @@ export class FontController {
 
   async reloadGlyphs(glyphNames) {
     for (const glyphName of glyphNames) {
+      if (!this.glyphMap[glyphName]) {
+        // Hmm, glyph deletion caused an error in the backend, now the
+        // glyphMap needs to be reloaded, too. We're running into a
+        // weird timing problem, and this sleepAsync() resolves that.
+        await sleepAsync(0);
+      }
       this._purgeGlyphCache(glyphName);
       // The undo stack is local, so any external change invalidates it
       delete this.undoStacks[glyphName];


### PR DESCRIPTION
When deleting a glyphs raises an error, the glyphMap should also be reloaded.

This fixes #1978.