### PR TITLE
Remove selectedSourceIndex sceneSettings field

### DIFF
--- a/src-js/fontra-core/src/glyph-controller.js
+++ b/src-js/fontra-core/src/glyph-controller.js
@@ -456,6 +456,23 @@ export class VariableGlyphController {
     return this.getDenseSourceLocationForSource(this.sources[sourceIndex]);
   }
 
+  splitLocation(location) {
+    const glyphAxisNames = new Set(this.axes.map((axis) => axis.name));
+
+    const fontLocation = {};
+    const glyphLocation = {};
+
+    for (const [axisName, axisValue] of Object.entries(location)) {
+      if (glyphAxisNames.has(axisName)) {
+        glyphLocation[axisName] = axisValue;
+      } else {
+        fontLocation[axisName] = axisValue;
+      }
+    }
+
+    return { fontLocation, glyphLocation };
+  }
+
   getDenseSourceLocationForSource(source) {
     const fontDefaultLocation = makeDefaultLocation(this.fontAxesSourceSpace);
     const glyphDefaultLocation = makeDefaultLocation(this.axes);

--- a/src-js/views-editor/src/editor.js
+++ b/src-js/views-editor/src/editor.js
@@ -1885,7 +1885,7 @@ export class EditorController extends ViewController {
       } else {
         await this._pasteReplaceGlyph(pasteVarGlyph);
       }
-      // Force sync between location and selectedSourceIndex, as the glyph's
+      // Force even trigger for fontLocationSourceMapped, as the glyph's
       // source list may have changed
       this.sceneSettings.fontLocationSourceMapped = {
         ...this.sceneSettings.fontLocationSourceMapped,
@@ -3091,7 +3091,7 @@ export class EditorController extends ViewController {
   async externalChange(change, isLiveChange) {
     await super.externalChange(change, isLiveChange);
 
-    // Force sync between location and selectedSourceIndex, as the glyph's
+    // Force even trigger for fontLocationSourceMapped, as the glyph's
     // source list may have changed
     this.sceneSettings.fontLocationSourceMapped = {
       ...this.sceneSettings.fontLocationSourceMapped,

--- a/src-js/views-editor/src/editor.js
+++ b/src-js/views-editor/src/editor.js
@@ -2845,31 +2845,12 @@ export class EditorController extends ViewController {
     this.sceneController.selection = newSelection;
   }
 
-  async doSelectPreviousNextSource(selectPrevious) {
-    const instance = this.sceneModel.getSelectedPositionedGlyph()?.glyph;
-    if (!instance) {
-      return;
-    }
-    const varGlyphController =
-      await this.sceneModel.getSelectedVariableGlyphController();
-    const sourceIndex = this.sceneSettings.selectedSourceIndex;
-    let newSourceIndex;
-    if (sourceIndex === undefined) {
-      newSourceIndex = varGlyphController.findNearestSourceForSourceLocation({
-        ...this.sceneSettings.fontLocationSourceMapped,
-        ...this.sceneSettings.glyphLocation,
-      });
-    } else {
-      newSourceIndex = modulo(
-        sourceIndex + (selectPrevious ? -1 : 1),
-        varGlyphController.sources.length
-      );
-    }
-    this.sceneController.scrollAdjustBehavior = "pin-glyph-center";
-    this.sceneSettings.selectedSourceIndex = newSourceIndex;
+  doSelectPreviousNextSource(selectPrevious) {
+    const panel = this.getSidebarPanel("designspace-navigation");
+    panel?.doSelectPreviousNextSource(selectPrevious);
   }
 
-  async doSelectPreviousNextSourceLayer(selectPrevious) {
+  doSelectPreviousNextSourceLayer(selectPrevious) {
     const panel = this.getSidebarPanel("designspace-navigation");
     panel?.doSelectPreviousNextSourceLayer(selectPrevious);
   }

--- a/src-js/views-editor/src/editor.js
+++ b/src-js/views-editor/src/editor.js
@@ -869,18 +869,26 @@ export class EditorController extends ViewController {
         this.getSidebarPanel("designspace-navigation").addSource();
         break;
       case "goToNearestSource":
-        const glyphController =
-          await this.sceneModel.getSelectedVariableGlyphController();
-        const nearestSourceIndex = glyphController.findNearestSourceForSourceLocation(
-          {
-            ...this.sceneSettings.fontLocationSourceMapped,
-            ...this.sceneSettings.glyphLocation,
-          },
-          true
-        );
-        this.sceneSettings.selectedSourceIndex = nearestSourceIndex;
+        this.goToNearestSource();
         break;
     }
+  }
+
+  async goToNearestSource() {
+    const glyphController = await this.sceneModel.getSelectedVariableGlyphController();
+    const nearestSourceIndex = glyphController.findNearestSourceForSourceLocation(
+      {
+        ...this.sceneSettings.fontLocationSourceMapped,
+        ...this.sceneSettings.glyphLocation,
+      },
+      true
+    );
+    const location =
+      glyphController.getDenseSourceLocationForSourceIndex(nearestSourceIndex);
+    const { fontLocation, glyphLocation } = glyphController.splitLocation(location);
+    this.sceneSettingsController.model.fontLocationSourceMapped = fontLocation;
+    this.sceneSettingsController.model.glyphLocation =
+      glyphController.foldNLIAxes(glyphLocation);
   }
 
   initTools() {

--- a/src-js/views-editor/src/editor.js
+++ b/src-js/views-editor/src/editor.js
@@ -818,7 +818,8 @@ export class EditorController extends ViewController {
         ...this.sceneSettings.selectedGlyph,
         isEditing: true,
       };
-      this.sceneSettings.selectedSourceIndex = 0;
+      // Navigate to the default location, so the new glyph's default source gets selected
+      this.sceneSettings.fontLocationSourceMapped = {};
     }
   }
 

--- a/src-js/views-editor/src/panel-designspace-navigation.js
+++ b/src-js/views-editor/src/panel-designspace-navigation.js
@@ -953,27 +953,25 @@ export default class DesignspaceNavigationPanel extends Panel {
   }
 
   async doSelectPreviousNextSource(selectPrevious) {
-    const instance = this.sceneModel.getSelectedPositionedGlyph()?.glyph;
-    if (!instance) {
-      return;
-    }
-    const varGlyphController =
-      await this.sceneModel.getSelectedVariableGlyphController();
-    const sourceIndex = this.sceneSettings.selectedSourceIndex;
-    let newSourceIndex;
-    if (sourceIndex === undefined) {
-      newSourceIndex = varGlyphController.findNearestSourceForSourceLocation({
+    let itemIndex = this.sourcesList.getSelectedItemIndex();
+    if (itemIndex != undefined) {
+      const newItemIndex = modulo(
+        itemIndex + (selectPrevious ? -1 : 1),
+        this.sourcesList.items.length
+      );
+      this.sourcesList.setSelectedItemIndex(newItemIndex, true);
+    } else {
+      const varGlyphController =
+        await this.sceneModel.getSelectedVariableGlyphController();
+      const nearestSourceIndex = varGlyphController.findNearestSourceForSourceLocation({
         ...this.sceneSettings.fontLocationSourceMapped,
         ...this.sceneSettings.glyphLocation,
       });
-    } else {
-      newSourceIndex = modulo(
-        sourceIndex + (selectPrevious ? -1 : 1),
-        varGlyphController.sources.length
+      const sourceItem = this.sourcesList.items.find(
+        (item) => item.sourceIndex === nearestSourceIndex
       );
+      this.sourcesList.setSelectedItem(sourceItem, true);
     }
-    this.sceneController.scrollAdjustBehavior = "pin-glyph-center";
-    this.sceneSettings.selectedSourceIndex = newSourceIndex;
   }
 
   doSelectPreviousNextSourceLayer(selectPrevious) {

--- a/src-js/views-editor/src/panel-designspace-navigation.js
+++ b/src-js/views-editor/src/panel-designspace-navigation.js
@@ -841,15 +841,14 @@ export default class DesignspaceNavigationPanel extends Panel {
     }
 
     this.sourcesList.setItems(sourceItems, false, true);
-    this.sourceListSetSelectedSource(this.sceneSettings.selectedSourceIndex);
+
+    await this.updateSourceListSelectionFromLocation();
 
     this.glyphSourcesAccordionItem.hidden = !varGlyphController;
 
     this._updateSourceLayersList();
     this._updateRemoveSourceButtonState();
     this._updateEditingStatus();
-
-    await this.updateSourceListSelectionFromLocation(true);
   }
 
   _updateSourceItems() {

--- a/src-js/views-editor/src/panel-designspace-navigation.js
+++ b/src-js/views-editor/src/panel-designspace-navigation.js
@@ -952,6 +952,30 @@ export default class DesignspaceNavigationPanel extends Panel {
     );
   }
 
+  async doSelectPreviousNextSource(selectPrevious) {
+    const instance = this.sceneModel.getSelectedPositionedGlyph()?.glyph;
+    if (!instance) {
+      return;
+    }
+    const varGlyphController =
+      await this.sceneModel.getSelectedVariableGlyphController();
+    const sourceIndex = this.sceneSettings.selectedSourceIndex;
+    let newSourceIndex;
+    if (sourceIndex === undefined) {
+      newSourceIndex = varGlyphController.findNearestSourceForSourceLocation({
+        ...this.sceneSettings.fontLocationSourceMapped,
+        ...this.sceneSettings.glyphLocation,
+      });
+    } else {
+      newSourceIndex = modulo(
+        sourceIndex + (selectPrevious ? -1 : 1),
+        varGlyphController.sources.length
+      );
+    }
+    this.sceneController.scrollAdjustBehavior = "pin-glyph-center";
+    this.sceneSettings.selectedSourceIndex = newSourceIndex;
+  }
+
   doSelectPreviousNextSourceLayer(selectPrevious) {
     if (this.sourceLayersList.items.length < 2) {
       return;

--- a/src-js/views-editor/src/panel-designspace-navigation.js
+++ b/src-js/views-editor/src/panel-designspace-navigation.js
@@ -294,13 +294,6 @@ export default class DesignspaceNavigationPanel extends Panel {
     });
 
     this.sceneSettingsController.addKeyListener(
-      ["selectedGlyph", "selectedSourceIndex"],
-      (event) => {
-        this._updateSourceLayersList();
-      }
-    );
-
-    this.sceneSettingsController.addKeyListener(
       [
         "fontAxesUseSourceCoordinates",
         "fontAxesShowEffectiveLocation",
@@ -340,6 +333,7 @@ export default class DesignspaceNavigationPanel extends Panel {
       true
     );
 
+    // TODO: stop depending on selectedSourceIndex
     this.sceneSettingsController.addKeyListener(
       "selectedSourceIndex",
       async (event) => {
@@ -358,7 +352,7 @@ export default class DesignspaceNavigationPanel extends Panel {
           sourceListItem = undefined;
         }
 
-        this.sourcesList.setSelectedItem(sourceListItem);
+        this.sourcesList.setSelectedItem(sourceListItem, true);
 
         this._updateRemoveSourceButtonState();
         this._updateEditingStatus();
@@ -423,7 +417,9 @@ export default class DesignspaceNavigationPanel extends Panel {
       } else {
         this.sceneSettings.editLayerName = null;
       }
+      this._updateRemoveSourceButtonState();
       this._updateEditingStatus();
+      this._updateSourceLayersList();
     });
 
     this.sourcesList.addEventListener("rowDoubleClicked", (event) => {
@@ -882,7 +878,7 @@ export default class DesignspaceNavigationPanel extends Panel {
   }
 
   async _updateSourceLayersList() {
-    const sourceIndex = this.sceneModel.sceneSettings.selectedSourceIndex;
+    const sourceIndex = this.sourcesList.getSelectedItem()?.sourceIndex;
     const haveLayers =
       this.sceneModel.selectedGlyph?.isEditing && sourceIndex != undefined;
     this.glyphLayersAccordionItem.hidden = !haveLayers;

--- a/src-js/views-editor/src/panel-designspace-navigation.js
+++ b/src-js/views-editor/src/panel-designspace-navigation.js
@@ -316,17 +316,7 @@ export default class DesignspaceNavigationPanel extends Panel {
     this.sceneSettingsController.addKeyListener(
       ["fontLocationSourceMapped", "glyphLocation"],
       async (event) => {
-        const varGlyphController =
-          await this.sceneModel.getSelectedVariableGlyphController();
-        const sourceIndex = varGlyphController?.getSourceIndex({
-          ...this.sceneSettings.fontLocationSourceMapped,
-          ...this.sceneSettings.glyphLocation,
-        });
-        const sourceItem =
-          sourceIndex !== undefined
-            ? this.sourcesList.items.find((item) => item.sourceIndex === sourceIndex)
-            : undefined;
-        this.sourcesList.setSelectedItem(sourceItem, true);
+        await this.updateSourceListSelectionFromLocation(true);
 
         this.sceneSettings.editLayerName = null;
         this.updateResetAllAxesButtonState();
@@ -390,7 +380,8 @@ export default class DesignspaceNavigationPanel extends Panel {
       this.sceneController.scrollAdjustBehavior = "pin-glyph-center";
       const selectedItem = this.sourcesList.getSelectedItem();
       const sourceIndex = selectedItem?.sourceIndex;
-      this.sceneSettings.selectedSourceIndex = sourceIndex;
+      await this.sceneController.setLocationFromSourceIndex(sourceIndex);
+
       if (sourceIndex != undefined) {
         const varGlyphController =
           await this.sceneModel.getSelectedVariableGlyphController();
@@ -471,6 +462,20 @@ export default class DesignspaceNavigationPanel extends Panel {
 
     this._updateAxes();
     this._updateSources();
+  }
+
+  async updateSourceListSelectionFromLocation(shouldDispatchEvent = false) {
+    const varGlyphController =
+      await this.sceneModel.getSelectedVariableGlyphController();
+    const sourceIndex = varGlyphController?.getSourceIndex({
+      ...this.sceneSettings.fontLocationSourceMapped,
+      ...this.sceneSettings.glyphLocation,
+    });
+    const sourceItem =
+      sourceIndex !== undefined
+        ? this.sourcesList.items.find((item) => item.sourceIndex === sourceIndex)
+        : undefined;
+    this.sourcesList.setSelectedItem(sourceItem, shouldDispatchEvent);
   }
 
   _setupSourceListColumnDescriptions() {
@@ -843,6 +848,8 @@ export default class DesignspaceNavigationPanel extends Panel {
     this._updateSourceLayersList();
     this._updateRemoveSourceButtonState();
     this._updateEditingStatus();
+
+    await this.updateSourceListSelectionFromLocation(true);
   }
 
   _updateSourceItems() {

--- a/src-js/views-editor/src/panel-designspace-navigation.js
+++ b/src-js/views-editor/src/panel-designspace-navigation.js
@@ -315,7 +315,19 @@ export default class DesignspaceNavigationPanel extends Panel {
 
     this.sceneSettingsController.addKeyListener(
       ["fontLocationSourceMapped", "glyphLocation"],
-      (event) => {
+      async (event) => {
+        const varGlyphController =
+          await this.sceneModel.getSelectedVariableGlyphController();
+        const sourceIndex = varGlyphController?.getSourceIndex({
+          ...this.sceneSettings.fontLocationSourceMapped,
+          ...this.sceneSettings.glyphLocation,
+        });
+        const sourceItem =
+          sourceIndex !== undefined
+            ? this.sourcesList.items.find((item) => item.sourceIndex === sourceIndex)
+            : undefined;
+        this.sourcesList.setSelectedItem(sourceItem, true);
+
         this.sceneSettings.editLayerName = null;
         this.updateResetAllAxesButtonState();
         this.updateInterpolationContributions();
@@ -331,32 +343,6 @@ export default class DesignspaceNavigationPanel extends Panel {
         }
       },
       true
-    );
-
-    // TODO: stop depending on selectedSourceIndex
-    this.sceneSettingsController.addKeyListener(
-      "selectedSourceIndex",
-      async (event) => {
-        const varGlyphController =
-          await this.sceneModel.getSelectedVariableGlyphController();
-        let index = event.newValue;
-
-        let sourceListItem = this.sourceListGetSourceItem(index);
-
-        if (
-          varGlyphController?.sources[index]?.layerName !== sourceListItem?.layerName
-        ) {
-          // the selectedSourceIndex event may come at a time that the
-          // sourcesList hasn't been updated yet, so could be out of
-          // sync. Prevent setting it to a wrong value.
-          sourceListItem = undefined;
-        }
-
-        this.sourcesList.setSelectedItem(sourceListItem, true);
-
-        this._updateRemoveSourceButtonState();
-        this._updateEditingStatus();
-      }
     );
 
     this.sceneSettingsController.addKeyListener(

--- a/src-js/views-editor/src/panel-designspace-navigation.js
+++ b/src-js/views-editor/src/panel-designspace-navigation.js
@@ -1172,9 +1172,6 @@ export default class DesignspaceNavigationPanel extends Panel {
       }
       return translate("sidebar.designspace-navigation.dialog.add-source.title");
     });
-    // Navigate to new source
-    const selectedSourceIndex = glyph.sources.length - 1; /* the newly added source */
-    this.sceneSettings.selectedSourceIndex = selectedSourceIndex;
   }
 
   async editSourceProperties(sourceIndex) {

--- a/src-js/views-editor/src/scene-controller.js
+++ b/src-js/views-editor/src/scene-controller.js
@@ -98,7 +98,6 @@ export class SceneController {
       glyphLocation: {},
       selectedGlyph: null,
       selectedGlyphName: null,
-      selectedSourceIndex: null,
       selection: new Set(),
       hoverSelection: new Set(),
       combinedSelection: new Set(), // dynamic: selection | hoverSelection

--- a/src-js/views-editor/src/scene-controller.js
+++ b/src-js/views-editor/src/scene-controller.js
@@ -262,10 +262,8 @@ export class SceneController {
 
         const location =
           varGlyphController.getDenseSourceLocationForSourceIndex(sourceIndex);
-        const { fontLocation, glyphLocation } = splitLocation(
-          location,
-          varGlyphController.axes
-        );
+        const { fontLocation, glyphLocation } =
+          varGlyphController.splitLocation(location);
 
         this.sceneSettingsController.setItem("fontLocationSourceMapped", fontLocation, {
           senderID: locationSelectedSourceToken,
@@ -1617,23 +1615,6 @@ export function equalGlyphSelection(glyphSelectionA, glyphSelectionB) {
     glyphSelectionA?.lineIndex === glyphSelectionB?.lineIndex &&
     glyphSelectionA?.glyphIndex === glyphSelectionB?.glyphIndex
   );
-}
-
-function splitLocation(location, glyphAxes) {
-  const glyphAxisNames = new Set(glyphAxes.map((axis) => axis.name));
-
-  const fontLocation = {};
-  const glyphLocation = {};
-
-  for (const [axisName, axisValue] of Object.entries(location)) {
-    if (glyphAxisNames.has(axisName)) {
-      glyphLocation[axisName] = axisValue;
-    } else {
-      fontLocation[axisName] = axisValue;
-    }
-  }
-
-  return { fontLocation, glyphLocation };
 }
 
 export function joinContours(path, firstPointIndex, secondPointIndex) {


### PR DESCRIPTION
This is in preparation of https://github.com/googlefonts/fontra/issues/1639.

It further decouples the sources list UI from the `glyph.sources` list, allowing me to move forward to show global locations in the glyph source list UI.