### PR TITLE
Make bundler actions generically named

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "test": "mocha test-js --reporter spec",
-    "bundle-rollup": "rollup --bundleConfigAsCjs -c"
+    "bundle": "rollup --bundleConfigAsCjs -c"
   },
   "type": "module",
   "devDependencies": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,7 @@ source = "vcs"
 
 
 [tool.hatch.build.hooks.custom]
-path = "scripts/rollup_build_hook.py"
+path = "scripts/bundler_build_hook.py"
 
 
 [tool.hatch.build.hooks.vcs]

--- a/scripts/bundler_build_hook.py
+++ b/scripts/bundler_build_hook.py
@@ -17,4 +17,4 @@ class RollupBuildHook(BuildHookInterface):
         if path.exists():
             shutil.rmtree(path)
         subprocess.check_output("npm install", shell=True)
-        subprocess.check_output("npm run bundle-rollup", shell=True)
+        subprocess.check_output("npm run bundle", shell=True)


### PR DESCRIPTION
This is a cosmetic change to the build system, aiming to minimise the invasiveness of #1952. When we move to bundling everything with webpack, it'll be a one-line change in package.json and there won't be odd references to `rollup` everywhere.