### PR TITLE
Small bug fixes for text entry panel

### DIFF
--- a/src/fontra/client/core/glyph-lines.js
+++ b/src/fontra/client/core/glyph-lines.js
@@ -109,7 +109,7 @@ export function textFromGlyphLines(glyphLines) {
       if (glyphInfo.character === "/") {
         // special-case slash, since it is the glyph name indicator character,
         // and needs to be escaped
-       textLine += "//";
+        textLine += "//";
       } else if (glyphInfo.character) {
         textLine += glyphInfo.character;
       } else {

--- a/src/fontra/client/core/glyph-lines.js
+++ b/src/fontra/client/core/glyph-lines.js
@@ -106,7 +106,7 @@ export function textFromGlyphLines(glyphLines) {
     let textLine = "";
     for (let i = 0; i < glyphLine.length; i++) {
       const glyphInfo = glyphLine[i];
-      if (glyphInfo.character) {
+      if (glyphInfo.character && glyphInfo.character !== "/") {
         textLine += glyphInfo.character;
       } else {
         textLine += "/" + glyphInfo.glyphName;

--- a/src/fontra/client/core/glyph-lines.js
+++ b/src/fontra/client/core/glyph-lines.js
@@ -106,7 +106,11 @@ export function textFromGlyphLines(glyphLines) {
     let textLine = "";
     for (let i = 0; i < glyphLine.length; i++) {
       const glyphInfo = glyphLine[i];
-      if (glyphInfo.character && glyphInfo.character !== "/") {
+      if (glyphInfo.character === "/") {
+        // special-case slash, since it is the glyph name indicator character,
+        // and needs to be escaped
+       textLine += "//";
+      } else if (glyphInfo.character) {
         textLine += glyphInfo.character;
       } else {
         textLine += "/" + glyphInfo.glyphName;

--- a/src/fontra/views/editor/panel-text-entry.js
+++ b/src/fontra/views/editor/panel-text-entry.js
@@ -11,6 +11,8 @@ export default class TextEntryPanel extends Panel {
       display: flex;
       flex-direction: column;
       gap: 0.5em;
+      max-height: 100%;
+      overflow-y: auto;
     }
 
     #text-align-menu {


### PR DESCRIPTION
These two small UI bugs were really bothering me so I fixed them.
1. `/slash` -> `/` -> *nothing* (or invalid character) (triggered by modification to the glyph lines such as by `cmd+left/right`)
2. Text area too tall for browser window, bad overflow behavior

Video demonstrating the bugs:

https://github.com/user-attachments/assets/7bf27d8e-d988-4aee-ba80-2c7ae572c29c


These are very trivial fixes, since I wanted to start off by contributing something small- but there are various improvements that would be desirable for the text panel, such as the ability to toggle whether to represent certain classes of glyphs as their character or `/name`, for example this is kind of annoying when working with combining glyphs since you may type `A/acutecomb` and have it turned in to `Á`, making it not possible to hand edit e.g. which base character it's applied on top of via the text panel (you can right click -> replace glyph on canvas, but that's not at all ergonomic).