### PR TITLE
Turn off edit mode if the selected glyph does not exist

### DIFF
--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -1268,10 +1268,14 @@ export class EditorController extends ViewController {
       selectedGlyphInfo.glyphIndex +
       (select ? (where == 1 ? 1 : 0) : where == -1 ? glyphInfos.length : 0);
 
+    const canEdit = !!this.fontController.glyphMap[glyphInfos.glyphName];
+
     this.sceneSettings.selectedGlyph = {
       lineIndex: selectedGlyphInfo.lineIndex,
       glyphIndex: glyphIndex,
-      isEditing: where && select ? false : this.sceneSettings.selectedGlyph.isEditing,
+      isEditing:
+        canEdit &&
+        (where && select ? false : this.sceneSettings.selectedGlyph.isEditing),
     };
   }
 


### PR DESCRIPTION
Fix the insertion code in EditorController to turn off edit mode when inserting a non-existing glyph.

This fixes #1987.