### PR TITLE
Remove css nowrap from body

### DIFF
--- a/src/fontra/client/core/ui-utils.js
+++ b/src/fontra/client/core/ui-utils.js
@@ -140,9 +140,10 @@ export function labeledCheckbox(label, controller, key, options) {
 }
 
 export function labelForElement(label, element, options) {
-  const labelElement = html.label({ for: element.id, style: "text-align: right;" }, [
-    label,
-  ]);
+  const labelElement = html.label(
+    { for: element.id, style: "white-space: nowrap; text-align: right;" },
+    [label]
+  );
   if (options?.labelClass) {
     labelElement.className = options.labelClass;
   }

--- a/src/fontra/client/css/core.css
+++ b/src/fontra/client/css/core.css
@@ -101,7 +101,6 @@ body {
   width: 100%;
   height: 100%;
   overflow: hidden; /* Hide scrollbars */
-  white-space: nowrap;
   overscroll-behavior: none;
   touch-action: none;
   color: var(--foreground-color);

--- a/src/fontra/client/css/shared.css
+++ b/src/fontra/client/css/shared.css
@@ -40,7 +40,3 @@ button,
 input[type="button"]:focus {
   outline: none;
 }
-
-.text-wrap {
-  white-space: wrap;
-}

--- a/src/fontra/client/css/tooltip.css
+++ b/src/fontra/client/css/tooltip.css
@@ -27,7 +27,6 @@
   content: attr(data-tooltip);
   width: max-content;
   max-width: var(--tooltip-max-width);
-  white-space: normal;
   font-size: 0.9rem;
   font-weight: normal;
   text-align: center;

--- a/src/fontra/client/web-components/glyph-cell-view.js
+++ b/src/fontra/client/web-components/glyph-cell-view.js
@@ -109,7 +109,6 @@ export class GlyphCellView extends HTMLElement {
       height: 100%;
       width: 100%;
       overflow-y: auto;
-      white-space: normal;
     }
 
     .glyph-count {

--- a/src/fontra/client/web-components/modal-dialog.js
+++ b/src/fontra/client/web-components/modal-dialog.js
@@ -36,7 +36,6 @@ export class ModalDialog extends SimpleElement {
     dialog {
       background-color: transparent;
       border: none;
-      white-space: normal;
     }
 
     dialog[open] {

--- a/src/fontra/client/web-components/simple-settings.js
+++ b/src/fontra/client/web-components/simple-settings.js
@@ -2,10 +2,6 @@ import { UnlitElement, div, input, label } from "/core/html-utils.js";
 
 export class SimpleSettings extends UnlitElement {
   static styles = `
-    :host {
-      white-space: normal;
-    }
-
     .header {
       margin-top: 0.6em;
       margin-bottom: 0.2em;

--- a/src/fontra/client/web-components/ui-form.js
+++ b/src/fontra/client/web-components/ui-form.js
@@ -96,10 +96,6 @@ export class Form extends SimpleElement {
       width: 4em;
     }
 
-    .ui-form-value.text {
-      white-space: normal;
-    }
-
     .ui-form-value.edit-number-x-y,
     .ui-form-value.universal-row {
       display: flex;

--- a/src/fontra/client/web-components/ui-list.js
+++ b/src/fontra/client/web-components/ui-list.js
@@ -83,11 +83,14 @@ export class UIList extends UnlitElement {
       background-color: var(--row-selected-background-color);
     }
 
-    .list-cell, .text-cell, .text-cell-header {
+    .list-cell,
+    .text-cell,
+    .text-cell-header {
       overflow: hidden;
       text-overflow: ellipsis;
       padding: 0 0.2em 0 0.1em;
-      box-sizing: content-box; /* FIXME: use border-box */
+      box-sizing: content-box; /* TODO: use border-box */
+      white-space: nowrap;
     }
 
     .list-cell.editing,
@@ -95,15 +98,18 @@ export class UIList extends UnlitElement {
       text-overflow: clip;
     }
 
-    .text-cell.left, .text-cell-header.left {
+    .text-cell.left,
+    .text-cell-header.left {
       text-align: left;
     }
 
-    .text-cell.center, .text-cell-header.center {
+    .text-cell.center,
+    .text-cell-header.center {
       text-align: center;
     }
 
-    .text-cell.right, .text-cell-header.right {
+    .text-cell.right,
+    .text-cell-header.right {
       text-align: right;
     }
     `;

--- a/src/fontra/views/applicationsettings/panel-shortcuts.js
+++ b/src/fontra/views/applicationsettings/panel-shortcuts.js
@@ -265,7 +265,6 @@ addStyleSheet(`
   .fontra-ui-shortcuts-panel-label {
     width: 18em;
     text-align: right;
-    white-space: normal;
   }
 
   .fontra-ui-shortcuts-panel-icon {

--- a/src/fontra/views/editor/panel-reference-font.js
+++ b/src/fontra/views/editor/panel-reference-font.js
@@ -189,7 +189,6 @@ export default class ReferenceFontPanel extends Panel {
     .reference-font-section {
       display: grid;
       gap: 1em;
-      white-space: normal;
       align-content: start;
     }
 

--- a/src/fontra/views/editor/panel-related-glyphs.js
+++ b/src/fontra/views/editor/panel-related-glyphs.js
@@ -83,7 +83,7 @@ export default class RelatedGlyphPanel extends Panel {
             class: "panel-section panel-section--flex related-glyphs-section",
           },
           [
-            html.div({ id: "related-glyphs-header", class: "text-wrap" }, [
+            html.div({ id: "related-glyphs-header" }, [
               translate("sidebar.related-glyphs.related-glyphs"),
             ]),
             this.glyphCellView,

--- a/src/fontra/views/editor/panel-selection-info.js
+++ b/src/fontra/views/editor/panel-selection-info.js
@@ -98,7 +98,7 @@ export default class SelectionInfoPanel extends Panel {
         },
       }),
       html.label(
-        { for: "behavior-checkbox", class: "text-wrap" },
+        { for: "behavior-checkbox" },
         translate("sidebar.selection-info.multi-source")
       ),
     ];


### PR DESCRIPTION
This sets document `white-space` back to `normal` (collapsed).
As mentioned in https://github.com/googlefonts/fontra/pull/1932#issuecomment-2615504160 I would recommend this. IMO it’s better for responsive behavior and avoids many overrides in the tree, since in most cases `nowrap` is an exception.