### PR TITLE
Improve webpack config for HtmlBundlerPlugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -248,6 +248,9 @@ dist
 # Stores VSCode versions used for testing VSCode extensions
 .vscode-test
 
+# JetBrains IDE
+.idea
+
 # yarn v2
 .yarn/cache
 .yarn/unplugged

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
       "devDependencies": {
         "copy-webpack-plugin": "^12.0.2",
         "css-loader": "^7.1.2",
-        "html-bundler-webpack-plugin": "^4.12.2",
+        "html-bundler-webpack-plugin": "^4.18.0",
         "npm": "^11.0.0",
         "prettier-plugin-organize-imports": "^4.1.0",
         "prettier-plugin-sort-json": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "devDependencies": {
     "copy-webpack-plugin": "^12.0.2",
     "css-loader": "^7.1.2",
-    "html-bundler-webpack-plugin": "^4.12.2",
+    "html-bundler-webpack-plugin": "^4.18.0",
     "npm": "^11.0.0",
     "prettier-plugin-organize-imports": "^4.1.0",
     "prettier-plugin-sort-json": "^4.1.1",

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -22,6 +22,15 @@ module.exports = (_env, argv) => {
               "@fontra/views-fontoverview/fontoverview.html"
             ),
           },
+          js: {
+            // JS output filename, relative to `output.path` Webpack option
+            filename: "js/[name].[contenthash:8].js",
+            chunkFilename: "js/[name].chunk.js",
+          },
+          css: {
+            // CSS output filename, relative to `output.path` Webpack option
+            filename: "css/[name].[contenthash:8].css",
+          },
         }),
       ],
       production: argv.mode === "production",


### PR DESCRIPTION
Hello,

I'm the author of the [html-bundler-webpack-plugin](https://github.com/webdiscus/html-bundler-webpack-plugin).
I want to improve the Webpack configuration to save processed JS and CSS in separate folders.

Defaults Webpack places generated HTML, JS and CSS files into directory specified in the `output.path` Webpack option.
After running `npm run bundle`, the `src/fontra/client/` directory contains a mix of generated HTML, CSS, and JS files.

![image](https://github.com/user-attachments/assets/a3caa60f-66f9-46bd-b935-4f12a4b2a2fc)


This PR allows configuring the Bundler Plugin to save JS and CSS, resolved in HTML, into separate directories:
- CSS -> `src/fontra/client/css/`
- JS -> `src/fontra/client/js/`

See  [js](https://github.com/webdiscus/html-bundler-webpack-plugin?tab=readme-ov-file#option-js) and [css](https://github.com/webdiscus/html-bundler-webpack-plugin?tab=readme-ov-file#option-css) plugin options.

Hashed file names ensure that the output file name is unique, avoiding conflicts with copied files.
Now, the root web directory `src/fontra/client/` contains only generated HTML files.

![Pasted Graphic 2](https://github.com/user-attachments/assets/aecee922-feab-4de8-bbf4-9b40681806d5)

All assets will be loaded in a browser:

![Pasted Graphic 1](https://github.com/user-attachments/assets/bd7fc47b-9840-4dd7-ab2b-ad00bc702c8b)
