### PR TITLE
[font overview] Update the axes UI then the axes change

### DIFF
--- a/src/fontra/views/fontoverview/panel-navigation.js
+++ b/src/fontra/views/fontoverview/panel-navigation.js
@@ -298,7 +298,6 @@ export class FontOverviewNavigation extends HTMLElement {
     this.fontController.addChangeListener(
       { axes: null },
       (change, isExternalChange) => {
-        console.log("yeah axessss");
         locationElement.axes = this.fontController.axes.axes;
         locationElement.values = { ...this.fontOverviewSettings.fontLocationUser };
       }

--- a/src/fontra/views/fontoverview/panel-navigation.js
+++ b/src/fontra/views/fontoverview/panel-navigation.js
@@ -295,6 +295,15 @@ export class FontOverviewNavigation extends HTMLElement {
       })
     );
 
+    this.fontController.addChangeListener(
+      { axes: null },
+      (change, isExternalChange) => {
+        console.log("yeah axessss");
+        locationElement.axes = this.fontController.axes.axes;
+        locationElement.values = { ...this.fontOverviewSettings.fontLocationUser };
+      }
+    );
+
     return locationElement;
   }
 


### PR DESCRIPTION
Previously, the Location axes in the font overview would not be update when editing/adding/removing axes in the axes font info panel. This fixes that.