### PR TITLE
[reference font] Improve reference font var location

### DIFF
--- a/src/fontra/views/editor/panel-reference-font.js
+++ b/src/fontra/views/editor/panel-reference-font.js
@@ -262,10 +262,10 @@ export default class ReferenceFontPanel extends Panel {
     editorController.sceneSettingsController.addKeyListener("fontLocationUser", () => {
       const fontVariationSettings = [];
       for (const axis of this.editorController.fontController.fontAxes) {
+        const axisValue =
+          this.editorController.sceneSettings.fontLocationUser[axis.name];
         fontVariationSettings.push(
-          `'${axis.tag}' ${
-            this.editorController.sceneSettings.fontLocationUser[axis.name]
-          }`
+          `'${axis.tag}' ${axisValue != undefined ? axisValue : axis.defaultValue}`
         );
       }
       const cssString = fontVariationSettings.join(",");


### PR DESCRIPTION
Previously, an unset axis would result in an axis value of 'undefined' in the CSS, which is invalid.