### PR TITLE
Guess glyph string for placeholder glyphs without code points

### DIFF
--- a/src-js/fontra-core/src/glyph-data.js
+++ b/src-js/fontra-core/src/glyph-data.js
@@ -119,6 +119,8 @@ export function getGlyphInfoFromGlyphName(glyphName) {
 
 export function guessGlyphPlaceholderString(codePoints, glyphName) {
   let glyphString = "";
+  let direction = undefined;
+
   if (codePoints?.[0]) {
     glyphString = getCharFromCodePoint(codePoints[0]);
   }
@@ -145,12 +147,15 @@ export function guessGlyphPlaceholderString(codePoints, glyphName) {
             break;
           case ".init":
             glyphString = glyphString + ZWJ;
+            direction = "rtl";
             break;
           case ".medi":
             glyphString = ZWJ + glyphString + ZWJ;
+            direction = "rtl";
             break;
           case ".fina":
             glyphString = ZWJ + glyphString;
+            direction = "rtl";
             break;
           default:
             break;
@@ -159,5 +164,5 @@ export function guessGlyphPlaceholderString(codePoints, glyphName) {
     }
   }
 
-  return glyphString;
+  return [glyphString, direction];
 }

--- a/src-js/fontra-core/src/glyph-data.js
+++ b/src-js/fontra-core/src/glyph-data.js
@@ -134,7 +134,9 @@ export function guessGlyphPlaceholderString(codePoints, glyphName) {
       baseGlyphNames = base.split("_").map((name) => name + suffix);
     }
 
-    const codePoints = baseGlyphNames.map((name) => getCodePointFromGlyphName(name));
+    const codePoints = baseGlyphNames
+      .map((name) => getCodePointFromGlyphName(name))
+      .filter((item) => item);
     if (codePoints.length == baseGlyphNames.length) {
       glyphString = codePoints
         .map((codePoint) => getCharFromCodePoint(codePoint))

--- a/src-js/fontra-core/src/glyph-data.js
+++ b/src-js/fontra-core/src/glyph-data.js
@@ -125,23 +125,32 @@ export function guessGlyphPlaceholderString(codePoints, glyphName) {
 
   if (!glyphString && glyphName) {
     const [baseGlyphName, extension] = splitGlyphNameExtension(glyphName);
-    if (extension) {
-      const codePoint = getCodePointFromGlyphName(baseGlyphName);
-      if (codePoint) {
-        const baseChar = getCharFromCodePoint(codePoint);
+
+    let baseGlyphNames = [baseGlyphName];
+    if (baseGlyphName.indexOf("_") != -1) {
+      const [base, suffix] = splitGlyphNameExtension(baseGlyphName, "-");
+      baseGlyphNames = base.split("_").map((name) => name + suffix);
+    }
+
+    const codePoints = baseGlyphNames.map((name) => getCodePointFromGlyphName(name));
+    if (codePoints.length == baseGlyphNames.length) {
+      glyphString = codePoints
+        .map((codePoint) => getCharFromCodePoint(codePoint))
+        .join("");
+
+      if (extension) {
         const ZWJ = "\u200D";
         switch (extension) {
           case ".isol":
-            glyphString = baseChar;
             break;
           case ".init":
-            glyphString = baseChar + ZWJ;
+            glyphString = glyphString + ZWJ;
             break;
           case ".medi":
-            glyphString = ZWJ + baseChar + ZWJ;
+            glyphString = ZWJ + glyphString + ZWJ;
             break;
           case ".fina":
-            glyphString = ZWJ + baseChar;
+            glyphString = ZWJ + glyphString;
             break;
           default:
             break;

--- a/src-js/fontra-core/src/glyph-data.js
+++ b/src-js/fontra-core/src/glyph-data.js
@@ -1,4 +1,9 @@
-import { assert, enumerate } from "./utils.js";
+import {
+  assert,
+  enumerate,
+  getCharFromCodePoint,
+  splitGlyphNameExtension,
+} from "./utils.js";
 
 let glyphDataCSV;
 
@@ -110,4 +115,40 @@ export function getGlyphInfoFromCodePoint(codePoint) {
 export function getGlyphInfoFromGlyphName(glyphName) {
   parseGlyphDataCSV();
   return glyphDataByName.get(glyphName);
+}
+
+export function guessGlyphPlaceholderString(codePoints, glyphName) {
+  let glyphString = "";
+  if (codePoints?.[0]) {
+    glyphString = getCharFromCodePoint(codePoints[0]);
+  }
+
+  if (!glyphString && glyphName) {
+    const [baseGlyphName, extension] = splitGlyphNameExtension(glyphName);
+    if (extension) {
+      const codePoint = getCodePointFromGlyphName(baseGlyphName);
+      if (codePoint) {
+        const baseChar = getCharFromCodePoint(codePoint);
+        const ZWJ = "\u200D";
+        switch (extension) {
+          case ".isol":
+            glyphString = baseChar;
+            break;
+          case ".init":
+            glyphString = baseChar + ZWJ;
+            break;
+          case ".medi":
+            glyphString = ZWJ + baseChar + ZWJ;
+            break;
+          case ".fina":
+            glyphString = ZWJ + baseChar;
+            break;
+          default:
+            break;
+        }
+      }
+    }
+  }
+
+  return glyphString;
 }

--- a/src-js/fontra-core/src/glyph-data.js
+++ b/src-js/fontra-core/src/glyph-data.js
@@ -123,6 +123,7 @@ export function guessGlyphPlaceholderString(codePoints, glyphName) {
 
   if (codePoints?.[0]) {
     glyphString = getCharFromCodePoint(codePoints[0]);
+    direction = getGlyphInfoFromCodePoint(codePoints[0])?.direction?.toLowerCase();
   }
 
   if (!glyphString && glyphName) {
@@ -141,6 +142,7 @@ export function guessGlyphPlaceholderString(codePoints, glyphName) {
       glyphString = codePoints
         .map((codePoint) => getCharFromCodePoint(codePoint))
         .join("");
+      direction = getGlyphInfoFromCodePoint(codePoints[0])?.direction?.toLowerCase();
 
       if (extension) {
         const ZWJ = "\u200D";
@@ -149,15 +151,12 @@ export function guessGlyphPlaceholderString(codePoints, glyphName) {
             break;
           case ".init":
             glyphString = glyphString + ZWJ;
-            direction = "rtl";
             break;
           case ".medi":
             glyphString = ZWJ + glyphString + ZWJ;
-            direction = "rtl";
             break;
           case ".fina":
             glyphString = ZWJ + glyphString;
-            direction = "rtl";
             break;
           default:
             break;
@@ -166,5 +165,5 @@ export function guessGlyphPlaceholderString(codePoints, glyphName) {
     }
   }
 
-  return [glyphString, direction];
+  return { glyphString, direction };
 }

--- a/src-js/fontra-core/src/utils.js
+++ b/src-js/fontra-core/src/utils.js
@@ -486,8 +486,8 @@ export function* iter(iterable) {
   }
 }
 
-export function splitGlyphNameExtension(glyphName) {
-  const periodIndex = glyphName.indexOf(".");
+export function splitGlyphNameExtension(glyphName, separator = ".") {
+  const periodIndex = glyphName.indexOf(separator);
   const baseGlyphName = periodIndex >= 1 ? glyphName.slice(0, periodIndex) : glyphName;
   const extension = periodIndex >= 1 ? glyphName.slice(periodIndex) : "";
   return [baseGlyphName, extension];

--- a/src-js/fontra-core/src/utils.js
+++ b/src-js/fontra-core/src/utils.js
@@ -487,9 +487,10 @@ export function* iter(iterable) {
 }
 
 export function splitGlyphNameExtension(glyphName, separator = ".") {
-  const periodIndex = glyphName.indexOf(separator);
-  const baseGlyphName = periodIndex >= 1 ? glyphName.slice(0, periodIndex) : glyphName;
-  const extension = periodIndex >= 1 ? glyphName.slice(periodIndex) : "";
+  const separatorIndex = glyphName.indexOf(separator);
+  const baseGlyphName =
+    separatorIndex >= 1 ? glyphName.slice(0, separatorIndex) : glyphName;
+  const extension = separatorIndex >= 1 ? glyphName.slice(separatorIndex) : "";
   return [baseGlyphName, extension];
 }
 

--- a/src-js/fontra-core/tests/test-glyph-data.js
+++ b/src-js/fontra-core/tests/test-glyph-data.js
@@ -62,8 +62,18 @@ describe("glyph-data Tests", () => {
   const guessGlyphPlaceholderString_testData = [
     { glyphName: "", codePoints: ["A".codePointAt(0)], glyphString: "A" },
     { glyphName: "B", codePoints: ["A".codePointAt(0)], glyphString: "A" },
-    { glyphName: "alef-ar", codePoints: [0x0627], glyphString: "\u0627" },
-    { glyphName: "alef-ar.isol", codePoints: [], glyphString: "\u0627" },
+    {
+      glyphName: "alef-ar",
+      codePoints: [0x0627],
+      glyphString: "\u0627",
+      direction: "rtl",
+    },
+    {
+      glyphName: "alef-ar.isol",
+      codePoints: [],
+      glyphString: "\u0627",
+      direction: "rtl",
+    },
     { glyphName: "alef-ar.isol", codePoints: [0xfe8d], glyphString: "\uFE8D" },
     {
       glyphName: "alef-ar.fina",
@@ -91,14 +101,24 @@ describe("glyph-data Tests", () => {
       direction: "rtl",
     },
     { glyphName: "f_i", codePoints: [], glyphString: "fi" },
-    { glyphName: "lam_alef-ar", codePoints: [], glyphString: "\u0644\u0627" },
+    {
+      glyphName: "lam_alef-ar",
+      codePoints: [],
+      glyphString: "\u0644\u0627",
+      direction: "rtl",
+    },
     {
       glyphName: "lam_alef-ar.fina",
       codePoints: [],
       glyphString: "\u200D\u0644\u0627",
       direction: "rtl",
     },
-    { glyphName: "lam_lam_alef-ar", codePoints: [], glyphString: "\u0644\u0644\u0627" },
+    {
+      glyphName: "lam_lam_alef-ar",
+      codePoints: [],
+      glyphString: "\u0644\u0644\u0627",
+      direction: "rtl",
+    },
     { glyphName: "lam_foo_alef-ar", codePoints: [], glyphString: "" },
   ];
 
@@ -106,7 +126,7 @@ describe("glyph-data Tests", () => {
     "guessGlyphPlaceholderString",
     guessGlyphPlaceholderString_testData,
     (testItem) => {
-      const [glyphString, direction] = guessGlyphPlaceholderString(
+      const { glyphString, direction } = guessGlyphPlaceholderString(
         testItem.codePoints,
         testItem.glyphName
       );

--- a/src-js/fontra-core/tests/test-glyph-data.js
+++ b/src-js/fontra-core/tests/test-glyph-data.js
@@ -99,6 +99,7 @@ describe("glyph-data Tests", () => {
       direction: "rtl",
     },
     { glyphName: "lam_lam_alef-ar", codePoints: [], glyphString: "\u0644\u0644\u0627" },
+    { glyphName: "lam_foo_alef-ar", codePoints: [], glyphString: "" },
   ];
 
   parametrize(

--- a/src-js/fontra-core/tests/test-glyph-data.js
+++ b/src-js/fontra-core/tests/test-glyph-data.js
@@ -65,17 +65,38 @@ describe("glyph-data Tests", () => {
     { glyphName: "alef-ar", codePoints: [0x0627], glyphString: "\u0627" },
     { glyphName: "alef-ar.isol", codePoints: [], glyphString: "\u0627" },
     { glyphName: "alef-ar.isol", codePoints: [0xfe8d], glyphString: "\uFE8D" },
-    { glyphName: "alef-ar.fina", codePoints: [], glyphString: "\u200D\u0627" },
+    {
+      glyphName: "alef-ar.fina",
+      codePoints: [],
+      glyphString: "\u200D\u0627",
+      direction: "rtl",
+    },
     { glyphName: "alef-ar.fina", codePoints: [0xfe8e], glyphString: "\uFE8E" },
-    { glyphName: "beh-ar.init", codePoints: [], glyphString: "\u0628\u200D" },
-    { glyphName: "beh-ar.medi", codePoints: [], glyphString: "\u200D\u0628\u200D" },
-    { glyphName: "uni0628.medi", codePoints: [], glyphString: "\u200D\u0628\u200D" },
+    {
+      glyphName: "beh-ar.init",
+      codePoints: [],
+      glyphString: "\u0628\u200D",
+      direction: "rtl",
+    },
+    {
+      glyphName: "beh-ar.medi",
+      codePoints: [],
+      glyphString: "\u200D\u0628\u200D",
+      direction: "rtl",
+    },
+    {
+      glyphName: "uni0628.medi",
+      codePoints: [],
+      glyphString: "\u200D\u0628\u200D",
+      direction: "rtl",
+    },
     { glyphName: "f_i", codePoints: [], glyphString: "fi" },
     { glyphName: "lam_alef-ar", codePoints: [], glyphString: "\u0644\u0627" },
     {
       glyphName: "lam_alef-ar.fina",
       codePoints: [],
       glyphString: "\u200D\u0644\u0627",
+      direction: "rtl",
     },
     { glyphName: "lam_lam_alef-ar", codePoints: [], glyphString: "\u0644\u0644\u0627" },
   ];
@@ -84,11 +105,12 @@ describe("glyph-data Tests", () => {
     "guessGlyphPlaceholderString",
     guessGlyphPlaceholderString_testData,
     (testItem) => {
-      const glyphString = guessGlyphPlaceholderString(
+      const [glyphString, direction] = guessGlyphPlaceholderString(
         testItem.codePoints,
         testItem.glyphName
       );
       expect(glyphString).to.equal(testItem.glyphString);
+      expect(direction).to.equal(testItem.direction);
     }
   );
 });

--- a/src-js/fontra-core/tests/test-glyph-data.js
+++ b/src-js/fontra-core/tests/test-glyph-data.js
@@ -4,6 +4,7 @@ import { parametrize } from "./test-support.js";
 import {
   getCodePointFromGlyphName,
   getSuggestedGlyphName,
+  guessGlyphPlaceholderString,
 } from "@fontra/core/glyph-data.js";
 
 describe("glyph-data Tests", () => {
@@ -55,6 +56,31 @@ describe("glyph-data Tests", () => {
     (testItem) => {
       const codePoint = getCodePointFromGlyphName(testItem.glyphName);
       expect(codePoint).to.equal(testItem.codePoint);
+    }
+  );
+
+  const guessGlyphPlaceholderString_testData = [
+    { glyphName: "", codePoints: ["A".codePointAt(0)], glyphString: "A" },
+    { glyphName: "B", codePoints: ["A".codePointAt(0)], glyphString: "A" },
+    { glyphName: "alef-ar", codePoints: [0x0627], glyphString: "\u0627" },
+    { glyphName: "alef-ar.isol", codePoints: [], glyphString: "\u0627" },
+    { glyphName: "alef-ar.isol", codePoints: [0xfe8d], glyphString: "\uFE8D" },
+    { glyphName: "alef-ar.fina", codePoints: [], glyphString: "\u200D\u0627" },
+    { glyphName: "alef-ar.fina", codePoints: [0xfe8e], glyphString: "\uFE8E" },
+    { glyphName: "beh-ar.init", codePoints: [], glyphString: "\u0628\u200D" },
+    { glyphName: "beh-ar.medi", codePoints: [], glyphString: "\u200D\u0628\u200D" },
+    { glyphName: "uni0628.medi", codePoints: [], glyphString: "\u200D\u0628\u200D" },
+  ];
+
+  parametrize(
+    "guessGlyphPlaceholderString",
+    guessGlyphPlaceholderString_testData,
+    (testItem) => {
+      const glyphString = guessGlyphPlaceholderString(
+        testItem.codePoints,
+        testItem.glyphName
+      );
+      expect(glyphString).to.equal(testItem.glyphString);
     }
   );
 });

--- a/src-js/fontra-core/tests/test-glyph-data.js
+++ b/src-js/fontra-core/tests/test-glyph-data.js
@@ -70,6 +70,14 @@ describe("glyph-data Tests", () => {
     { glyphName: "beh-ar.init", codePoints: [], glyphString: "\u0628\u200D" },
     { glyphName: "beh-ar.medi", codePoints: [], glyphString: "\u200D\u0628\u200D" },
     { glyphName: "uni0628.medi", codePoints: [], glyphString: "\u200D\u0628\u200D" },
+    { glyphName: "f_i", codePoints: [], glyphString: "fi" },
+    { glyphName: "lam_alef-ar", codePoints: [], glyphString: "\u0644\u0627" },
+    {
+      glyphName: "lam_alef-ar.fina",
+      codePoints: [],
+      glyphString: "\u200D\u0644\u0627",
+    },
+    { glyphName: "lam_lam_alef-ar", codePoints: [], glyphString: "\u0644\u0644\u0627" },
   ];
 
   parametrize(

--- a/src-js/fontra-webcomponents/src/glyph-cell.js
+++ b/src-js/fontra-webcomponents/src/glyph-cell.js
@@ -1,14 +1,10 @@
+import { guessGlyphPlaceholderString } from "@fontra/core/glyph-data.js";
 import { SVGPath2D } from "@fontra/core/glyph-svg.js";
 import * as html from "@fontra/core/html-utils.js";
 import { UnlitElement } from "@fontra/core/html-utils.js";
 import * as svg from "@fontra/core/svg-utils.js";
 import { Transform } from "@fontra/core/transform.js";
-import {
-  assert,
-  getCharFromCodePoint,
-  rgbaToCSS,
-  throttleCalls,
-} from "@fontra/core/utils.js";
+import { assert, rgbaToCSS, throttleCalls } from "@fontra/core/utils.js";
 import { InlineSVG } from "./inline-svg.js";
 import { themeColorCSS } from "./theme-support.js";
 
@@ -132,9 +128,10 @@ export class GlyphCell extends UnlitElement {
     this.height = (1 + this.marginTop + this.marginBottom) * this.size;
     assert(this.height === UNSCALED_CELL_HEIGHT, "manual size dependency incorrect");
     this.width = this.height;
-    this._glyphCharacter = this.codePoints?.[0]
-      ? getCharFromCodePoint(this.codePoints[0]) || ""
-      : "";
+    this._placeholderString = guessGlyphPlaceholderString(
+      this.codePoints,
+      this.glyphName
+    );
     this._selected = false;
   }
 
@@ -223,13 +220,14 @@ export class GlyphCell extends UnlitElement {
             : html.div(
                 {
                   class: "glyph-shape-placeholder",
+                  dir: "auto",
                   style: `
                   width: calc(${this.width}px * var(--glyph-cell-scale-factor));
                   font-size: calc(${fallbackFontSize}px * var(--glyph-cell-scale-factor));
                   line-height: ${fallbackFontSize}px;
                 `,
                 },
-                [this._glyphCharacter]
+                [this._placeholderString]
               ),
           html.div(
             {

--- a/src-js/fontra-webcomponents/src/glyph-cell.js
+++ b/src-js/fontra-webcomponents/src/glyph-cell.js
@@ -128,7 +128,7 @@ export class GlyphCell extends UnlitElement {
     this.height = (1 + this.marginTop + this.marginBottom) * this.size;
     assert(this.height === UNSCALED_CELL_HEIGHT, "manual size dependency incorrect");
     this.width = this.height;
-    this._placeholderString = guessGlyphPlaceholderString(
+    [this._placeholderString, this._placeholderDirection] = guessGlyphPlaceholderString(
       this.codePoints,
       this.glyphName
     );
@@ -220,7 +220,9 @@ export class GlyphCell extends UnlitElement {
             : html.div(
                 {
                   class: "glyph-shape-placeholder",
-                  dir: "auto",
+                  ...(this._placeholderDirection
+                    ? { dir: this._placeholderDirection }
+                    : {}),
                   style: `
                   width: calc(${this.width}px * var(--glyph-cell-scale-factor));
                   font-size: calc(${fallbackFontSize}px * var(--glyph-cell-scale-factor));

--- a/src-js/fontra-webcomponents/src/glyph-cell.js
+++ b/src-js/fontra-webcomponents/src/glyph-cell.js
@@ -128,10 +128,12 @@ export class GlyphCell extends UnlitElement {
     this.height = (1 + this.marginTop + this.marginBottom) * this.size;
     assert(this.height === UNSCALED_CELL_HEIGHT, "manual size dependency incorrect");
     this.width = this.height;
-    [this._placeholderString, this._placeholderDirection] = guessGlyphPlaceholderString(
+    const { glyphString, direction } = guessGlyphPlaceholderString(
       this.codePoints,
       this.glyphName
     );
+    this._placeholderString = glyphString;
+    this._placeholderDirection = direction || "auto";
     this._selected = false;
   }
 
@@ -220,9 +222,7 @@ export class GlyphCell extends UnlitElement {
             : html.div(
                 {
                   class: "glyph-shape-placeholder",
-                  ...(this._placeholderDirection
-                    ? { dir: this._placeholderDirection }
-                    : {}),
+                  dir: this._placeholderDirection,
                   style: `
                   width: calc(${this.width}px * var(--glyph-cell-scale-factor));
                   font-size: calc(${fallbackFontSize}px * var(--glyph-cell-scale-factor));

--- a/src-js/views-editor/src/visualization-layer-definitions.js
+++ b/src-js/views-editor/src/visualization-layer-definitions.js
@@ -154,15 +154,15 @@ registerVisualizationLayerDefinition({
         -lineDistance * glyphNameFontSize
       );
     }
-    const [placeholderString, placeholderDirection] = guessGlyphPlaceholderString(
+    const { glyphString, direction } = guessGlyphPlaceholderString(
       positionedGlyph.character?.codePointAt(0),
       positionedGlyph.glyphName
     );
-    if (placeholderString) {
+    if (glyphString) {
       context.font = `${placeholderFontSize}px fontra-ui-regular, sans-serif`;
-      context.direction = placeholderDirection;
+      context.direction = direction;
       context.fillText(
-        placeholderString,
+        glyphString,
         positionedGlyph.glyph.xAdvance / 2,
         -lineDistance * glyphNameFontSize - 0.4 * placeholderFontSize
       );

--- a/src-js/views-editor/src/visualization-layer-definitions.js
+++ b/src-js/views-editor/src/visualization-layer-definitions.js
@@ -1,3 +1,4 @@
+import { guessGlyphPlaceholderString } from "@fontra/core/glyph-data.js";
 import { translate } from "@fontra/core/localization.js";
 import { rectToPoints } from "@fontra/core/rectangle.js";
 import { difference, isSuperset, union } from "@fontra/core/set-ops.js";
@@ -152,9 +153,16 @@ registerVisualizationLayerDefinition({
         positionedGlyph.glyph.xAdvance / 2,
         -lineDistance * glyphNameFontSize
       );
+    }
+    const placeholderString = guessGlyphPlaceholderString(
+      positionedGlyph.character?.codePointAt(0),
+      positionedGlyph.glyphName
+    );
+    if (placeholderString) {
       context.font = `${placeholderFontSize}px fontra-ui-regular, sans-serif`;
+      context.direction = "rtl"; // FIXME "auto" does not work here
       context.fillText(
-        positionedGlyph.character,
+        placeholderString,
         positionedGlyph.glyph.xAdvance / 2,
         -lineDistance * glyphNameFontSize - 0.4 * placeholderFontSize
       );

--- a/src-js/views-editor/src/visualization-layer-definitions.js
+++ b/src-js/views-editor/src/visualization-layer-definitions.js
@@ -154,13 +154,13 @@ registerVisualizationLayerDefinition({
         -lineDistance * glyphNameFontSize
       );
     }
-    const placeholderString = guessGlyphPlaceholderString(
+    const [placeholderString, placeholderDirection] = guessGlyphPlaceholderString(
       positionedGlyph.character?.codePointAt(0),
       positionedGlyph.glyphName
     );
     if (placeholderString) {
       context.font = `${placeholderFontSize}px fontra-ui-regular, sans-serif`;
-      context.direction = "rtl"; // FIXME "auto" does not work here
+      context.direction = placeholderDirection;
       context.fillText(
         placeholderString,
         positionedGlyph.glyph.xAdvance / 2,


### PR DESCRIPTION
See the discussion in #2005

This works in the font overview, but I didn’t manage to find the relevant code in editor, so editing such glyphs still does not shows blank placeholder.