### PR TITLE
Drag to open menu

### DIFF
--- a/src/fontra/client/web-components/menu-bar.js
+++ b/src/fontra/client/web-components/menu-bar.js
@@ -46,13 +46,13 @@ export class MenuBar extends SimpleElement {
     this.render();
     window.addEventListener("blur", this.closeMenu.bind(this));
     window.addEventListener("click", this.onClick.bind(this));
+    window.addEventListener("menu-panel:key-down", this.handleKeyDown.bind(this));
     this.contentElement.addEventListener("mouseover", this.onMouseOver.bind(this));
     this.contentElement.addEventListener(
       "mouseleave",
       this.unhoverMenuItems.bind(this)
     );
     this.contentElement.addEventListener("mousedown", this.onMouseDown.bind(this));
-    this.contentElement.addEventListener("keydown", this.handleKeyDown.bind(this));
     this.showMenuWhenHover = false;
   }
 
@@ -157,11 +157,11 @@ export class MenuBar extends SimpleElement {
   }
 
   handleKeyDown(event) {
-    event.stopImmediatePropagation();
-    switch (event.key) {
+    const { key } = event.detail;
+    switch (key) {
       case "ArrowLeft":
       case "ArrowRight":
-        this.navigateMenuBar(event.key);
+        this.navigateMenuBar(key);
         break;
     }
   }

--- a/src/fontra/client/web-components/menu-bar.js
+++ b/src/fontra/client/web-components/menu-bar.js
@@ -44,24 +44,29 @@ export class MenuBar extends SimpleElement {
     this.contentElement = this.shadowRoot.appendChild(html.div());
     this.contentElement.classList.add("menu-bar");
     this.render();
-    window.addEventListener("mousedown", this.onBlur.bind(this));
-    window.addEventListener("blur", this.onBlur.bind(this));
-    this.contentElement.addEventListener("mouseover", this.onMouseover.bind(this));
+    window.addEventListener("blur", this.closeMenu.bind(this));
+    window.addEventListener("click", this.onClick.bind(this));
+    this.contentElement.addEventListener("mouseover", this.onMouseOver.bind(this));
     this.contentElement.addEventListener(
       "mouseleave",
       this.unhoverMenuItems.bind(this)
     );
-    this.contentElement.addEventListener("click", this.onClick.bind(this));
+    this.contentElement.addEventListener("mousedown", this.onMouseDown.bind(this));
     this.contentElement.addEventListener("keydown", this.handleKeyDown.bind(this));
     this.showMenuWhenHover = false;
   }
 
   onClick(event) {
+    if (event.target !== this) {
+      this.closeMenu();
+    }
+  }
+
+  onMouseDown(event) {
     if (event.target.classList.contains("menu-item")) {
       const currentSelection = this.contentElement.querySelector(".current");
       if (currentSelection === event.target) {
-        this.clearCurrentSelection();
-        this.showMenuWhenHover = false;
+        this.closeMenu();
       } else {
         for (let i = 0; i < this.contentElement.childElementCount; i++) {
           const node = this.contentElement.childNodes[i];
@@ -73,10 +78,12 @@ export class MenuBar extends SimpleElement {
           }
         }
       }
+    } else {
+      this.closeMenu();
     }
   }
 
-  onMouseover(event) {
+  onMouseOver(event) {
     this.hoverMenuItem(event);
 
     const currentSelection = this.contentElement.querySelector(".current");
@@ -118,12 +125,7 @@ export class MenuBar extends SimpleElement {
     }
   }
 
-  onBlur(event) {
-    this.clearCurrentSelection();
-    this.showMenuWhenHover = false;
-  }
-
-  clearCurrentSelection(event) {
+  clearCurrentSelection() {
     const currentSelection = this.contentElement.querySelector(".current");
     if (currentSelection) {
       currentSelection.classList.remove("current");
@@ -143,16 +145,15 @@ export class MenuBar extends SimpleElement {
     };
     const menuPanel = new MenuPanel(items, {
       position,
-      onSelect: () => {
-        this.showMenuWhenHover = false;
-        this.clearCurrentSelection();
-      },
-      onClose: () => {
-        this.showMenuWhenHover = false;
-        this.clearCurrentSelection();
-      },
+      onSelect: () => this.closeMenu(),
+      onClose: () => this.closeMenu(),
     });
     this.contentElement.appendChild(menuPanel);
+  }
+
+  closeMenu() {
+    this.clearCurrentSelection();
+    this.showMenuWhenHover = false;
   }
 
   handleKeyDown(event) {
@@ -193,12 +194,6 @@ export class MenuBar extends SimpleElement {
         html.div(
           {
             class: item.bold ? "menu-item menu-item-bold" : "menu-item",
-            onmousedown: (event) => {
-              const currentSelection = this.contentElement.querySelector(".current");
-              if (currentSelection === event.target) {
-                event.stopImmediatePropagation();
-              }
-            },
           },
           [item.title]
         )

--- a/src/fontra/client/web-components/menu-panel.js
+++ b/src/fontra/client/web-components/menu-panel.js
@@ -288,10 +288,20 @@ export class MenuPanel extends SimpleElement {
     }
   }
 
+  dispatchKeyDown(key) {
+    window.dispatchEvent(
+      new CustomEvent("menu-panel:key-down", {
+        bubbles: false,
+        detail: { key },
+      })
+    );
+  }
+
   handleKeyDown(event) {
     event.preventDefault();
     event.stopImmediatePropagation();
     this.searchMenuItems(event.key);
+    this.dispatchKeyDown(event.key);
     switch (event.key) {
       case "Escape":
         this.dismiss();
@@ -345,7 +355,6 @@ export class MenuPanel extends SimpleElement {
   }
 
   findSelectedItem() {
-    let selectedItem;
     for (const item of this.menuElement.children) {
       if (item.classList.contains("selected")) {
         return item;

--- a/src/fontra/client/web-components/menu-panel.js
+++ b/src/fontra/client/web-components/menu-panel.js
@@ -389,7 +389,6 @@ export class MenuPanel extends SimpleElement {
 
 customElements.define("menu-panel", MenuPanel);
 
-window.addEventListener("mousedown", (event) => MenuPanel.closeAllMenus(event));
 window.addEventListener("blur", (event) => MenuPanel.closeAllMenus(event));
 
 function getMenuContainer() {


### PR DESCRIPTION
Resolves #2049

I realized that `navigateMenuBar` did not work, because of `stopImmediatePropagation` here  https://github.com/googlefonts/fontra/compare/main...giovanniTramonto:fontra:drag-to-open-menu?expand=1#diff-b35c3a0aab4b807296ca1634d437d26deffcdb268652aabf8495b802c1ceabcaR304 
So solved this too in b7fed8c19add114b0f9acac1fa386bc89ef9a91c by custom event