### PR TITLE
[designspace] Fix editing sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for Fontra
 
+## 2025-03-16
+
+- Fixed several bugs in the designspace backend related to editing font sources. [Issue 2040](https://github.com/googlefonts/fontra/issues/2040) [PR 2091](https://github.com/googlefonts/fontra/pull/2091)
+
 ## 2025-03-14
 
 New features:

--- a/src/fontra/backends/designspace.py
+++ b/src/fontra/backends/designspace.py
@@ -351,15 +351,16 @@ class DesignspaceBackend:
         for source in self.dsDoc.sources:
             if self._familyName is None and source.familyName:
                 self._familyName = source.familyName
-            reader = manager.getReader(source.path)
+            ufoPath = os.path.normpath(source.path)
+            reader = manager.getReader(ufoPath)
             defaultLayerName = reader.getDefaultLayerName()
             ufoLayerName = source.layerName or defaultLayerName
 
-            sourceLayer = self.ufoLayers.findItem(path=source.path, name=ufoLayerName)
+            sourceLayer = self.ufoLayers.findItem(path=ufoPath, name=ufoLayerName)
             if sourceLayer is None:
                 sourceLayer = UFOLayer(
                     manager=manager,
-                    path=source.path,
+                    path=ufoPath,
                     name=ufoLayerName,
                     fontraLayerName=source.name,
                 )
@@ -389,7 +390,7 @@ class DesignspaceBackend:
         # Add remaining layers (background layers, variable glyph layers)
         manager = self.ufoManager
         for source in self.dsDoc.sources:
-            ufoPath = source.path
+            ufoPath = os.path.normpath(source.path)
             reader = manager.getReader(ufoPath)
             for ufoLayerName in reader.getLayerNames():
                 layer = self.ufoLayers.findItem(path=ufoPath, name=ufoLayerName)

--- a/src/fontra/backends/designspace.py
+++ b/src/fontra/backends/designspace.py
@@ -365,9 +365,8 @@ class DesignspaceBackend:
                 )
                 self.ufoLayers.append(sourceLayer)
 
-            sourceStyleName = source.styleName or sourceLayer.fileName
-            sourceName = (
-                sourceStyleName
+            sourceName = source.styleName or (
+                sourceLayer.fileName
                 if ufoLayerName == defaultLayerName
                 else source.layerName
             )

--- a/src/fontra/backends/designspace.py
+++ b/src/fontra/backends/designspace.py
@@ -383,7 +383,12 @@ class DesignspaceBackend:
                 )
             )
 
+        self._addNonSourceLayers()
+        self._updatePathsToWatch()
+
+    def _addNonSourceLayers(self) -> None:
         # Add remaining layers (background layers, variable glyph layers)
+        manager = self.ufoManager
         for source in self.dsDoc.sources:
             ufoPath = source.path
             reader = manager.getReader(ufoPath)
@@ -399,8 +404,6 @@ class DesignspaceBackend:
                             fontraLayerName=fontraLayerName,
                         )
                     )
-
-        self._updatePathsToWatch()
 
     def buildGlyphFileNameMapping(self):
         glifFileNames = {}
@@ -1042,6 +1045,7 @@ class DesignspaceBackend:
                 dsSource = replace(
                     dsSource,
                     identifier=sourceIdentifier,
+                    name=fontSource.name,
                     location=denseSourceLocation,
                 )
             else:
@@ -1086,6 +1090,7 @@ class DesignspaceBackend:
         for dsSource in newDSSources:
             newLayers.append(dsSource.layer)
         self.ufoLayers = newLayers
+        self._addNonSourceLayers()
 
         axisOrder = [axis.name for axis in self.dsDoc.axes]
         newSourceDescriptors = [

--- a/src/fontra/backends/designspace.py
+++ b/src/fontra/backends/designspace.py
@@ -1090,7 +1090,6 @@ class DesignspaceBackend:
         for dsSource in newDSSources:
             newLayers.append(dsSource.layer)
         self.ufoLayers = newLayers
-        self._addNonSourceLayers()
 
         axisOrder = [axis.name for axis in self.dsDoc.axes]
         newSourceDescriptors = [
@@ -1099,6 +1098,8 @@ class DesignspaceBackend:
         self.dsDoc.sources = sortedSourceDescriptors(
             newSourceDescriptors, self.dsDoc.sources, axisOrder
         )
+
+        self._addNonSourceLayers()
 
         self._writeDesignSpaceDocument()
 

--- a/test-py/test_backends_designspace.py
+++ b/test-py/test_backends_designspace.py
@@ -822,6 +822,21 @@ async def test_putSources_variable_glyph_bug(writableTestFont):
     assert glyph is not None
 
 
+async def test_putSources_source_name(writableTestFont):
+    fontSources = await writableTestFont.getSources()
+    for i, source in enumerate(fontSources.values()):
+        source.name = f"source{i}"
+    await writableTestFont.putSources(fontSources)
+
+    reopenedBackend = getFileSystemBackend(writableTestFont.dsDoc.path)
+    reopenedFontSources = await reopenedBackend.getSources()
+
+    assert [s.name for s in reopenedFontSources.values()] == [
+        s.name for s in fontSources.values()
+    ]
+    assert reopenedFontSources == fontSources
+
+
 expectedAxesWithMappings = Axes(
     axes=[
         FontAxis(

--- a/test-py/test_backends_designspace.py
+++ b/test-py/test_backends_designspace.py
@@ -813,6 +813,15 @@ async def test_putSources_delete_revive(writableTestFont):
     assert revivedGlyph == originalGlyph
 
 
+async def test_putSources_variable_glyph_bug(writableTestFont):
+    # https://github.com/googlefonts/fontra/issues/2040
+    fontSources = await writableTestFont.getSources()
+    await writableTestFont.putSources(fontSources)
+
+    glyph = await writableTestFont.getGlyph("varcotest2")
+    assert glyph is not None
+
+
 expectedAxesWithMappings = Axes(
     axes=[
         FontAxis(


### PR DESCRIPTION
This fixes #2040.

`putSources()` threw away ufo layer definitions for non-source layers.

This additionally fixes two bugs I found while fixing the original bug:
- fontSource.name was not written to the ds source styleName attribute
- ds source styleName attribute was not _read_ for sparse masters (non-default layerName)