### PR TITLE
Background layer support for .designspace / .ufo

### DIFF
--- a/src/fontra/backends/copy.py
+++ b/src/fontra/backends/copy.py
@@ -112,10 +112,10 @@ async def copyGlyphs(
     backgroundImageIdentifiers = []
 
     while glyphNamesToCopy:
+        glyphNamesCopied.update(glyphNamesToCopy)
         if progressInterval and not (len(glyphNamesToCopy) % progressInterval):
             logger.info(f"{len(glyphNamesToCopy)} glyphs left to copy")
         glyphName = glyphNamesToCopy.pop(0)
-        glyphNamesCopied.update(glyphNamesToCopy)
         logger.debug(f"reading {glyphName}")
 
         try:

--- a/src/fontra/backends/designspace.py
+++ b/src/fontra/backends/designspace.py
@@ -817,7 +817,7 @@ class DesignspaceBackend:
             # Assume sparse source, add new layer to existing UFO
             poleDSSource = self._findDSSourceForSparseSource(location)
             ufoLayer = self._createUFOLayer(
-                glyphName, poleDSSource.layer.path, layerName, layerName
+                glyphName, poleDSSource.layer.path, layerName, sourceIdentifier
             )
         else:
             # New UFO

--- a/src/fontra/backends/designspace.py
+++ b/src/fontra/backends/designspace.py
@@ -754,7 +754,7 @@ class DesignspaceBackend:
         glyphName: str,
         source: GlyphSource,
         localDefaultLocation: dict[str, float],
-        revLayerNameMapping: dict[str, float],
+        revLayerNameMapping: dict[str, str],
     ):
         baseLocation = {}
         if source.locationBase:

--- a/test-py/data/mutatorsans/MutatorSansLightCondensed.ufo/glyphs/R_.alt.glif
+++ b/test-py/data/mutatorsans/MutatorSansLightCondensed.ufo/glyphs/R_.alt.glif
@@ -104,17 +104,6 @@
           </dict>
         </array>
       </dict>
-      <key>xyz.fontra.layer-names</key>
-      <dict>
-        <key>MutatorSansLightCondensed/foreground</key>
-        <string>&lt;default&gt;</string>
-        <key>MutatorSansLightCondensed/weight=1</key>
-        <string>weight=1</string>
-        <key>MutatorSansLightCondensed/width=1</key>
-        <string>width=1</string>
-        <key>MutatorSansLightCondensed/width=1,weight=1</key>
-        <string>width=1,weight=1</string>
-      </dict>
       <key>xyz.fontra.source-names</key>
       <dict>
         <key>LightCondensed</key>

--- a/test-py/data/mutatorsans/MutatorSansLightCondensed.ufo/glyphs/varcotest1.glif
+++ b/test-py/data/mutatorsans/MutatorSansLightCondensed.ufo/glyphs/varcotest1.glif
@@ -105,7 +105,7 @@
       </array>
       <key>xyz.fontra.layer-names</key>
       <dict>
-        <key>MutatorSansBoldCondensed/foreground</key>
+        <key>bold-condensed</key>
         <string>weight=850</string>
       </dict>
       <key>xyz.fontra.source-names</key>

--- a/test-py/data/mutatorsans/MutatorSansLightCondensed.ufo/glyphs/varcotest2.glif
+++ b/test-py/data/mutatorsans/MutatorSansLightCondensed.ufo/glyphs/varcotest2.glif
@@ -82,8 +82,12 @@
       </dict>
       <key>xyz.fontra.layer-names</key>
       <dict>
-        <key>MutatorSansBoldCondensed/weight=850,flip=100</key>
+        <key>bold-condensed^weight=850,flip=100</key>
         <string>weight=850,flip=100</string>
+        <key>light-condensed^varco_flip</key>
+        <string>varco_flip</string>
+        <key>light-condensed^varco_flop</key>
+        <string>varco_flop</string>
       </dict>
     </dict>
   </lib>

--- a/test-py/test_backends_designspace.py
+++ b/test-py/test_backends_designspace.py
@@ -596,8 +596,8 @@ async def test_writeCorrectLayers(tmpdir, testFont):
     dsPath = tmpdir / "Test.designspace"
     font = newFileSystemBackend(dsPath)
 
-    axes = await testFont.getAxes()
-    await font.putAxes(axes)
+    await font.putAxes(await testFont.getAxes())
+    await font.putSources(await testFont.getSources())
     glyphMap = await testFont.getGlyphMap()
     glyph = await testFont.getGlyph("A")
 
@@ -607,8 +607,11 @@ async def test_writeCorrectLayers(tmpdir, testFont):
     assert [
         "fontinfo.plist",
         "glyphs",
-        "glyphs.light-condensed^support",
+        "glyphs.support",
+        "glyphs.support.S_.middle",
+        "glyphs.support.crossbar",
         "layercontents.plist",
+        "lib.plist",
         "metainfo.plist",
     ] == fileNamesFromDir(tmpdir / "Test_LightCondensed.ufo")
 

--- a/test-py/test_font.py
+++ b/test-py/test_font.py
@@ -23,12 +23,12 @@ getGlyphTestData = [
             "name": "period",
             "sources": [
                 {
-                    "layerName": "MutatorSansLightCondensed/foreground",
+                    "layerName": "default",
                     "name": "default",
                 }
             ],
             "layers": {
-                "MutatorSansLightCondensed/foreground": {
+                "default": {
                     "glyph": {
                         "xAdvance": 170,
                         "path": {
@@ -38,7 +38,7 @@ getGlyphTestData = [
                         },
                     },
                 },
-                "MutatorSansLightCondensed/background": {
+                "default^background": {
                     "glyph": {
                         "xAdvance": 170,
                         "path": {
@@ -58,12 +58,12 @@ getGlyphTestData = [
             "sources": [
                 {
                     "location": {},
-                    "layerName": "MutatorSansLightCondensed/foreground",
+                    "layerName": "default",
                     "name": "default",
                 }
             ],
             "layers": {
-                "MutatorSansLightCondensed/foreground": {
+                "default": {
                     "glyph": {
                         "components": [
                             {
@@ -111,31 +111,31 @@ getGlyphTestData = [
                 {
                     "name": "LightCondensed",
                     "location": {"italic": 0, "weight": 150.0, "width": 0.0},
-                    "layerName": "MutatorSansLightCondensed/foreground",
+                    "layerName": "light-condensed",
                 },
                 {
                     "name": "BoldCondensed",
                     "location": {"italic": 0, "weight": 850.0, "width": 0.0},
-                    "layerName": "MutatorSansBoldCondensed/foreground",
+                    "layerName": "bold-condensed",
                 },
                 {
                     "name": "LightWide",
                     "location": {"italic": 0, "weight": 150.0, "width": 1000.0},
-                    "layerName": "MutatorSansLightWide/foreground",
+                    "layerName": "light-wide",
                 },
                 {
                     "name": "BoldWide",
                     "location": {"italic": 0, "weight": 850.0, "width": 1000.0},
-                    "layerName": "MutatorSansBoldWide/foreground",
+                    "layerName": "bold-wide",
                 },
                 {
                     "name": "LightCondensedItalic",
                     "location": {"italic": 1, "weight": 150.0, "width": 0.0},
-                    "layerName": "MutatorSansLightCondensedItalic/public.default",
+                    "layerName": "light-condensed-italic",
                 },
             ],
             "layers": {
-                "MutatorSansLightCondensed/foreground": {
+                "light-condensed": {
                     "glyph": {
                         "xAdvance": 170,
                         "path": {
@@ -145,7 +145,7 @@ getGlyphTestData = [
                         },
                     },
                 },
-                "MutatorSansLightCondensed/background": {
+                "light-condensed^background": {
                     "glyph": {
                         "xAdvance": 170,
                         "path": {
@@ -155,7 +155,7 @@ getGlyphTestData = [
                         },
                     },
                 },
-                "MutatorSansBoldCondensed/foreground": {
+                "bold-condensed": {
                     "glyph": {
                         "xAdvance": 250,
                         "path": {
@@ -165,7 +165,7 @@ getGlyphTestData = [
                         },
                     },
                 },
-                "MutatorSansLightWide/foreground": {
+                "light-wide": {
                     "glyph": {
                         "xAdvance": 290,
                         "path": {
@@ -175,7 +175,7 @@ getGlyphTestData = [
                         },
                     },
                 },
-                "MutatorSansBoldWide/foreground": {
+                "bold-wide": {
                     "glyph": {
                         "xAdvance": 310,
                         "path": {
@@ -185,7 +185,7 @@ getGlyphTestData = [
                         },
                     },
                 },
-                "MutatorSansLightCondensedItalic/public.default": {
+                "light-condensed-italic": {
                     "glyph": {
                         "xAdvance": 170,
                         "path": {
@@ -206,26 +206,26 @@ getGlyphTestData = [
                 {
                     "name": "LightCondensed",
                     "location": {"italic": 0, "weight": 150.0, "width": 0.0},
-                    "layerName": "MutatorSansLightCondensed/foreground",
+                    "layerName": "light-condensed",
                 },
                 {
                     "name": "BoldCondensed",
                     "location": {"italic": 0, "weight": 850.0, "width": 0.0},
-                    "layerName": "MutatorSansBoldCondensed/foreground",
+                    "layerName": "bold-condensed",
                 },
                 {
                     "name": "LightWide",
                     "location": {"italic": 0, "weight": 150.0, "width": 1000.0},
-                    "layerName": "MutatorSansLightWide/foreground",
+                    "layerName": "light-wide",
                 },
                 {
                     "name": "BoldWide",
                     "location": {"italic": 0, "weight": 850.0, "width": 1000.0},
-                    "layerName": "MutatorSansBoldWide/foreground",
+                    "layerName": "bold-wide",
                 },
             ],
             "layers": {
-                "MutatorSansLightCondensed/foreground": {
+                "light-condensed": {
                     "glyph": {
                         "components": [
                             {
@@ -262,7 +262,7 @@ getGlyphTestData = [
                         "xAdvance": 396,
                     },
                 },
-                "MutatorSansBoldCondensed/foreground": {
+                "bold-condensed": {
                     "glyph": {
                         "components": [
                             {
@@ -299,7 +299,7 @@ getGlyphTestData = [
                         "xAdvance": 740,
                     },
                 },
-                "MutatorSansLightWide/foreground": {
+                "light-wide": {
                     "glyph": {
                         "components": [
                             {
@@ -336,7 +336,7 @@ getGlyphTestData = [
                         "xAdvance": 1190,
                     },
                 },
-                "MutatorSansBoldWide/foreground": {
+                "bold-wide": {
                     "glyph": {
                         "components": [
                             {
@@ -384,7 +384,7 @@ getGlyphTestData = [
                 {
                     "name": "LightCondensed",
                     "location": {"italic": 0, "weight": 150.0, "width": 0.0},
-                    "layerName": "MutatorSansLightCondensed/foreground",
+                    "layerName": "light-condensed",
                 },
                 {
                     "name": "weight=850",
@@ -393,7 +393,7 @@ getGlyphTestData = [
                 },
             ],
             "layers": {
-                "MutatorSansLightCondensed/foreground": {
+                "light-condensed": {
                     "glyph": {
                         "components": [
                             {
@@ -510,17 +510,17 @@ getGlyphTestData = [
             ],
             "sources": [
                 {
-                    "layerName": "MutatorSansLightCondensed/foreground",
+                    "layerName": "light-condensed",
                     "location": {"italic": 0, "weight": 150.0, "width": 0.0},
                     "name": "LightCondensed",
                 },
                 {
-                    "layerName": "MutatorSansLightCondensed/varco_flip",
+                    "layerName": "varco_flip",
                     "location": {"flip": 100},
                     "name": "varco_flip",
                 },
                 {
-                    "layerName": "MutatorSansLightCondensed/varco_flop",
+                    "layerName": "varco_flop",
                     "location": {"flop": 100},
                     "name": "varco_flop",
                 },
@@ -533,7 +533,7 @@ getGlyphTestData = [
                 },
             ],
             "layers": {
-                "MutatorSansLightCondensed/foreground": {
+                "light-condensed": {
                     "glyph": {
                         "path": {
                             "contourInfo": [{"endPoint": 7, "isClosed": True}],
@@ -560,7 +560,7 @@ getGlyphTestData = [
                         "xAdvance": 500,
                     },
                 },
-                "MutatorSansLightCondensed/varco_flip": {
+                "varco_flip": {
                     "glyph": {
                         "path": {
                             "contourInfo": [{"endPoint": 7, "isClosed": True}],
@@ -587,7 +587,7 @@ getGlyphTestData = [
                         "xAdvance": 500,
                     },
                 },
-                "MutatorSansLightCondensed/varco_flop": {
+                "varco_flop": {
                     "glyph": {
                         "path": {
                             "contourInfo": [{"endPoint": 7, "isClosed": True}],

--- a/test-py/test_fonthandler.py
+++ b/test-py/test_fonthandler.py
@@ -50,7 +50,7 @@ async def test_fontHandler_basic(testFontHandler):
         glyph = await testFontHandler.getGlyph("A", connection=None)
 
     layerName, layer = firstLayerItem(glyph)
-    assert "MutatorSansLightCondensed/foreground" == layerName
+    assert "light-condensed" == layerName
     assert 32 == len(layer.glyph.path.coordinates)
     assert 20 == layer.glyph.path.coordinates[0]
 


### PR DESCRIPTION
Towards #50.

- This adapts the fonts vs ufo layer name mapping to be compatible with the new bg layer naming convention

Todo:
- [x] more testing
- [x] create new bg layer from Fontra, and get correct ufo layer name