### PR TITLE
[reference font / opfs] iterDirectory will fail if the dir doesn't exist yet

### DIFF
--- a/src/fontra/views/editor/panel-reference-font.js
+++ b/src/fontra/views/editor/panel-reference-font.js
@@ -156,8 +156,10 @@ function garbageCollectFontItem(fontItem) {
 async function listFontFileNamesInOPFS() {
   const opfs = await _getOPFS();
   const fileNames = [];
-  for await (const name of opfs.iterDirectory([referenceFontsFolderName])) {
-    fileNames.push(name);
+  if (await opfs.exists([referenceFontsFolderName])) {
+    for await (const name of opfs.iterDirectory([referenceFontsFolderName])) {
+      fileNames.push(name);
+    }
   }
   return fileNames;
 }

--- a/src/fontra/views/editor/panel-reference-font.js
+++ b/src/fontra/views/editor/panel-reference-font.js
@@ -176,6 +176,7 @@ async function deleteFontFileFromOPFS(fileName) {
 
 async function writeFontFileToOPFS(fileName, file) {
   const opfs = await _getOPFS();
+  await opfs.createDirectory([referenceFontsFolderName]);
   await opfs.writeFile([referenceFontsFolderName, fileName], file);
 }
 


### PR DESCRIPTION
This fixes #2011.

These are regressions from #1918.