### PR TITLE
Add support for font guidelines

### DIFF
--- a/src/fontra/client/core/font-controller.js
+++ b/src/fontra/client/core/font-controller.js
@@ -20,6 +20,7 @@ import {
   colorizeImage,
   getCharFromCodePoint,
   mapObjectValues,
+  normalizeGuidelines,
   sleepAsync,
   throttleCalls,
   uniqueID,
@@ -1140,6 +1141,7 @@ function ensureDenseSources(sources) {
           return { value: metric.value, zone: metric.zone || 0 };
         }
       ),
+      guidelines: normalizeGuidelines(source.guidelines || []),
       customData: source.customData || {},
     };
   });

--- a/src/fontra/client/web-components/ui-list.js
+++ b/src/fontra/client/web-components/ui-list.js
@@ -326,7 +326,9 @@ export class UIList extends UnlitElement {
 
     const onchange = (event) => {
       const formatter = colDesc.formatter || DefaultFormatter;
-      const { value, error } = formatter.fromString(cell.innerText);
+      const { value, error } = formatter.fromString(
+        cell.innerText != "\n" ? cell.innerText : ""
+      );
       if (!error) {
         item[colDesc.key] = value;
       }

--- a/src/fontra/views/editor/visualization-layer-definitions.js
+++ b/src/fontra/views/editor/visualization-layer-definitions.js
@@ -502,14 +502,10 @@ registerVisualizationLayerDefinition({
   },
   colors: {
     strokeColor: "#0006",
-    boxColor: "#FFFB",
-    color: "#000",
     strokeColorFontGuideline: "#00BFFF80",
   },
   colorsDarkMode: {
     strokeColor: "#FFF8",
-    boxColor: "#1118",
-    color: "#FFF",
     strokeColorFontGuideline: "#00BFFF70",
   },
   draw: (context, positionedGlyph, parameters, model, controller) => {
@@ -530,7 +526,7 @@ registerVisualizationLayerDefinition({
     if (!model.fontSourceInstance) {
       return;
     }
-    for (const guideline of model.fontSourceInstance.guidelines || []) {
+    for (const guideline of model.fontSourceInstance.guidelines) {
       _drawGuideline(
         context,
         parameters,

--- a/src/fontra/views/editor/visualization-layer-definitions.js
+++ b/src/fontra/views/editor/visualization-layer-definitions.js
@@ -524,11 +524,17 @@ registerVisualizationLayerDefinition({
       _drawGuideline(context, parameters, guideline);
     }
 
-    // TODO: Font Guidelines
+    // Draw font guidelines
+    if (!model.fontSourceInstance) {
+      return;
+    }
+    for (const guideline of model.fontSourceInstance.guidelines || []) {
+      _drawGuideline(context, parameters, guideline, parameters.strokeDash / 2);
+    }
   },
 });
 
-function _drawGuideline(context, parameters, guideline) {
+function _drawGuideline(context, parameters, guideline, strokeDash) {
   withSavedState(context, () => {
     context.strokeStyle = parameters.strokeColor;
     context.lineWidth = parameters.strokeWidth;
@@ -574,7 +580,7 @@ function _drawGuideline(context, parameters, guideline) {
 
       // collect lines
       let lines = [[halfMarker, parameters.strokeLength]];
-      if (guideline.name !== undefined) {
+      if (guideline.name !== undefined && guideline.name.trim() !== "") {
         // with name
         lines.push([
           -textWidth / 2 + moveText - parameters.margin,
@@ -587,10 +593,7 @@ function _drawGuideline(context, parameters, guideline) {
       }
       // draw lines
       for (const [x1, x2] of lines) {
-        strokeLineDashed(context, x1, 0, x2, 0, [
-          parameters.strokeDash * 2,
-          parameters.strokeDash,
-        ]);
+        strokeLineDashed(context, x1, 0, x2, 0, [strokeDash * 2, strokeDash]);
       }
     });
   });

--- a/src/fontra/views/editor/visualization-layer-definitions.js
+++ b/src/fontra/views/editor/visualization-layer-definitions.js
@@ -582,7 +582,7 @@ function _drawGuideline(context, parameters, guideline, strokeColor) {
 
       // collect lines
       let lines = [[halfMarker, parameters.strokeLength]];
-      if (guideline.name !== undefined && guideline.name.trim() !== "") {
+      if (guideline.name) {
         // with name
         lines.push([
           -textWidth / 2 + moveText - parameters.margin,

--- a/src/fontra/views/editor/visualization-layer-definitions.js
+++ b/src/fontra/views/editor/visualization-layer-definitions.js
@@ -562,14 +562,13 @@ function _drawGuideline(context, parameters, guideline, strokeColor) {
       context.scale(1, -1);
 
       let textWidth;
-      let textHeight;
       let moveText;
       const halfMarker = parameters.originMarkerRadius / 2 + parameters.strokeWidth * 2;
       // draw name
       if (guideline.name) {
         const strLine = `${guideline.name}`;
         textWidth = Math.max(context.measureText(strLine).width);
-        textHeight = Math.max(getTextHeight(context, strLine));
+        const textVerticalCenter = Math.max(getTextVerticalCenter(context, strLine));
 
         context.fillStyle = strokeColor;
         moveText =
@@ -578,7 +577,7 @@ function _drawGuideline(context, parameters, guideline, strokeColor) {
           halfMarker - // move half of the marker radius left + stroke width
           parameters.margin * // move one margin to left to get a short line on the left
             2; // move another margin left to get the margin on the right
-        context.fillText(strLine, moveText, textHeight / 2);
+        context.fillText(strLine, moveText, textVerticalCenter);
       }
 
       // collect lines
@@ -1867,7 +1866,7 @@ function drawRoundRect(context, x, y, width, height, radii) {
   context.fill();
 }
 
-function getTextHeight(context, text) {
+function getTextVerticalCenter(context, text) {
   const metrics = context.measureText(text);
-  return metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent;
+  return (metrics.actualBoundingBoxAscent - metrics.actualBoundingBoxDescent) / 2;
 }

--- a/src/fontra/views/editor/visualization-layer-definitions.js
+++ b/src/fontra/views/editor/visualization-layer-definitions.js
@@ -390,7 +390,7 @@ registerVisualizationLayerDefinition({
       const pt = { x: anchor.x, y: anchor.y };
 
       const strLine = `${anchor.name}`;
-      const width = Math.max(context.measureText(strLine).width) + 2 * margin;
+      const width = context.measureText(strLine).width + 2 * margin;
 
       context.fillStyle = parameters.boxColor;
       drawRoundRect(
@@ -567,8 +567,8 @@ function _drawGuideline(context, parameters, guideline, strokeColor) {
       // draw name
       if (guideline.name) {
         const strLine = `${guideline.name}`;
-        textWidth = Math.max(context.measureText(strLine).width);
-        const textVerticalCenter = Math.max(getTextVerticalCenter(context, strLine));
+        textWidth = context.measureText(strLine).width;
+        const textVerticalCenter = getTextVerticalCenter(context, strLine);
 
         context.fillStyle = strokeColor;
         moveText =
@@ -1121,7 +1121,7 @@ registerVisualizationLayerDefinition({
       const startPoint = glyph.path.getPoint(startPointIndex);
 
       const strLine = `${contourIndex}`;
-      const width = Math.max(context.measureText(strLine).width) + 2 * margin;
+      const width = context.measureText(strLine).width + 2 * margin;
 
       context.fillStyle = parameters.boxColor;
       drawRoundRect(

--- a/src/fontra/views/editor/visualization-layer-definitions.js
+++ b/src/fontra/views/editor/visualization-layer-definitions.js
@@ -504,11 +504,13 @@ registerVisualizationLayerDefinition({
     strokeColor: "#0006",
     boxColor: "#FFFB",
     color: "#000",
+    strokeColorFontGuideline: "#00BFFF80",
   },
   colorsDarkMode: {
     strokeColor: "#FFF8",
     boxColor: "#1118",
     color: "#FFF",
+    strokeColorFontGuideline: "#00BFFF70",
   },
   draw: (context, positionedGlyph, parameters, model, controller) => {
     context.font = `${parameters.fontSize}px fontra-ui-regular, sans-serif`;
@@ -521,7 +523,7 @@ registerVisualizationLayerDefinition({
 
     // Draw glyph guidelines
     for (const guideline of positionedGlyph.glyph.guidelines) {
-      _drawGuideline(context, parameters, guideline, parameters.strokeDash);
+      _drawGuideline(context, parameters, guideline, parameters.strokeColor);
     }
 
     // Draw font guidelines
@@ -529,14 +531,19 @@ registerVisualizationLayerDefinition({
       return;
     }
     for (const guideline of model.fontSourceInstance.guidelines || []) {
-      _drawGuideline(context, parameters, guideline, parameters.strokeDash / 2);
+      _drawGuideline(
+        context,
+        parameters,
+        guideline,
+        parameters.strokeColorFontGuideline
+      );
     }
   },
 });
 
-function _drawGuideline(context, parameters, guideline, strokeDash) {
+function _drawGuideline(context, parameters, guideline, strokeColor) {
   withSavedState(context, () => {
-    context.strokeStyle = parameters.strokeColor;
+    context.strokeStyle = strokeColor;
     context.lineWidth = parameters.strokeWidth;
     //translate to guideline origin
     context.translate(guideline.x, guideline.y);
@@ -547,7 +554,7 @@ function _drawGuideline(context, parameters, guideline, strokeDash) {
         context,
         -parameters.iconSize / 2,
         parameters.iconSize / 2,
-        parameters.strokeColor,
+        strokeColor,
         parameters.iconSize
       );
     } else {
@@ -568,7 +575,7 @@ function _drawGuideline(context, parameters, guideline, strokeDash) {
         textWidth = Math.max(context.measureText(strLine).width);
         textHeight = Math.max(getTextHeight(context, strLine));
 
-        context.fillStyle = parameters.strokeColor;
+        context.fillStyle = strokeColor;
         moveText =
           0 - // this is centered to the guideline origin
           textWidth / 2 - // move half width left -> right aligned to origin
@@ -593,7 +600,10 @@ function _drawGuideline(context, parameters, guideline, strokeDash) {
       }
       // draw lines
       for (const [x1, x2] of lines) {
-        strokeLineDashed(context, x1, 0, x2, 0, [strokeDash * 2, strokeDash]);
+        strokeLineDashed(context, x1, 0, x2, 0, [
+          parameters.strokeDash * 2,
+          parameters.strokeDash,
+        ]);
       }
     });
   });

--- a/src/fontra/views/editor/visualization-layer-definitions.js
+++ b/src/fontra/views/editor/visualization-layer-definitions.js
@@ -521,7 +521,7 @@ registerVisualizationLayerDefinition({
 
     // Draw glyph guidelines
     for (const guideline of positionedGlyph.glyph.guidelines) {
-      _drawGuideline(context, parameters, guideline);
+      _drawGuideline(context, parameters, guideline, parameters.strokeDash);
     }
 
     // Draw font guidelines

--- a/src/fontra/views/editor/visualization-layer-definitions.js
+++ b/src/fontra/views/editor/visualization-layer-definitions.js
@@ -502,11 +502,11 @@ registerVisualizationLayerDefinition({
   },
   colors: {
     strokeColor: "#0006",
-    strokeColorFontGuideline: "#00BFFF80",
+    strokeColorFontGuideline: "#00BFFF",
   },
   colorsDarkMode: {
     strokeColor: "#FFF8",
-    strokeColorFontGuideline: "#00BFFF70",
+    strokeColorFontGuideline: "#00BFFFC0",
   },
   draw: (context, positionedGlyph, parameters, model, controller) => {
     context.font = `${parameters.fontSize}px fontra-ui-regular, sans-serif`;

--- a/src/fontra/views/fontinfo/panel-axes.js
+++ b/src/fontra/views/fontinfo/panel-axes.js
@@ -910,7 +910,8 @@ function buildValueLabelList(axisController) {
   ]);
 }
 
-function updateRemoveButton(list, buttons) {
+// TODO: Refactor this.
+export function updateRemoveButton(list, buttons) {
   list.addEventListener("listSelectionChanged", (event) => {
     buttons.disableRemoveButton = list.getSelectedItemIndex() === undefined;
   });

--- a/src/fontra/views/fontinfo/panel-sources.js
+++ b/src/fontra/views/fontinfo/panel-sources.js
@@ -14,6 +14,7 @@ import {
 } from "../core/ui-utils.js";
 import { arrowKeyDeltas, enumerate, modulo, range, round } from "../core/utils.js";
 import { UIList } from "../web-components/ui-list.js";
+import { updateRemoveButton } from "./panel-axes.js";
 import { BaseInfoPanel } from "./panel-base.js";
 import {
   locationToString,
@@ -873,14 +874,6 @@ function buildFontGuidelineList(controller) {
     labelList,
     addRemoveButton,
   ]);
-}
-
-// This is a copy of the function from panel-axes.js
-// TODO: refactor to avoid duplication.
-function updateRemoveButton(list, buttons) {
-  list.addEventListener("listSelectionChanged", (event) => {
-    buttons.disableRemoveButton = list.getSelectedItemIndex() === undefined;
-  });
 }
 
 function buildElementLocations(controller, fontAxes) {

--- a/src/fontra/views/fontinfo/panel-sources.js
+++ b/src/fontra/views/fontinfo/panel-sources.js
@@ -785,7 +785,7 @@ function buildFontGuidelineList(controller) {
     {
       key: "name",
       title: translate("guideline.labels.name"),
-      width: "11em",
+      width: "15em", // TODO: set to 11em once 'Locked' column is added
       editable: true,
       continuous: false,
     },
@@ -816,17 +816,19 @@ function buildFontGuidelineList(controller) {
       formatter: OptionalNumberFormatter,
       continuous: false,
     },
-    {
-      key: "dummy", // this is a spacer column
-      title: " ",
-      width: "0.25em",
-    },
-    {
-      key: "locked",
-      title: translate("guideline.labels.locked"),
-      width: "4em",
-      cellFactory: checkboxListCell,
-    },
+    // TODO: Font Guidelines
+    // Once the guidelines can be edited in the editor view, we want to add these columns
+    // {
+    //   key: "dummy", // this is a spacer column
+    //   title: " ",
+    //   width: "0.25em",
+    // },
+    // {
+    //   key: "locked",
+    //   title: translate("guideline.labels.locked"),
+    //   width: "4em",
+    //   cellFactory: checkboxListCell,
+    // },
   ];
   labelList.showHeader = true;
   labelList.minHeight = "5em";

--- a/src/fontra/views/fontinfo/panel-sources.js
+++ b/src/fontra/views/fontinfo/panel-sources.js
@@ -692,7 +692,7 @@ class SourceBox extends HTMLElement {
       );
     }
     if (!this.source.isSparse) {
-      // NOTE: Don't show 'Line Metrics' or 'Guidelines' for sparce sources.
+      // NOTE: Don't show 'Line Metrics' or 'Guidelines' for sparse sources.
       this.append(
         html.div({ class: "fontra-ui-font-info-sources-panel-header" }, [
           getLabelFromKey("lineMetricsHorizontalLayout"),

--- a/src/fontra/views/fontinfo/panel-sources.js
+++ b/src/fontra/views/fontinfo/panel-sources.js
@@ -690,18 +690,21 @@ class SourceBox extends HTMLElement {
         buildElementLocations(this.controllers.location, this.fontAxesSourceSpace)
       );
     }
-    this.append(
-      html.div({ class: "fontra-ui-font-info-sources-panel-header" }, [
-        getLabelFromKey("lineMetricsHorizontalLayout"),
-      ]),
-      buildElementLineMetricsHor(this.controllers.lineMetricsHorizontalLayout)
-    );
-    this.append(
-      html.div({ class: "fontra-ui-font-info-sources-panel-header" }, [
-        getLabelFromKey("guidelines"),
-      ]),
-      buildFontGuidelineList(this.controllers.guidelines)
-    );
+    if (!this.source.isSparse) {
+      // NOTE: Don't show 'Line Metrics' or 'Guidelines' for sparce sources.
+      this.append(
+        html.div({ class: "fontra-ui-font-info-sources-panel-header" }, [
+          getLabelFromKey("lineMetricsHorizontalLayout"),
+        ]),
+        buildElementLineMetricsHor(this.controllers.lineMetricsHorizontalLayout)
+      );
+      this.append(
+        html.div({ class: "fontra-ui-font-info-sources-panel-header" }, [
+          getLabelFromKey("guidelines"),
+        ]),
+        buildFontGuidelineList(this.controllers.guidelines)
+      );
+    }
   }
 }
 


### PR DESCRIPTION
Fixes #1963 #909 #2026

This allows adding/editing of font level guidelines via the sources panel. 
Currently it's not possible to edit font level guidelines within the editor view (we may want to create a new issue for this and see it as a follow up).

Quick demo:

https://github.com/user-attachments/assets/ad122b3b-ce95-43d1-98de-809658f33e2d

