### PR TITLE
Peel off glyph-cell-view displayMode option

### DIFF
--- a/src/fontra/client/web-components/glyph-cell-view.js
+++ b/src/fontra/client/web-components/glyph-cell-view.js
@@ -18,7 +18,6 @@ export class GlyphCellView extends HTMLElement {
     this.glyphSelectionKey = options?.glyphSelectionKey || "glyphSelection";
     this.closedGlyphSectionsKey =
       options?.closedGlyphSectionsKey || "closedGlyphSections";
-    this.displayMode = options?.displayMode || "block";
 
     this._magnification = 1;
 
@@ -95,9 +94,10 @@ export class GlyphCellView extends HTMLElement {
 
     this.accordion.appendStyle(`
     :host {
-      display: ${this.displayMode};
+      display: block;
+      height: inherit;
       user-select: none;
-      -webkit-user-select: none;
+      -webkit-user-select: none; /* Safari */
     }
 
     .placeholder-label {

--- a/src/fontra/views/editor/panel-related-glyphs.js
+++ b/src/fontra/views/editor/panel-related-glyphs.js
@@ -29,6 +29,7 @@ export default class RelatedGlyphPanel extends Panel {
     glyph-cell-view {
       flex: 1;
       overflow: hidden;
+      height: 100%;
     }
 
     .no-related-glyphs {
@@ -59,7 +60,7 @@ export default class RelatedGlyphPanel extends Panel {
     this.glyphCellView = new GlyphCellView(
       this.editorController.fontController,
       this.editorController.sceneSettingsController,
-      { glyphSelectionKey: "relatedGlyphsGlyphSelection", displayMode: "inline" }
+      { glyphSelectionKey: "relatedGlyphsGlyphSelection" }
     );
 
     this.glyphCellView.onOpenSelectedGlyphs = (event) => this.openSelectedGlyphs(event);


### PR DESCRIPTION
CSS only solution to peel off `displayMode` option from `glyph-cell-view`