### PR TITLE
Refactor/UI list style settings

### DIFF
--- a/src/fontra/client/web-components/plugin-manager.js
+++ b/src/fontra/client/web-components/plugin-manager.js
@@ -34,7 +34,7 @@ export class PluginManager extends SimpleElement {
     observable.synchronizeWithLocalStorage("fontra.plugins");
     this.observable = observable;
     this.pluginList = new UIList();
-    this.pluginList.minHeight = "5em";
+    this.pluginList.style.setProperty("--container-min-height", "5em");
     this.pluginList.setItems(observable.model.plugins);
     this.pluginList.columnDescriptions = [
       {

--- a/src/fontra/client/web-components/ui-list.js
+++ b/src/fontra/client/web-components/ui-list.js
@@ -27,6 +27,7 @@ export class UIList extends UnlitElement {
 
     .container {
       overflow: auto;
+      min-height: var(--container-min-height, auto);
       height: 100%;
       width: 100%;
       border: solid 1px var(--border-color);
@@ -157,7 +158,6 @@ export class UIList extends UnlitElement {
   }
 
   render() {
-    this.container.style = this.minHeight ? `min-height: ${this.minHeight};` : "";
     const contents = [];
     if (this.showHeader) {
       contents.push(this._makeHeader());
@@ -168,7 +168,6 @@ export class UIList extends UnlitElement {
 
   static properties = {
     showHeader: { type: Boolean },
-    minHeight: { type: String },
   };
 
   get columnDescriptions() {

--- a/src/fontra/client/web-components/ui-list.js
+++ b/src/fontra/client/web-components/ui-list.js
@@ -18,7 +18,7 @@ export class UIList extends UnlitElement {
     ${themeColorCSS(colors)}
 
     :host {
-      display: grid;  /* also set by code below */
+      display: grid;
       grid-template-rows: auto 1fr;
       gap: 0.2em;
       min-height: 0;
@@ -157,7 +157,6 @@ export class UIList extends UnlitElement {
   }
 
   render() {
-    this._updateVisibility();
     this.container.style = this.minHeight ? `min-height: ${this.minHeight};` : "";
     const contents = [];
     if (this.showHeader) {
@@ -193,7 +192,6 @@ export class UIList extends UnlitElement {
     const selectedItem = this.getSelectedItem();
     this.contents.innerHTML = "";
     this.items = items;
-    this._updateVisibility();
     this._itemsBackLog = Array.from(items);
     this.setSelectedItem(selectedItem, shouldDispatchEvent);
     this._addMoreItemsIfNeeded();
@@ -201,10 +199,6 @@ export class UIList extends UnlitElement {
       this.container.scrollLeft = scrollLeft;
       this.container.scrollTop = scrollTop;
     }
-  }
-
-  _updateVisibility() {
-    this.style.display = this.items?.length || this.minHeight ? "grid" : "none";
   }
 
   getSelectedItem() {

--- a/src/fontra/views/editor/panel-reference-font.js
+++ b/src/fontra/views/editor/panel-reference-font.js
@@ -620,7 +620,7 @@ export default class ReferenceFontPanel extends Panel {
     this.filesUIList.columnDescriptions = columnDescriptions;
     this.filesUIList.itemEqualFunc = (a, b) => a.fontIdentifier == b.fontIdentifier;
 
-    this.filesUIList.minHeight = "6em";
+    this.filesUIList.style.setProperty("--container-min-height", "6em");
 
     this.filesUIList.onFilesDrop = (files) => this._filesDropHandler(files);
 

--- a/src/fontra/views/fontinfo/panel-axes.js
+++ b/src/fontra/views/fontinfo/panel-axes.js
@@ -740,7 +740,7 @@ function buildMappingList(axisController) {
     },
   ];
   mappingList.showHeader = true;
-  mappingList.minHeight = "5em";
+  mappingList.style.setProperty("--container-min-height", "5em");
   mappingList.setItems(items);
 
   const deleteSelectedItem = () => {
@@ -867,7 +867,7 @@ function buildValueLabelList(axisController) {
     // },
   ];
   labelList.showHeader = true;
-  labelList.minHeight = "5em";
+  labelList.style.setProperty("--container-min-height", "5em");
   labelList.setItems(items);
 
   const deleteSelectedItem = () => {


### PR DESCRIPTION
First commit:
The `_updateVisibility` function never set any element to `display: none`. All `ui-list` (except glyph-search) were using `min-height` and `this.items` is defined as array in constructor (should not be `undefined`). Also I guess, if a list should become hidden, its better practice when the parent decides it (where data is set).

Second commit:
I guess setting `min-height` for container with custom properties is cleaner.