### PR TITLE
Delete tangent point

### DIFF
--- a/src/fontra/client/core/path-functions.js
+++ b/src/fontra/client/core/path-functions.js
@@ -687,8 +687,8 @@ function simpleTangentDeletion(points) {
     (acc, pt) => acc + (!pt.type ? 1 : 0),
     0
   );
-  const firstBetweenIsOnCurve = !betweenPoints[0].type;
-  const lastBetweenIsOnCurve = !betweenPoints.at(-1).type;
+  const firstBetweenIsOnCurve = betweenPoints[0].smooth;
+  const lastBetweenIsOnCurve = betweenPoints.at(-1).smooth;
 
   if (numOnCurvePoints === 2 && firstBetweenIsOnCurve && lastBetweenIsOnCurve) {
     return betweenPoints.slice(1, -1);

--- a/src/fontra/client/core/path-functions.js
+++ b/src/fontra/client/core/path-functions.js
@@ -664,6 +664,7 @@ function computeHandlesFromFragment(curveType, contour) {
   }
   const leftTangent = getEndTangent(contour.points, true);
   const rightTangent = getEndTangent(contour.points, false);
+
   const bezier = fitCubic(samplePoints, leftTangent, rightTangent, 0.5);
   let handle1, handle2;
   handle1 = bezier.points[1];
@@ -701,21 +702,9 @@ function simpleTangentDeletion(points) {
 }
 
 function getEndTangent(points, isStart) {
-  const numPoints = points.length;
-  const direction = isStart ? 1 : -1;
-  const firstIndex = isStart ? 0 : numPoints - 1;
-  const firstPoint = points[firstIndex];
-  let secondPoint = points[firstIndex + direction];
-
-  for (let i = firstIndex + direction; i >= 0 && i < numPoints; i += direction) {
-    const testPoint = points[i];
-    if (testPoint.x !== firstPoint.x || testPoint.y !== firstPoint.y) {
-      secondPoint = testPoint;
-      break;
-    }
-  }
-
-  return vector.normalizeVector(vector.subVectors(secondPoint, firstPoint));
+  return vector.normalizeVector(
+    vector.subVectors(points.at(isStart ? 1 : -2), points.at(isStart ? 0 : -1))
+  );
 }
 
 export function scalePoint(pinPoint, point, factor) {

--- a/src/fontra/client/core/path-functions.js
+++ b/src/fontra/client/core/path-functions.js
@@ -687,15 +687,23 @@ function simpleTangentDeletion(points) {
     (acc, pt) => acc + (!pt.type ? 1 : 0),
     0
   );
-  const firstBetweenIsOnCurve = betweenPoints[0].smooth;
-  const lastBetweenIsOnCurve = betweenPoints.at(-1).smooth;
 
-  if (numOnCurvePoints === 2 && firstBetweenIsOnCurve && lastBetweenIsOnCurve) {
+  // If the first/last in-between point is either an on-curve that coincides with
+  // the first/last point, or it is a smooth on-curve point, then we can delete it
+  // without refitting the curve
+  const canDeleteFirstBetween =
+    !betweenPoints[0].type &&
+    (betweenPoints[0].smooth || pointsEqual(points[0], betweenPoints[0]));
+  const canDeleteLastBetween =
+    !betweenPoints.at(-1).type &&
+    (betweenPoints.at(-1).smooth || pointsEqual(points.at(-1), betweenPoints.at(-1)));
+
+  if (numOnCurvePoints === 2 && canDeleteFirstBetween && canDeleteLastBetween) {
     return betweenPoints.slice(1, -1);
   } else if (numOnCurvePoints === 1) {
-    if (firstBetweenIsOnCurve) {
+    if (canDeleteFirstBetween) {
       return betweenPoints.slice(1);
-    } else if (lastBetweenIsOnCurve) {
+    } else if (canDeleteLastBetween) {
       return betweenPoints.slice(0, -1);
     }
   }
@@ -712,6 +720,10 @@ export function scalePoint(pinPoint, point, factor) {
     pinPoint,
     vector.mulVectorScalar(vector.subVectors(point, pinPoint), factor)
   );
+}
+
+function pointsEqual(point1, point2) {
+  return point1.x === point2.x && point1.y === point2.y;
 }
 
 export function getSelectionByContour(path, pointIndices) {


### PR DESCRIPTION
Second attempt to fix #2033.

When the selection is just a tangent point, then don't refit the curve, but only delete the tangent point itself.