### PR TITLE
Add reference-font remove button

### DIFF
--- a/src/fontra/client/core/html-utils.js
+++ b/src/fontra/client/core/html-utils.js
@@ -167,6 +167,7 @@ export const a = createDomElement.bind(null, "a");
 export const br = createDomElement.bind(null, "br");
 export const button = createDomElement.bind(null, "button");
 export const div = createDomElement.bind(null, "div");
+export const form = createDomElement.bind(null, "form");
 export const section = createDomElement.bind(null, "section");
 export const input = createDomElement.bind(null, "input");
 export const label = createDomElement.bind(null, "label");

--- a/src/fontra/client/web-components/modal-dialog.js
+++ b/src/fontra/client/web-components/modal-dialog.js
@@ -137,13 +137,6 @@ export class ModalDialog extends SimpleElement {
       font-size: 1.1rem;
       resize: none;
     }
-
-    dialog .content {
-      display: grid;
-      gap: 0.5em;
-      grid-template-columns: max-content auto;
-      align-items: center;
-    }
   `;
 
   constructor() {

--- a/src/fontra/client/web-components/modal-dialog.js
+++ b/src/fontra/client/web-components/modal-dialog.js
@@ -137,6 +137,13 @@ export class ModalDialog extends SimpleElement {
       font-size: 1.1rem;
       resize: none;
     }
+
+    dialog .content {
+      display: grid;
+      gap: 0.5em;
+      grid-template-columns: max-content auto;
+      align-items: center;
+    }
   `;
 
   constructor() {

--- a/src/fontra/client/web-components/ui-list.js
+++ b/src/fontra/client/web-components/ui-list.js
@@ -201,6 +201,7 @@ export class UIList extends UnlitElement {
       this.container.scrollLeft = scrollLeft;
       this.container.scrollTop = scrollTop;
     }
+    this._dispatchEvent("itemsSet");
   }
 
   _updateVisibility() {

--- a/src/fontra/client/web-components/ui-list.js
+++ b/src/fontra/client/web-components/ui-list.js
@@ -1,3 +1,4 @@
+import { InlineSVG } from "./inline-svg.js";
 import { themeColorCSS } from "./theme-support.js";
 import * as html from "/core/html-utils.js";
 import { UnlitElement } from "/core/html-utils.js";
@@ -7,10 +8,17 @@ const LIST_CHUNK_SIZE = 200; // the amount of items added to the list at a time
 
 const colors = {
   "border-color": ["lightgray", "darkgray"],
+  "button-color": ["#ddd", "#888"],
+  "button-hover-color": ["#ccc", "#999"],
+  "button-active-color": ["#bbb", "#bbb"],
   "row-border-color": ["#ddd", "#333"],
   "row-foreground-color": ["black", "white"],
   "row-background-color": ["white", "#333"],
   "row-selected-background-color": ["#ddd", "#555"],
+  "row-selected-button-color": ["white", "#333"],
+  "row-selected-button-hover-color": ["darkgray", "lightgray"],
+  "row-selected-button-active-color": ["#888", "#ddd"],
+  "text-color": ["#000", "#fff"],
 };
 
 export class UIList extends UnlitElement {
@@ -67,6 +75,7 @@ export class UIList extends UnlitElement {
 
     .row {
       display: flex;
+      justify-content: space-between;
       width: min-content;
       min-width: 100%;
       border-top: solid 1px var(--row-border-color);
@@ -79,7 +88,7 @@ export class UIList extends UnlitElement {
       user-select: none;
     }
 
-    .contents > .selected {
+    .row.selected {
       background-color: var(--row-selected-background-color);
     }
 
@@ -105,6 +114,47 @@ export class UIList extends UnlitElement {
 
     .text-cell.right, .text-cell-header.right {
       text-align: right;
+    }
+
+    .ui-list-button {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      position: relative;
+      width: 1rem;
+      height: 1rem;
+      line-height: 0;
+      cursor: pointer;
+      padding: 0;
+      border-radius: 0.5rem;
+      border: none;
+      background: var(--button-color);
+      color: var(--text-color);
+    }
+
+    .ui-list-button:hover {
+      background-color: var(--button-hover-color);
+    }
+
+    .ui-list-button:active {
+      background-color: var(--button-active-color);
+    }
+
+    .ui-list-button inline-svg {
+      display: block;
+      width: 0.6rem;
+    }
+
+    .row.selected .ui-list-button {
+      background-color: var(--row-selected-button-color);
+    }
+
+    .row.selected .ui-list-button:hover {
+      background-color: var(--row-selected-button-hover-color);
+    }
+
+    .row.selected .ui-list-button:active {
+      background-color: var(--row-selected-button-active-color);
     }
     `;
 
@@ -255,8 +305,7 @@ export class UIList extends UnlitElement {
     const items = this._itemsBackLog.splice(0, LIST_CHUNK_SIZE);
     let rowIndex = this.contents.childElementCount;
     for (const item of items) {
-      const row = document.createElement("div");
-      row.className = "row";
+      const row = html.div({ class: "row" }, []);
       row.dataset.rowIndex = rowIndex;
       if (rowIndex === this.selectedItemIndex) {
         row.classList.add("selected");
@@ -287,6 +336,25 @@ export class UIList extends UnlitElement {
           }
         }
         row.appendChild(cell);
+      }
+
+      if (this.deleteItem) {
+        row.appendChild(
+          html.div({}, [
+            html.button(
+              {
+                class: "ui-list-button",
+                onclick: (event) => {
+                  const index = this._getRowIndexFromTarget(event.target);
+                  if (!isNaN(index) && index >= this.contents.children.length - 1) {
+                    this.deleteItem(index);
+                  }
+                },
+              },
+              [new InlineSVG("/images/minus.svg")]
+            ),
+          ])
+        );
       }
 
       this.contents.appendChild(row);

--- a/src/fontra/client/web-components/ui-list.js
+++ b/src/fontra/client/web-components/ui-list.js
@@ -1,4 +1,3 @@
-import { InlineSVG } from "./inline-svg.js";
 import { themeColorCSS } from "./theme-support.js";
 import * as html from "/core/html-utils.js";
 import { UnlitElement } from "/core/html-utils.js";
@@ -8,17 +7,10 @@ const LIST_CHUNK_SIZE = 200; // the amount of items added to the list at a time
 
 const colors = {
   "border-color": ["lightgray", "darkgray"],
-  "button-color": ["#ddd", "#888"],
-  "button-hover-color": ["#ccc", "#999"],
-  "button-active-color": ["#bbb", "#bbb"],
   "row-border-color": ["#ddd", "#333"],
   "row-foreground-color": ["black", "white"],
   "row-background-color": ["white", "#333"],
   "row-selected-background-color": ["#ddd", "#555"],
-  "row-selected-button-color": ["white", "#333"],
-  "row-selected-button-hover-color": ["darkgray", "lightgray"],
-  "row-selected-button-active-color": ["#888", "#ddd"],
-  "text-color": ["#000", "#fff"],
 };
 
 export class UIList extends UnlitElement {
@@ -75,7 +67,6 @@ export class UIList extends UnlitElement {
 
     .row {
       display: flex;
-      justify-content: space-between;
       width: min-content;
       min-width: 100%;
       border-top: solid 1px var(--row-border-color);
@@ -88,7 +79,7 @@ export class UIList extends UnlitElement {
       user-select: none;
     }
 
-    .row.selected {
+    .contents > .selected {
       background-color: var(--row-selected-background-color);
     }
 
@@ -114,47 +105,6 @@ export class UIList extends UnlitElement {
 
     .text-cell.right, .text-cell-header.right {
       text-align: right;
-    }
-
-    .ui-list-button {
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      position: relative;
-      width: 1rem;
-      height: 1rem;
-      line-height: 0;
-      cursor: pointer;
-      padding: 0;
-      border-radius: 0.5rem;
-      border: none;
-      background: var(--button-color);
-      color: var(--text-color);
-    }
-
-    .ui-list-button:hover {
-      background-color: var(--button-hover-color);
-    }
-
-    .ui-list-button:active {
-      background-color: var(--button-active-color);
-    }
-
-    .ui-list-button inline-svg {
-      display: block;
-      width: 0.6rem;
-    }
-
-    .row.selected .ui-list-button {
-      background-color: var(--row-selected-button-color);
-    }
-
-    .row.selected .ui-list-button:hover {
-      background-color: var(--row-selected-button-hover-color);
-    }
-
-    .row.selected .ui-list-button:active {
-      background-color: var(--row-selected-button-active-color);
     }
     `;
 
@@ -305,7 +255,8 @@ export class UIList extends UnlitElement {
     const items = this._itemsBackLog.splice(0, LIST_CHUNK_SIZE);
     let rowIndex = this.contents.childElementCount;
     for (const item of items) {
-      const row = html.div({ class: "row" }, []);
+      const row = document.createElement("div");
+      row.className = "row";
       row.dataset.rowIndex = rowIndex;
       if (rowIndex === this.selectedItemIndex) {
         row.classList.add("selected");
@@ -336,25 +287,6 @@ export class UIList extends UnlitElement {
           }
         }
         row.appendChild(cell);
-      }
-
-      if (this.deleteItem) {
-        row.appendChild(
-          html.div({}, [
-            html.button(
-              {
-                class: "ui-list-button",
-                onclick: (event) => {
-                  const index = this._getRowIndexFromTarget(event.target);
-                  if (!isNaN(index) && index >= this.contents.children.length - 1) {
-                    this.deleteItem(index);
-                  }
-                },
-              },
-              [new InlineSVG("/images/minus.svg")]
-            ),
-          ])
-        );
       }
 
       this.contents.appendChild(row);

--- a/src/fontra/views/editor/panel-reference-font.js
+++ b/src/fontra/views/editor/panel-reference-font.js
@@ -431,7 +431,9 @@ export default class ReferenceFontPanel extends Panel {
   }
 
   async _filesHandler(files) {
-    if (files.length === 0) return;
+    if (files.length === 0) {
+      return;
+    }
 
     const fontItemsInvalid = [];
     const fontItems = [...files]
@@ -544,10 +546,7 @@ export default class ReferenceFontPanel extends Panel {
   }
 
   async _deleteSelectedItemHandler() {
-    const index = this.filesUIList.getSelectedItemIndex();
-    if (index > -1 && index <= this.filesUIList.items.length - 1) {
-      await this._deleteItemOrAll(index);
-    }
+    await this._deleteItemOrAll(this.filesUIList.getSelectedItemIndex());
   }
 
   async _deleteAllHandler() {
@@ -670,7 +669,7 @@ export default class ReferenceFontPanel extends Panel {
     const fileInput = input(
       {
         type: "file",
-        accept: ".ttf,.otf,.woff,.woff2",
+        accept: [...fontFileExtensions].map((extension) => `.${extension}`).join(","),
         multiple: true,
       },
       []

--- a/src/fontra/views/editor/panel-reference-font.js
+++ b/src/fontra/views/editor/panel-reference-font.js
@@ -562,7 +562,7 @@ export default class ReferenceFontPanel extends Panel {
     model.selectedFontIndex = -1;
     model.referenceFontName = "";
 
-    filesUIList.setItems(listItems);
+    filesUIList.setItems(listItems, false, true);
     if (!filesUIList.getSelectedItemIndex() && listItems.length > 0) {
       filesUIList.setSelectedItemIndex(index === 0 ? 0 : index - 1, true);
     }

--- a/src/fontra/views/editor/panel-reference-font.js
+++ b/src/fontra/views/editor/panel-reference-font.js
@@ -624,6 +624,8 @@ export default class ReferenceFontPanel extends Panel {
 
     this.filesUIList.onFilesDrop = (files) => this._filesDropHandler(files);
 
+    this.filesUIList.deleteItem = (index) => this._deleteItemOrAll(index);
+
     this.filesUIList.addEventListener("listSelectionChanged", () => {
       this._listSelectionChangedHandler();
     });

--- a/src/fontra/views/editor/panel-reference-font.js
+++ b/src/fontra/views/editor/panel-reference-font.js
@@ -465,9 +465,10 @@ export default class ReferenceFontPanel extends Panel {
       dialog(dialogTitle, dialogMessage, [{ title: translate("dialog.okay") }], 5000);
     }
 
+    const newSelectedItemIndex = this.filesUIList.items.length;
     const newItems = [...this.filesUIList.items, ...fontItems];
     this.filesUIList.setItems(newItems);
-    this.filesUIList.setSelectedItemIndex(this.filesUIList.items.length - 1, true);
+    this.filesUIList.setSelectedItemIndex(newSelectedItemIndex, true);
 
     const writtenFontItems = [...this.model.fontList];
     try {
@@ -543,7 +544,10 @@ export default class ReferenceFontPanel extends Panel {
   }
 
   async _deleteSelectedItemHandler() {
-    await this._deleteItemOrAll(this.filesUIList.getSelectedItemIndex());
+    const index = this.filesUIList.getSelectedItemIndex();
+    if (index > -1 && index <= this.filesUIList.items.length - 1) {
+      await this._deleteItemOrAll(index);
+    }
   }
 
   async _deleteAllHandler() {
@@ -641,8 +645,9 @@ export default class ReferenceFontPanel extends Panel {
       this._listSelectionChangedHandler()
     );
 
-    this.filesUIList.addEventListener("deleteKey", () =>
-      this._deleteSelectedItemHandler()
+    this.filesUIList.addEventListener(
+      "deleteKey",
+      async () => await this._deleteSelectedItemHandler()
     );
     this.filesUIList.addEventListener("deleteKeyAlt", () => this._deleteAllHandler());
 
@@ -676,14 +681,8 @@ export default class ReferenceFontPanel extends Panel {
     });
     const addRemoveButtons = createDomElement("add-remove-buttons");
     addRemoveButtons.addButtonCallback = () => fileInput.click();
-    addRemoveButtons.removeButtonCallback = async () => {
-      const index = this.filesUIList.getSelectedItemIndex();
-      const maxIndex = () => this.filesUIList.items.length - 1;
-      if (!isNaN(index) && index <= maxIndex()) {
-        await this._deleteItemOrAll(index);
-        this.filesUIList.setSelectedItemIndex(maxIndex(), true);
-      }
-    };
+    addRemoveButtons.removeButtonCallback = async () =>
+      await this._deleteSelectedItemHandler();
 
     const disableRemoveButtonIfNeeded = () => {
       addRemoveButtons.disableRemoveButton = this.filesUIList.items.length === 0;

--- a/src/fontra/views/editor/panel-reference-font.js
+++ b/src/fontra/views/editor/panel-reference-font.js
@@ -663,7 +663,7 @@ export default class ReferenceFontPanel extends Panel {
     const addRemoveButtons = createDomElement("add-remove-buttons");
     addRemoveButtons.addButtonCallback = async () => {
       // TODO: translation
-      const dialog = await dialogSetup("Upload", null, [
+      const dialog = await dialogSetup("Add Reference Font(s)", null, [
         {
           title: translate("dialog.cancel"),
           resultValue: "cancel",
@@ -678,7 +678,6 @@ export default class ReferenceFontPanel extends Panel {
       const fileInput = input(
         {
           type: "file",
-          id: "reference-font-file",
           accept: ".ttf,.otf,.woff,.woff2",
           multiple: true,
         },
@@ -686,10 +685,7 @@ export default class ReferenceFontPanel extends Panel {
       );
       dialog.setContent(
         form({ enctype: "multipart/form-data", class: "content" }, [
-          label({ for: "reference-font-file", class: "reference-font-label" }, [
-            "Choose a font", // TODO: translation
-          ]),
-          fileInput,
+          label({}, [fileInput]),
         ])
       );
       const result = await dialog.run();


### PR DESCRIPTION
Before reference-font items could only be deleted by selecting (clicking) an item and pressing delete-key after. Not self-explanatory. 
Now there is a remove (-) button at the end of each line.

![Bildschirmfoto 2025-02-10 um 16 01 28](https://github.com/user-attachments/assets/8d5c0ffa-07e5-40a2-84fd-45b7b44e0026)
