### PR TITLE
JS package scaffolding

### DIFF
--- a/src-js/fontra-core/package.json
+++ b/src-js/fontra-core/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@fontra/core",
+  "dependencies": {
+    "@fontra/core": "file:",
+    "bezier-js": "^6.1.4",
+    "fflate": "^0.8.2",
+    "lib-font": "^2.4.3",
+    "tsc": "^2.0.4"
+  },
+  "exports": {
+    "./webpack.config.cjs": "./webpack.config.cjs",
+    "./*": "./src/*"
+  },
+  "scripts": {
+    "test": "mocha tests --reporter spec"
+  },
+  "type": "module",
+  "devDependencies": {
+    "chai": "^5.1.2",
+    "chai-almost": "^1.0.1",
+    "mocha": "^11.0.1"
+  }
+}

--- a/src-js/fontra-core/webpack.config.cjs
+++ b/src-js/fontra-core/webpack.config.cjs
@@ -1,0 +1,15 @@
+let CopyPlugin = require("copy-webpack-plugin");
+let path = require("path");
+
+module.exports = {
+  plugins: [
+    new CopyPlugin({
+      patterns: [
+        {
+          context: path.resolve(__dirname, "assets"),
+          from: "**/*",
+        },
+      ],
+    }),
+  ],
+};

--- a/src-js/fontra-webcomponents/package.json
+++ b/src-js/fontra-webcomponents/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@fontra/web-components",
+  "exports": {
+    "./*": "./src/*"
+  },
+  "type": "module"
+}

--- a/src-js/views-applicationsettings/package.json
+++ b/src-js/views-applicationsettings/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@fontra/views-applicationsettings",
+  "exports": {
+    "./start.js": "./src/start.js",
+    "./applicationsettings.js": "./src/applicationsettings.js",
+    "./applicationsettings.html": "./applicationsettings.html"
+  },
+  "type": "module",
+  "fontra": {
+    "view": "applicationsettings"
+  }
+}

--- a/src-js/views-editor/package.json
+++ b/src-js/views-editor/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@fontra/views-editor",
+  "exports": {
+    "./start.js": "./src/start.js",
+    "./editor.js": "./src/editor.js",
+    "./editor.html": "./editor.html"
+  },
+  "type": "module",
+  "fontra": {
+    "view": "editor"
+  }
+}

--- a/src-js/views-fontinfo/package.json
+++ b/src-js/views-fontinfo/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@fontra/views-fontinfo",
+  "exports": {
+    "./start.js": "./src/start.js",
+    "./fontinfo.js": "./src/fontinfo.js",
+    "./fontinfo.html": "./fontinfo.html"
+  },
+  "type": "module",
+  "fontra": {
+    "view": "fontinfo"
+  }
+}

--- a/src-js/views-fontoverview/package.json
+++ b/src-js/views-fontoverview/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@fontra/views-fontoverview",
+  "exports": {
+    "./start.js": "./src/start.js",
+    "./fontoverview.js": "./src/fontoverview.js",
+    "./fontoverview.html": "./fontoverview.html"
+  },
+  "type": "module",
+  "fontra": {
+    "view": "fontoverview"
+  }
+}

--- a/src/fontra/client/core/webpack-base.js
+++ b/src/fontra/client/core/webpack-base.js
@@ -1,0 +1,85 @@
+// Make a webpack configuration object with some defaults; this can be
+// used both for the Fontra installation itself, and for custom out-of-tree
+// views and project managers.
+import HtmlBundlerPlugin from "html-bundler-webpack-plugin";
+import path from "path";
+
+const fallback = {
+  fs: false,
+  zlib: false,
+  assert: false,
+  util: false,
+  stream: false,
+  path: false,
+  url: false,
+  buffer: import.meta.resolve("buffer"),
+};
+
+const module = {
+  rules: [
+    {
+      test: /\.s?css$/,
+      use: ["css-loader"],
+    },
+    {
+      test: /\.(ico|png|jp?g|svg)/,
+      type: "asset/resource",
+    },
+    {
+      test: /\.tsx?$/,
+      loader: "babel-loader",
+      exclude: /node_modules/,
+      options: {
+        presets: ["@babel/preset-env", "@babel/preset-typescript"],
+      },
+    },
+  ],
+};
+
+export function makeConfig(options) {
+  let destination = options.destination;
+  if (!destination) {
+    throw new Error("destination is required");
+  }
+  if (!options.home) {
+    throw new Error("home is required");
+  }
+
+  const experiments = {
+    asyncWebAssembly: true,
+  };
+
+  let config = {
+    output: {
+      path: destination,
+      filename: options.production ? "[name].[contenthash].js" : "[name].js",
+      chunkFormat: false,
+      clean: true,
+    },
+    devtool: options.production ? false : "eval-source-map",
+    mode: options.production ? "production" : "development",
+    experiments,
+    module,
+    resolve: {
+      modules: [path.resolve(options.home, "node_modules")],
+      extensionAlias: {
+        ".js": [".ts", ".js"],
+      },
+      fallback,
+    },
+    plugins: [],
+  };
+
+  if (options.subdirectory) {
+    config.output.publicPath = options.subdirectory + "/";
+  }
+
+  if (options.views) {
+    config.plugins = options.views;
+  }
+
+  if (options.custom) {
+    Object.assign(config, options.custom);
+  }
+  return config;
+}

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -1,0 +1,30 @@
+const HtmlBundlerPlugin = require("html-bundler-webpack-plugin");
+const makeConfig = require("@fontra/core/webpack-base.js").makeConfig;
+const path = require("path");
+
+module.exports = (_env, argv) => {
+  return makeConfig({
+    home: __dirname,
+    destination: path.resolve(__dirname, "src", "fontra", "client"),
+    views: [
+      // Unfortunately we run into version compatibility problems if we get
+      // webpack-base.js to provide its own HtmlBundlerPlugin, so we have
+      // to provide our own.
+      new HtmlBundlerPlugin({
+        entry: {
+          landing: require.resolve("@fontra/projectmanager-filesystem/landing.html"),
+          applicationsettings: require.resolve(
+            "@fontra/views-applicationsettings/applicationsettings.html"
+          ),
+          editor: require.resolve("@fontra/views-editor/editor.html"),
+          fontinfo: require.resolve("@fontra/views-fontinfo/fontinfo.html"),
+          fontoverview: require.resolve("@fontra/views-fontoverview/fontoverview.html"),
+        },
+      }),
+    ],
+    production: argv.mode === "production",
+    custom: {
+      extends: require.resolve("@fontra/core/webpack.config.cjs"), // This does the copy of core assets
+    },
+  });
+};


### PR DESCRIPTION
This is another non-invasive change as part of #1952. It adds a bunch of files which don't do anything right now, but will magically become relevant once we move the JS sources out of the Python tree.

Draft for now, because I'm going to make another branch on top of this locally to confirm I can do the migration and it all works.