### PR TITLE
Move JS code from HTML to start.js

### DIFF
--- a/src/fontra/views/applicationsettings/applicationsettings.html
+++ b/src/fontra/views/applicationsettings/applicationsettings.html
@@ -6,10 +6,6 @@
     <link href="/css/core.css" rel="stylesheet" />
     <link href="/css/tooltip.css" rel="stylesheet" />
     <title>Fontra Application Settings</title>
-    <script type="module" src="/web-components/modal-dialog.js"></script>
-    <script type="module" src="/web-components/grouped-settings.js"></script>
-    <script type="module" src="/web-components/plugin-manager.js"></script>
-    <script type="module" src="/core/theme-settings.js"></script>
     <style>
       body {
         overflow: auto;
@@ -67,14 +63,5 @@
       <div id="panel-container"></div>
     </div>
   </body>
-  <script type="module">
-    import { ApplicationSettingsController } from "/applicationsettings/applicationsettings.js";
-
-    async function startApp() {
-      window.applicationSettingsController = new ApplicationSettingsController();
-      await window.applicationSettingsController.start();
-    }
-
-    startApp();
-  </script>
+  <script type="module" src="/applicationsettings/start.js"></script>
 </html>

--- a/src/fontra/views/applicationsettings/start.js
+++ b/src/fontra/views/applicationsettings/start.js
@@ -1,0 +1,13 @@
+import "/core/theme-settings.js";
+import "/web-components/grouped-settings.js";
+import "/web-components/modal-dialog.js";
+import "/web-components/plugin-manager.js";
+
+import { ApplicationSettingsController } from "/applicationsettings/applicationsettings.js";
+
+async function startApp() {
+  window.applicationSettingsController = new ApplicationSettingsController();
+  await window.applicationSettingsController.start();
+}
+
+startApp();

--- a/src/fontra/views/editor/editor.html
+++ b/src/fontra/views/editor/editor.html
@@ -14,14 +14,6 @@
         }
       }
     </script>
-    <script type="module" src="/core/theme-settings.js"></script>
-    <script type="module" src="/web-components/add-remove-buttons.js"></script>
-    <script type="module" src="/web-components/designspace-location.js"></script>
-    <script type="module" src="/web-components/glyph-search-list.js"></script>
-    <script type="module" src="/web-components/grouped-settings.js"></script>
-    <script type="module" src="/web-components/inline-svg.js"></script>
-    <script type="module" src="/web-components/modal-dialog.js"></script>
-    <script type="module" src="/web-components/ui-list.js"></script>
   </head>
   <body>
     <modal-dialog></modal-dialog>
@@ -101,13 +93,5 @@
     </div>
   </body>
 
-  <script type="module">
-    import { EditorController } from "/editor/editor.js";
-
-    async function startApp() {
-      window.editorController = await EditorController.fromBackend();
-    }
-
-    startApp();
-  </script>
+  <script type="module" src="/editor/start.js"></script>
 </html>

--- a/src/fontra/views/editor/start.js
+++ b/src/fontra/views/editor/start.js
@@ -1,0 +1,16 @@
+import "/core/theme-settings.js";
+import "/web-components/add-remove-buttons.js";
+import "/web-components/designspace-location.js";
+import "/web-components/glyph-search-list.js";
+import "/web-components/grouped-settings.js";
+import "/web-components/inline-svg.js";
+import "/web-components/modal-dialog.js";
+import "/web-components/ui-list.js";
+
+import { EditorController } from "/editor/editor.js";
+
+async function startApp() {
+  window.editorController = await EditorController.fromBackend();
+}
+
+startApp();

--- a/src/fontra/views/fontinfo/fontinfo.html
+++ b/src/fontra/views/fontinfo/fontinfo.html
@@ -6,8 +6,6 @@
     <link href="/css/core.css" rel="stylesheet" />
     <link href="/css/tooltip.css" rel="stylesheet" />
     <title>Fontra Font Info</title>
-    <script type="module" src="/web-components/modal-dialog.js"></script>
-    <script type="module" src="/core/theme-settings.js"></script>
     <style>
       body {
         overflow: auto;
@@ -65,13 +63,5 @@
       <div id="panel-container"></div>
     </div>
   </body>
-  <script type="module">
-    import { FontInfoController } from "/fontinfo/fontinfo.js";
-
-    async function startApp() {
-      window.fontInfoController = await FontInfoController.fromBackend();
-    }
-
-    startApp();
-  </script>
+  <script type="module" src="/fontinfo/start.js"></script>
 </html>

--- a/src/fontra/views/fontinfo/start.js
+++ b/src/fontra/views/fontinfo/start.js
@@ -1,0 +1,10 @@
+import "/core/theme-settings.js";
+import "/web-components/modal-dialog.js";
+
+import { FontInfoController } from "/fontinfo/fontinfo.js";
+
+async function startApp() {
+  window.fontInfoController = await FontInfoController.fromBackend();
+}
+
+startApp();

--- a/src/fontra/views/fontoverview/fontoverview.html
+++ b/src/fontra/views/fontoverview/fontoverview.html
@@ -7,8 +7,6 @@
     <link href="/fontoverview/fontoverview.css" rel="stylesheet" />
     <link href="/css/tooltip.css" rel="stylesheet" />
     <title>Fontra Font Overview</title>
-    <script type="module" src="/web-components/modal-dialog.js"></script>
-    <script type="module" src="/core/theme-settings.js"></script>
   </head>
   <body>
     <modal-dialog></modal-dialog>
@@ -19,13 +17,5 @@
       <div id="glyph-cell-view-container"></div>
     </div>
   </body>
-  <script type="module">
-    import { FontOverviewController } from "/fontoverview/fontoverview.js";
-
-    async function startApp() {
-      window.fontOverviewController = await FontOverviewController.fromBackend();
-    }
-
-    startApp();
-  </script>
+  <script src="/fontoverview/start.js" type="module"></script>
 </html>

--- a/src/fontra/views/fontoverview/start.js
+++ b/src/fontra/views/fontoverview/start.js
@@ -1,0 +1,10 @@
+import "/core/theme-settings.js";
+import "/web-components/modal-dialog.js";
+
+import { FontOverviewController } from "/fontoverview/fontoverview.js";
+
+async function startApp() {
+  window.fontOverviewController = await FontOverviewController.fromBackend();
+}
+
+startApp();


### PR DESCRIPTION
This is another PR aimed at reducing the size of the #1952 change when it comes. It's good to have all the JS things in JS, not in HTML!