### PR TITLE
Split landing.js in two: start.js (script) and landing.js (importable module)

### DIFF
--- a/src-js/projectmanager-filesystem/landing.html
+++ b/src-js/projectmanager-filesystem/landing.html
@@ -18,5 +18,5 @@
       <div class="landing-item" id="project-list" tabindex="3"></div>
     </div>
   </body>
-  <script type="module" src="@fontra/projectmanager-filesystem/landing.js"></script>
+  <script type="module" src="@fontra/projectmanager-filesystem/start.js"></script>
 </html>

--- a/src-js/projectmanager-filesystem/package.json
+++ b/src-js/projectmanager-filesystem/package.json
@@ -5,6 +5,7 @@
     "test": "echo \"No test specified for @fontra/projectmanager-filesystem\""
   },
   "exports": {
+    "./start.js": "./src/start.js",
     "./landing.js": "./src/landing.js",
     "./landing.html": "./landing.html",
     "./assets/*": "./assets/*"

--- a/src-js/projectmanager-filesystem/src/landing.js
+++ b/src-js/projectmanager-filesystem/src/landing.js
@@ -20,5 +20,3 @@ export async function startupLandingPage(authenticateFunc) {
     projectListContainer.appendChild(projectElement);
   }
 }
-
-startupLandingPage();

--- a/src-js/projectmanager-filesystem/src/start.js
+++ b/src-js/projectmanager-filesystem/src/start.js
@@ -1,0 +1,3 @@
+import { startupLandingPage } from "./landing.js";
+
+startupLandingPage();


### PR DESCRIPTION
This fixes #2094.