### PR TITLE
Don't show 'Transform selection' if only one point is selected

### DIFF
--- a/src/fontra/client/core/glyph-controller.js
+++ b/src/fontra/client/core/glyph-controller.js
@@ -700,6 +700,13 @@ export class StaticGlyphController {
       backgroundImage: backgroundImageIndices,
     } = parseSelection(selection);
 
+    if (selection.size == 1 && pointIndices?.length == 1) {
+      // Return if only one point is selected.
+      // NOTE: We need to check selection.size == 1 because otherwise we don't know
+      // if someone selected a single point + a different object like a component, anchor, etc.
+      return undefined;
+    }
+
     pointIndices = pointIndices || [];
     componentIndices = componentIndices || [];
     anchorIndices = anchorIndices || [];

--- a/src/fontra/client/core/glyph-controller.js
+++ b/src/fontra/client/core/glyph-controller.js
@@ -700,13 +700,6 @@ export class StaticGlyphController {
       backgroundImage: backgroundImageIndices,
     } = parseSelection(selection);
 
-    if (selection.size == 1 && pointIndices?.length == 1) {
-      // Return if only one point is selected.
-      // NOTE: We need to check selection.size == 1 because otherwise we don't know
-      // if someone selected a single point + a different object like a component, anchor, etc.
-      return undefined;
-    }
-
     pointIndices = pointIndices || [];
     componentIndices = componentIndices || [];
     anchorIndices = anchorIndices || [];

--- a/src/fontra/views/editor/edit-tools-pointer.js
+++ b/src/fontra/views/editor/edit-tools-pointer.js
@@ -817,6 +817,13 @@ function getTransformHandles(transformBounds, margin) {
 }
 
 function getTransformSelectionBounds(glyph, selection, getBackgroundImageBoundsFunc) {
+  const { point: pointIndices } = parseSelection(selection);
+  if (selection.size == 1 && pointIndices?.length == 1) {
+    // Return if only one point is selected.
+    // NOTE: We need to check selection.size == 1 because otherwise we don't know
+    // if someone selected a single point + a different object like a component, anchor, etc.
+    return undefined;
+  }
   const selectionBounds = glyph.getSelectionBounds(
     selection,
     getBackgroundImageBoundsFunc

--- a/src/fontra/views/editor/edit-tools-pointer.js
+++ b/src/fontra/views/editor/edit-tools-pointer.js
@@ -818,9 +818,8 @@ function getTransformHandles(transformBounds, margin) {
 
 function getTransformSelectionBounds(glyph, selection, getBackgroundImageBoundsFunc) {
   if (selection.size == 1 && parseSelection(selection).point?.length == 1) {
-    // Return if only one point is selected.
-    // NOTE: We need to check selection.size == 1 because otherwise we don't know
-    // if someone selected a single point + a different object like a component, anchor, etc.
+    // Return if only a single point is selected, as in that case the "selection bounds"
+    // is not really useful for the user, and is distracting instead.
     return undefined;
   }
   const selectionBounds = glyph.getSelectionBounds(

--- a/src/fontra/views/editor/edit-tools-pointer.js
+++ b/src/fontra/views/editor/edit-tools-pointer.js
@@ -817,13 +817,6 @@ function getTransformHandles(transformBounds, margin) {
 }
 
 function getTransformSelectionBounds(glyph, selection, getBackgroundImageBoundsFunc) {
-  const { point: pointIndices } = parseSelection(selection);
-  if (selection.size == 1 && pointIndices?.length == 1) {
-    // Return if only one point is selected.
-    // NOTE: We need to check selection.size == 1 because otherwise we don't know
-    // if someone selected a single point + a different object like a component, anchor, etc.
-    return undefined;
-  }
   const selectionBounds = glyph.getSelectionBounds(
     selection,
     getBackgroundImageBoundsFunc

--- a/src/fontra/views/editor/edit-tools-pointer.js
+++ b/src/fontra/views/editor/edit-tools-pointer.js
@@ -817,8 +817,7 @@ function getTransformHandles(transformBounds, margin) {
 }
 
 function getTransformSelectionBounds(glyph, selection, getBackgroundImageBoundsFunc) {
-  const { point: pointIndices } = parseSelection(selection);
-  if (selection.size == 1 && pointIndices?.length == 1) {
+  if (selection.size == 1 && parseSelection(selection).point?.length == 1) {
     // Return if only one point is selected.
     // NOTE: We need to check selection.size == 1 because otherwise we don't know
     // if someone selected a single point + a different object like a component, anchor, etc.


### PR DESCRIPTION
Fixes #2022 