### PR TITLE
Fix tooltips in sidebars #2050

### DIFF
--- a/src/fontra/client/css/tooltip.css
+++ b/src/fontra/client/css/tooltip.css
@@ -29,6 +29,7 @@
   max-width: var(--tooltip-max-width);
   font-size: 0.9rem;
   font-weight: normal;
+  line-height: normal;
   text-align: center;
   position: absolute;
   display: block;

--- a/src/fontra/views/editor/panel-designspace-navigation.js
+++ b/src/fontra/views/editor/panel-designspace-navigation.js
@@ -210,9 +210,7 @@ export default class DesignspaceNavigationPanel extends Panel {
     ];
 
     return html.div({ class: "panel" }, [
-      html.div({ class: "panel-section panel-section--flex panel-section--noscroll" }, [
-        this.accordion,
-      ]),
+      html.div({ class: "panel-section panel-section--full-height" }, [this.accordion]),
     ]);
   }
 

--- a/src/fontra/views/editor/panel.js
+++ b/src/fontra/views/editor/panel.js
@@ -20,6 +20,9 @@ export default class Panel extends SimpleElement {
     .panel-section--noscroll {
       overflow: hidden;
     }
+    .panel-section--full-height {
+      height: 100%;
+    }
   `;
 
   constructor(editorController) {


### PR DESCRIPTION
This fixes the 2 bugs mentioned in https://github.com/googlefonts/fontra/issues/2050 

Tooltip line-height. The change in https://github.com/googlefonts/fontra/commit/ad2cb59ad4227a6bdb03df17738433128c6a4e41  was related to an issue with icons while scrolling, because of their line-height. In this case tooltip inherited the `0` line-height.

Tooltip cropping. This was was caused in a4edd57f4a7d8dc71ad495a494b4ab15ab00e2b5 