### PR TITLE
Rework font sources UI

### DIFF
--- a/src/fontra/views/fontinfo/fontinfo.html
+++ b/src/fontra/views/fontinfo/fontinfo.html
@@ -8,7 +8,7 @@
     <title>Fontra Font Info</title>
     <style>
       body {
-        overflow: auto;
+        overflow: hidden;
       }
       .main-container {
         display: grid;

--- a/src/fontra/views/fontinfo/fontinfo.html
+++ b/src/fontra/views/fontinfo/fontinfo.html
@@ -16,7 +16,7 @@
         padding: 0em;
         gap: 0em;
         width: 100vw;
-        height: 100vh;
+        height: calc(100vh - var(--top-bar-height));
       }
 
       #header-container {

--- a/src/fontra/views/fontinfo/fontinfo.html
+++ b/src/fontra/views/fontinfo/fontinfo.html
@@ -23,7 +23,7 @@
         display: grid;
         align-content: start;
         gap: 1em;
-        padding: 2em 1em 2em 2em;
+        padding: 1em 1em 1em 1em;
       }
 
       .header {
@@ -43,7 +43,7 @@
 
       .font-info-panel {
         display: grid;
-        padding: 2em 2em 2em 1em;
+        padding: 1em 1em 1em 0;
         outline: none;
       }
 

--- a/src/fontra/views/fontinfo/fontinfo.html
+++ b/src/fontra/views/fontinfo/fontinfo.html
@@ -58,6 +58,7 @@
   </head>
   <body>
     <modal-dialog></modal-dialog>
+    <div class="top-bar-container"></div>
     <div class="main-container">
       <div id="header-container"></div>
       <div id="panel-container"></div>

--- a/src/fontra/views/fontinfo/fontinfo.html
+++ b/src/fontra/views/fontinfo/fontinfo.html
@@ -8,7 +8,7 @@
     <title>Fontra Font Info</title>
     <style>
       body {
-        overflow: hidden;
+        overflow: auto;
       }
       .main-container {
         display: grid;

--- a/src/fontra/views/fontinfo/fontinfo.js
+++ b/src/fontra/views/fontinfo/fontinfo.js
@@ -112,16 +112,12 @@ export class FontInfoController extends ViewController {
 
   getUndoRedoLabel(isRedo) {
     const panel = this.panels[this.selectedPanel];
-    const info = panel?.undoStack?.getTopUndoRedoRecord(isRedo)?.info;
-    return (
-      (isRedo ? translate("action.redo") : translate("action.undo")) +
-      (info ? " " + info.label : "")
-    );
+    return panel.getUndoRedoLabel(isRedo);
   }
 
   canUndoRedo(isRedo) {
     const panel = this.panels[this.selectedPanel];
-    return panel?.undoStack?.getTopUndoRedoRecord(isRedo)?.info;
+    return panel.canUndoRedo(isRedo);
   }
 
   doUndoRedo(isRedo) {

--- a/src/fontra/views/fontinfo/fontinfo.js
+++ b/src/fontra/views/fontinfo/fontinfo.js
@@ -1,3 +1,4 @@
+import { registerActionCallbacks } from "../core/actions.js";
 import * as html from "../core/html-utils.js";
 import { AxesPanel } from "./panel-axes.js";
 import { CrossAxisMappingPanel } from "./panel-cross-axis-mapping.js";
@@ -19,7 +20,9 @@ export class FontInfoController extends ViewController {
     const url = new URL(window.location);
     this.selectedPanel = url.hash ? url.hash.slice(1) : "font-info-panel";
 
-    const myMenuBar = makeFontraMenuBar(["File", "Font"], this);
+    this.initActions();
+
+    const myMenuBar = makeFontraMenuBar(["File", "Edit", "Font"], this);
     document.querySelector(".top-bar-container").appendChild(myMenuBar);
 
     const panelContainer = document.querySelector("#panel-container");
@@ -89,6 +92,41 @@ export class FontInfoController extends ViewController {
   handleKeyDown(event) {
     const panel = this.panels[this.selectedPanel];
     panel?.handleKeyDown?.(event);
+  }
+
+  initActions() {
+    registerActionCallbacks(
+      "action.undo",
+      () => this.doUndoRedo(false),
+      () => this.canUndoRedo(false),
+      () => this.getUndoRedoLabel(false)
+    );
+
+    registerActionCallbacks(
+      "action.redo",
+      () => this.doUndoRedo(true),
+      () => this.canUndoRedo(true),
+      () => this.getUndoRedoLabel(true)
+    );
+  }
+
+  getUndoRedoLabel(isRedo) {
+    const panel = this.panels[this.selectedPanel];
+    const info = panel?.undoStack?.getTopUndoRedoRecord(isRedo)?.info;
+    return (
+      (isRedo ? translate("action.redo") : translate("action.undo")) +
+      (info ? " " + info.label : "")
+    );
+  }
+
+  canUndoRedo(isRedo) {
+    const panel = this.panels[this.selectedPanel];
+    return panel?.undoStack?.getTopUndoRedoRecord(isRedo)?.info;
+  }
+
+  doUndoRedo(isRedo) {
+    const panel = this.panels[this.selectedPanel];
+    return panel.doUndoRedo(isRedo);
   }
 }
 

--- a/src/fontra/views/fontinfo/fontinfo.js
+++ b/src/fontra/views/fontinfo/fontinfo.js
@@ -4,6 +4,7 @@ import { CrossAxisMappingPanel } from "./panel-cross-axis-mapping.js";
 import { DevelopmentStatusDefinitionsPanel } from "./panel-development-status-definitions.js";
 import { FontInfoPanel } from "./panel-font-info.js";
 import { SourcesPanel } from "./panel-sources.js";
+import { makeFontraMenuBar } from "/core/fontra-menus.js";
 import { translate } from "/core/localization.js";
 import { ViewController } from "/core/view-controller.js";
 
@@ -17,6 +18,9 @@ export class FontInfoController extends ViewController {
 
     const url = new URL(window.location);
     this.selectedPanel = url.hash ? url.hash.slice(1) : "font-info-panel";
+
+    const myMenuBar = makeFontraMenuBar(["File", "Edit", "View", "Font"], this);
+    document.querySelector(".top-bar-container").appendChild(myMenuBar);
 
     const panelContainer = document.querySelector("#panel-container");
     const headerContainer = document.querySelector("#header-container");

--- a/src/fontra/views/fontinfo/fontinfo.js
+++ b/src/fontra/views/fontinfo/fontinfo.js
@@ -19,7 +19,7 @@ export class FontInfoController extends ViewController {
     const url = new URL(window.location);
     this.selectedPanel = url.hash ? url.hash.slice(1) : "font-info-panel";
 
-    const myMenuBar = makeFontraMenuBar(["File", "Edit", "View", "Font"], this);
+    const myMenuBar = makeFontraMenuBar(["File", "Font"], this);
     document.querySelector(".top-bar-container").appendChild(myMenuBar);
 
     const panelContainer = document.querySelector("#panel-container");

--- a/src/fontra/views/fontinfo/panel-base.js
+++ b/src/fontra/views/fontinfo/panel-base.js
@@ -1,6 +1,7 @@
 import { UndoStack, reverseUndoRecord } from "../core/font-controller.js";
 import * as html from "../core/html-utils.js";
 import { commandKeyProperty } from "../core/utils.js";
+import { translate } from "/core/localization.js";
 
 export class BaseInfoPanel {
   constructor(fontInfoController, panelElement) {
@@ -44,6 +45,18 @@ export class BaseInfoPanel {
         this.doUndoRedo(event.shiftKey);
       }
     }
+  }
+
+  getUndoRedoLabel(isRedo) {
+    const info = this.undoStack.getTopUndoRedoRecord(isRedo)?.info;
+    return (
+      (isRedo ? translate("action.redo") : translate("action.undo")) +
+      (info ? " " + info.label : "")
+    );
+  }
+
+  canUndoRedo(isRedo) {
+    return this.undoStack.getTopUndoRedoRecord(isRedo)?.info;
   }
 
   async doUndoRedo(isRedo) {

--- a/src/fontra/views/fontinfo/panel-sources.js
+++ b/src/fontra/views/fontinfo/panel-sources.js
@@ -683,28 +683,22 @@ class SourceBox extends HTMLElement {
     this.append(
       html.div({ class: "fontra-ui-font-info-sources-panel-header" }, [
         getLabelFromKey("general"),
-      ])
+      ]),
+      buildElement(this.controllers.general)
     );
-    this.append(buildElement(this.controllers.general));
-
     // Don't add 'Location', if the font has no axes.
     if (this.fontAxesSourceSpace.length > 0) {
       this.append(
         html.div({ class: "fontra-ui-font-info-sources-panel-header" }, [
           getLabelFromKey("location"),
-        ])
-      );
-      this.append(
+        ]),
         buildElementLocations(this.controllers.location, this.fontAxesSourceSpace)
       );
     }
-
     this.append(
       html.div({ class: "fontra-ui-font-info-sources-panel-header" }, [
         getLabelFromKey("lineMetricsHorizontalLayout"),
-      ])
-    );
-    this.append(
+      ]),
       buildElementLineMetricsHor(this.controllers.lineMetricsHorizontalLayout)
     );
   }

--- a/src/fontra/views/fontinfo/panel-sources.js
+++ b/src/fontra/views/fontinfo/panel-sources.js
@@ -11,7 +11,7 @@ import {
   labeledTextInput,
   textInput,
 } from "../core/ui-utils.js";
-import { arrowKeyDeltas, enumerate, modulo, round } from "../core/utils.js";
+import { arrowKeyDeltas, enumerate, modulo, range, round } from "../core/utils.js";
 import { BaseInfoPanel } from "./panel-base.js";
 import {
   locationToString,
@@ -378,22 +378,16 @@ export class SourcesPanel extends BaseInfoPanel {
       ".fontra-ui-font-info-sources-panel-source-name-box"
     );
 
-    let index = 0;
-    for (const [i, sourceNameBox] of enumerate(sourceNameBoxes)) {
-      if (sourceNameBox.selected) {
-        index = i;
-        break;
-      }
-    }
+    const sourcesLength = sourceNameBoxes.length;
+    const index = range(sourcesLength).find((i) => sourceNameBoxes[i].selected);
 
     const selectPrevious = "ArrowUp" == event.key;
-    const len = sourceNameBoxes.length;
     const newIndex =
       index == -1
         ? selectPrevious
-          ? len - 1
+          ? sourcesLength - 1
           : 0
-        : modulo(index + (selectPrevious ? -1 : 1), len);
+        : modulo(index + (selectPrevious ? -1 : 1), sourcesLength);
 
     sourceNameBoxes[newIndex].selected = true;
   }

--- a/src/fontra/views/fontinfo/panel-sources.js
+++ b/src/fontra/views/fontinfo/panel-sources.js
@@ -33,7 +33,7 @@ addStyleSheet(`
 .font-sources-container {
   display: grid;
   grid-template-columns: auto 1fr;
-  height: calc(100vh - var(--top-bar-height));
+  overflow: hidden;
 }
 
 #font-sources-container-names,
@@ -41,14 +41,18 @@ addStyleSheet(`
   display: grid;
   align-content: start;
   gap: 0.5em;
-  padding-top: 2em;
-  padding-bottom: 2em;
   overflow: auto;
 }
 
+.font-sources-container-wrapper {
+  display: grid;
+  align-content: start;
+  gap: 0.5em;
+  overflow: hidden;
+}
+
 #sources-panel.font-info-panel {
-  padding-top: 0;
-  padding-bottom: 0;
+  height: 100%;
 }
 `);
 
@@ -84,10 +88,22 @@ export class SourcesPanel extends BaseInfoPanel {
     const containerSourcesNames = html.div({
       id: "font-sources-container-names",
     });
+    const containerSourcesNamesWrapper = html.div(
+      {
+        class: "font-sources-container-wrapper",
+      },
+      [containerSourcesNames]
+    );
 
     const containerSourceContent = html.div({
       id: "font-sources-container-source-content",
     });
+    const containerSourceContentWrapper = html.div(
+      {
+        class: "font-sources-container-wrapper",
+      },
+      [containerSourceContent]
+    );
 
     for (const [i, identifier] of enumerate(
       this.fontController.getSortedSourceIdentifiers()
@@ -106,19 +122,17 @@ export class SourcesPanel extends BaseInfoPanel {
       containerSourcesNames.appendChild(sourceNameBoxElement);
     }
 
-    const addRemoveSourceButtons = html.createDomElement("add-remove-buttons", {
-      id: "axis-list-add-remove-buttons",
-    });
+    const addRemoveSourceButtons = html.createDomElement("add-remove-buttons");
     addRemoveSourceButtons.addButtonCallback = (event) => {
       this.newSource();
     };
     addRemoveSourceButtons.removeButtonCallback = (event) => {
       this.deleteSource();
     };
-    containerSourcesNames.appendChild(addRemoveSourceButtons);
+    containerSourcesNamesWrapper.appendChild(addRemoveSourceButtons);
 
-    container.appendChild(containerSourcesNames);
-    container.appendChild(containerSourceContent);
+    container.appendChild(containerSourcesNamesWrapper);
+    container.appendChild(containerSourceContentWrapper);
     this.panelElement.appendChild(container);
     this.panelElement.focus();
 

--- a/src/fontra/views/fontinfo/panel-sources.js
+++ b/src/fontra/views/fontinfo/panel-sources.js
@@ -102,7 +102,7 @@ export class SourcesPanel extends BaseInfoPanel {
 
     const sortedSourceIdentifiers = this.fontController.getSortedSourceIdentifiers();
 
-    for (const [i, identifier] of enumerate(sortedSourceIdentifiers)) {
+    for (const identifier of sortedSourceIdentifiers) {
       const sourceNameBoxElement = new SourceNameBox(
         this.fontAxesSourceSpace,
         sources,
@@ -135,12 +135,8 @@ export class SourcesPanel extends BaseInfoPanel {
     const sourceNameBoxes = document.querySelectorAll(
       ".fontra-ui-font-info-sources-panel-source-name-box"
     );
-    for (const sourceNameBox of sourceNameBoxes) {
-      if (sourceNameBox.sourceIdentifier == selectedSourceIdentifier) {
-        sourceNameBox.selected = true;
-        break;
-      }
-    }
+    const index = sortedSourceIdentifiers.indexOf(selectedSourceIdentifier);
+    sourceNameBoxes[index].selected = true;
   }
 
   deleteSource() {

--- a/src/fontra/views/fontinfo/panel-sources.js
+++ b/src/fontra/views/fontinfo/panel-sources.js
@@ -100,9 +100,9 @@ export class SourcesPanel extends BaseInfoPanel {
       [containerSourceContent]
     );
 
-    for (const [i, identifier] of enumerate(
-      this.fontController.getSortedSourceIdentifiers()
-    )) {
+    const sortedSourceIdentifiers = this.fontController.getSortedSourceIdentifiers();
+
+    for (const [i, identifier] of enumerate(sortedSourceIdentifiers)) {
       const sourceNameBoxElement = new SourceNameBox(
         this.fontAxesSourceSpace,
         sources,
@@ -110,10 +110,6 @@ export class SourcesPanel extends BaseInfoPanel {
         this.postChange.bind(this),
         this.setupUI.bind(this)
       );
-      if (selectedSourceIdentifier == undefined && i == 0) {
-        // by default the first source is selected.
-        selectedSourceIdentifier = identifier;
-      }
       containerSourcesNames.appendChild(sourceNameBoxElement);
     }
 
@@ -131,6 +127,11 @@ export class SourcesPanel extends BaseInfoPanel {
     this.panelElement.appendChild(container);
     this.panelElement.focus();
 
+    selectedSourceIdentifier = sortedSourceIdentifiers.includes(
+      selectedSourceIdentifier
+    )
+      ? selectedSourceIdentifier
+      : sortedSourceIdentifiers[0];
     const sourceNameBoxes = document.querySelectorAll(
       ".fontra-ui-font-info-sources-panel-source-name-box"
     );

--- a/src/fontra/views/fontinfo/panel-sources.js
+++ b/src/fontra/views/fontinfo/panel-sources.js
@@ -1,3 +1,8 @@
+import {
+  doPerformAction,
+  getActionIdentifierFromKeyEvent,
+  registerActionCallbacks,
+} from "../core/actions.js";
 import { recordChanges } from "../core/change-recorder.js";
 import * as html from "../core/html-utils.js";
 import { addStyleSheet } from "../core/html-utils.js";
@@ -360,12 +365,11 @@ export class SourcesPanel extends BaseInfoPanel {
   }
 
   handleKeyDown(event) {
-    if (event[commandKeyProperty]) {
-      if (event.key == "z") {
-        event.stopImmediatePropagation();
-        event.preventDefault();
-        this.doUndoRedo(event.shiftKey);
-      }
+    const actionIdentifier = getActionIdentifierFromKeyEvent(event);
+    if (actionIdentifier) {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      doPerformAction(actionIdentifier, event);
     } else if (event.key in arrowKeyDeltas) {
       this.handleArrowKeys(event);
     }

--- a/src/fontra/views/fontinfo/panel-sources.js
+++ b/src/fontra/views/fontinfo/panel-sources.js
@@ -637,7 +637,7 @@ class SourceBox extends HTMLElement {
           );
           element.innerHTML = source[event.key];
         }
-      }, `edit source general ${event.key}`);
+      }, `edit ${event.key}`);
     });
 
     this.controllers.location.addListener((event) => {
@@ -647,17 +647,18 @@ class SourceBox extends HTMLElement {
       }
       this.editSource((source) => {
         source.location[event.key] = event.newValue;
-      }, `edit source location ${event.key}`);
+      }, `edit location (“${event.key}” axis)`);
     });
 
     this.controllers.lineMetricsHorizontalLayout.addListener((event) => {
+      const [which, lineMetricName] = event.key.split("-");
       this.editSource((source) => {
-        if (event.key.startsWith("value-")) {
+        if (which === "value") {
           source.lineMetricsHorizontalLayout[event.key.slice(6)].value = event.newValue;
         } else {
           source.lineMetricsHorizontalLayout[event.key.slice(5)].zone = event.newValue;
         }
-      }, `edit source line metrics ${event.key}`);
+      }, `edit line metric ${which} “${lineMetricName}”`);
     });
 
     this.innerHTML = "";

--- a/src/fontra/views/fontinfo/panel-sources.js
+++ b/src/fontra/views/fontinfo/panel-sources.js
@@ -393,6 +393,7 @@ class SourceNameBox extends HTMLElement {
     this.setupUI = setupUI;
     this.controllers = {};
     this._updateContents();
+    this.onclick = (event) => this.selectThis();
   }
 
   get source() {
@@ -439,12 +440,11 @@ class SourceNameBox extends HTMLElement {
   }
 
   _updateContents() {
-    (this.onclick = (event) => this.selectThis()),
-      this.append(
-        html.div({ id: `source-name-box-name-${this.sourceIdentifier}` }, [
-          this.source.name,
-        ])
-      );
+    this.append(
+      html.div({ id: `source-name-box-name-${this.sourceIdentifier}` }, [
+        this.source.name,
+      ])
+    );
 
     this.append(
       html.createDomElement("icon-button", {
@@ -647,14 +647,17 @@ class SourceBox extends HTMLElement {
     );
     this.append(buildElement(this.controllers.general));
 
-    this.append(
-      html.div({ class: "fontra-ui-font-info-sources-panel-header" }, [
-        getLabelFromKey("location"),
-      ])
-    );
-    this.append(
-      buildElementLocations(this.controllers.location, this.fontAxesSourceSpace)
-    );
+    // Don't add 'Location', if the font has no axes.
+    if (this.fontAxesSourceSpace.length > 0) {
+      this.append(
+        html.div({ class: "fontra-ui-font-info-sources-panel-header" }, [
+          getLabelFromKey("location"),
+        ])
+      );
+      this.append(
+        buildElementLocations(this.controllers.location, this.fontAxesSourceSpace)
+      );
+    }
 
     this.append(
       html.div({ class: "fontra-ui-font-info-sources-panel-header" }, [

--- a/src/fontra/views/fontinfo/panel-sources.js
+++ b/src/fontra/views/fontinfo/panel-sources.js
@@ -161,7 +161,7 @@ export class SourcesPanel extends BaseInfoPanel {
       return;
     }
 
-    const undoLabel = `add source '${newSource.name}'`;
+    const undoLabel = `add source '${newSource.name}'`; // TODO: translation
 
     let sourceIdentifier;
     do {
@@ -637,7 +637,7 @@ class SourceBox extends HTMLElement {
           );
           element.innerHTML = source[event.key];
         }
-      }, `edit ${event.key}`);
+      }, `edit ${event.key}`); // TODO: translation
     });
 
     this.controllers.location.addListener((event) => {
@@ -647,7 +647,7 @@ class SourceBox extends HTMLElement {
       }
       this.editSource((source) => {
         source.location[event.key] = event.newValue;
-      }, `edit location (“${event.key}” axis)`);
+      }, `edit location (“${event.key}” axis)`); // TODO: translation
     });
 
     this.controllers.lineMetricsHorizontalLayout.addListener((event) => {
@@ -658,7 +658,7 @@ class SourceBox extends HTMLElement {
         } else {
           source.lineMetricsHorizontalLayout[event.key.slice(5)].zone = event.newValue;
         }
-      }, `edit line metric ${which} “${lineMetricName}”`);
+      }, `edit line metric ${which} “${lineMetricName}”`); // TODO: translation
     });
 
     this.innerHTML = "";

--- a/src/fontra/views/fontinfo/panel-sources.js
+++ b/src/fontra/views/fontinfo/panel-sources.js
@@ -23,23 +23,19 @@ import { dialogSetup, message } from "/web-components/modal-dialog.js";
 
 addStyleSheet(`
 .font-sources-container {
-  display: flex;
+  display: grid;
+  grid-template-columns: auto 1fr;
   height: calc(100vh - var(--top-bar-height));
 }
 
-#font-sources-container-names {
+#font-sources-container-names,
+#font-sources-container-source-content {
   display: grid;
   align-content: start;
   gap: 0.5em;
   padding-top: 2em;
-}
-
-#font-sources-container-source-content {
-  display: grid;
-  gap: 0.5em;
-  width: 100%;
+  padding-bottom: 2em;
   overflow: auto;
-  padding-top: 2em;
 }
 
 #sources-panel.font-info-panel {
@@ -96,7 +92,7 @@ export class SourcesPanel extends BaseInfoPanel {
         this.setupUI.bind(this)
       );
       if (i == 0) {
-        // be default the first source is selected.
+        // by default the first source is selected.
         sourceBoxNameElement.classList.add("selected");
       }
       containerSourcesNames.appendChild(sourceBoxNameElement);

--- a/src/fontra/views/fontinfo/panel-sources.js
+++ b/src/fontra/views/fontinfo/panel-sources.js
@@ -508,12 +508,11 @@ addStyleSheet(`
 
 .fontra-ui-font-info-sources-panel-column {
   display: grid;
-  grid-template-columns: minmax(4.5em, max-content) minmax(40%, max-content);
+  grid-template-columns: minmax(4.5em, max-content) minmax(max-content, 25em);
   gap: 0.5em;
   align-items: start;
   align-content: start;
   padding-bottom: 2em;
-  justify-content: center;
 }
 
 .fontra-ui-font-info-sources-panel-line-metrics-hor {

--- a/src/fontra/views/fontinfo/panel-sources.js
+++ b/src/fontra/views/fontinfo/panel-sources.js
@@ -1,8 +1,4 @@
-import {
-  doPerformAction,
-  getActionIdentifierFromKeyEvent,
-  registerActionCallbacks,
-} from "../core/actions.js";
+import { doPerformAction, getActionIdentifierFromKeyEvent } from "../core/actions.js";
 import { recordChanges } from "../core/change-recorder.js";
 import * as html from "../core/html-utils.js";
 import { addStyleSheet } from "../core/html-utils.js";
@@ -15,13 +11,7 @@ import {
   labeledTextInput,
   textInput,
 } from "../core/ui-utils.js";
-import {
-  arrowKeyDeltas,
-  commandKeyProperty,
-  enumerate,
-  modulo,
-  round,
-} from "../core/utils.js";
+import { arrowKeyDeltas, enumerate, modulo, round } from "../core/utils.js";
 import { BaseInfoPanel } from "./panel-base.js";
 import {
   locationToString,

--- a/src/fontra/views/fontinfo/panel-sources.js
+++ b/src/fontra/views/fontinfo/panel-sources.js
@@ -24,13 +24,14 @@ import { dialogSetup, message } from "/web-components/modal-dialog.js";
 addStyleSheet(`
 .font-sources-container {
   display: flex;
-  height: calc(100vh - 7em);
+  height: calc(100vh - var(--top-bar-height));
 }
 
 #font-sources-container-names {
   display: grid;
   align-content: start;
   gap: 0.5em;
+  padding-top: 2em;
 }
 
 #font-sources-container-source-content {
@@ -38,6 +39,12 @@ addStyleSheet(`
   gap: 0.5em;
   width: 100%;
   overflow: auto;
+  padding-top: 2em;
+}
+
+#sources-panel.font-info-panel {
+  padding-top: 0;
+  padding-bottom: 0;
 }
 `);
 

--- a/src/fontra/views/fontinfo/panel-sources.js
+++ b/src/fontra/views/fontinfo/panel-sources.js
@@ -438,6 +438,7 @@ class SourceNameBox extends HTMLElement {
     this.classList.toggle("selected", this._selected);
     if (this._selected) {
       selectedSourceIdentifier = this.sourceIdentifier;
+      this.scrollIntoView({ behavior: "auto", block: "nearest", inline: "nearest" });
       this._deselectOtherSourceNameBoxs();
       this._updateSourceBox();
     }

--- a/src/fontra/views/fontinfo/panel-sources.js
+++ b/src/fontra/views/fontinfo/panel-sources.js
@@ -155,7 +155,7 @@ export class SourcesPanel extends BaseInfoPanel {
   deleteSource() {
     const undoLabel = translate(
       "sources.undo.delete",
-      this.fontController.sources[selectedSourceIdentifier]
+      this.fontController.sources[selectedSourceIdentifier].name
     );
     const root = { sources: this.fontController.sources };
     const changes = recordChanges(root, (root) => {

--- a/src/fontra/views/fontinfo/panel-sources.js
+++ b/src/fontra/views/fontinfo/panel-sources.js
@@ -328,6 +328,11 @@ export class SourcesPanel extends BaseInfoPanel {
   }
 
   handleArrowKeys(event) {
+    if (document.activeElement.id != "sources-panel") {
+      // The focus is somewhere else, for example on an input element.
+      // In this case arrow keys should be ignored.
+      return;
+    }
     if (!["ArrowUp", "ArrowDown"].includes(event.key)) {
       // We currently don't support any actions for left or right arrow.
       return;


### PR DESCRIPTION
Fixes #1997

- I use "add-remove-buttons" (similar to other areas of Fontra) to add or remove a font source, this makes the repeating trash-icon redundant
- When adding a new font source, this will be 'selected'.
- With arrow up and down you can go to previous or next source (this will be ignored if the focus is for example on an input)