### PR TITLE
[sources panel] Italic angle fix: write correct number type

### DIFF
--- a/src/fontra/core/classes.py
+++ b/src/fontra/core/classes.py
@@ -343,7 +343,8 @@ def _unstructureFloat(v):
         if v.is_integer():
             return int(v)
     except AttributeError:
-        pass
+        if not isinstance(v, (int, float)):
+            raise TypeError(f"Expected int or float, got {type(v)}. ({v!r})")
     return v
 
 

--- a/src/fontra/views/fontinfo/panel-sources.js
+++ b/src/fontra/views/fontinfo/panel-sources.js
@@ -5,6 +5,7 @@ import { addStyleSheet } from "../core/html-utils.js";
 import { translate } from "../core/localization.js";
 import { ObservableController } from "../core/observable-object.js";
 import {
+  NumberFormatter,
   OptionalNumberFormatter,
   checkboxListCell,
   labelForElement,
@@ -723,6 +724,12 @@ function buildElement(controller) {
       .map(([labelName, keyName, value]) => {
         if (typeof value === "boolean") {
           return [html.div(), labeledCheckbox(labelName, controller, keyName, {})];
+        } else if (typeof value === "number") {
+          return labeledTextInput(labelName, controller, keyName, {
+            continuous: false,
+            type: "number",
+            formatter: NumberFormatter,
+          });
         } else {
           return labeledTextInput(labelName, controller, keyName, {
             continuous: false,


### PR DESCRIPTION
- When serializing numbers, ensure they actually ar enumbers (float or int)
- Use NumberFormatter for italicAngle, so we write the value as a number

This fixes #2036.