### PR TITLE
Validate canvas viewBox on getting and setting; add validateRect() func

### DIFF
--- a/src-js/fontra-core/src/canvas-controller.js
+++ b/src-js/fontra-core/src/canvas-controller.js
@@ -1,4 +1,4 @@
-import { normalizeRect, rectCenter } from "./rectangle.js";
+import { normalizeRect, rectCenter, validateRect } from "./rectangle.js";
 import { consolidateCalls, withSavedState } from "./utils.js";
 
 const MIN_MAGNIFICATION = 0.005;
@@ -211,12 +211,14 @@ export class CanvasController {
     const top = this.canvas.parentElement.offsetTop;
     const bottomLeft = this.localPoint({ x: 0 + left, y: 0 + top });
     const topRight = this.localPoint({ x: width + left, y: height + top });
-    return normalizeRect({
+    const viewBox = normalizeRect({
       xMin: bottomLeft.x,
       yMin: bottomLeft.y,
       xMax: topRight.x,
       yMax: topRight.y,
     });
+    validateRect(viewBox);
+    return viewBox;
   }
 
   isActualViewBox(viewBox) {
@@ -231,6 +233,7 @@ export class CanvasController {
   }
 
   setViewBox(viewBox) {
+    validateRect(viewBox);
     this.magnification = this._getProposedViewBoxMagnification(viewBox);
     const canvasCenter = this.canvasPoint(rectCenter(viewBox));
     this.origin.x = this.canvasWidth / 2 + this.origin.x - canvasCenter.x;

--- a/src-js/fontra-core/src/canvas-controller.js
+++ b/src-js/fontra-core/src/canvas-controller.js
@@ -1,5 +1,5 @@
 import { normalizeRect, rectCenter, validateRect } from "./rectangle.js";
-import { consolidateCalls, withSavedState } from "./utils.js";
+import { assert, consolidateCalls, isNumber, withSavedState } from "./utils.js";
 
 const MIN_MAGNIFICATION = 0.005;
 const MAX_MAGNIFICATION = 200;
@@ -51,11 +51,15 @@ export class CanvasController {
   }
 
   get canvasWidth() {
-    return this.canvas.parentElement.getBoundingClientRect().width;
+    const w = this.canvas.parentElement.getBoundingClientRect().width;
+    assert(isNumber(w));
+    return w;
   }
 
   get canvasHeight() {
-    return this.canvas.parentElement.getBoundingClientRect().height;
+    const h = this.canvas.parentElement.getBoundingClientRect().height;
+    assert(isNumber(h));
+    return h;
   }
 
   get devicePixelRatio() {
@@ -79,6 +83,8 @@ export class CanvasController {
       // parent container
       const dx = this.previousOffsets["parentOffsetX"] - parentOffsetX;
       const dy = this.previousOffsets["parentOffsetY"] - parentOffsetY;
+      assert(isNumber(dx));
+      assert(isNumber(dy));
       this.origin.x += dx;
       this.origin.y += dy;
     }
@@ -113,6 +119,8 @@ export class CanvasController {
     // We try to detect whether the event comes from a "clunky" scroll wheel, one
     // that outputs rather large values for deltaY (this appears to be common on
     // Windows), so we can scale down to keep zoom speed and scroll speed in check.
+    assert(isNumber(deltaX));
+    assert(isNumber(deltaY));
     const clunkyScrollWheel =
       Math.abs(deltaY) > 50 && Math.abs(wheelDeltaY / deltaY) < 2;
     if (event.ctrlKey || event.altKey) {
@@ -150,6 +158,7 @@ export class CanvasController {
   }
 
   _doPinchMagnify(event, zoomFactor) {
+    assert(isNumber(zoomFactor));
     const center = this.localPoint({ x: event.pageX, y: event.pageY });
     const prevMagnification = this.magnification;
 
@@ -191,13 +200,18 @@ export class CanvasController {
     const y =
       -(event.y - this.canvas.parentElement.offsetTop - this.origin.y) /
       this.magnification;
-    return { x: x, y: y };
+
+    assert(isNumber(x));
+    assert(isNumber(y));
+    return { x, y };
   }
 
   canvasPoint(point) {
     const x = point.x * this.magnification + this.origin.x;
     const y = -point.y * this.magnification + this.origin.y;
-    return { x: x, y: y };
+    assert(isNumber(x));
+    assert(isNumber(y));
+    return { x, y };
   }
 
   get onePixelUnit() {
@@ -253,8 +267,11 @@ export class CanvasController {
   }
 
   _getProposedViewBoxMagnification(viewBox) {
+    validateRect(viewBox);
     const width = this.canvasWidth;
     const height = this.canvasHeight;
+    assert(isNumber(width));
+    assert(isNumber(height));
     const magnificationX = Math.abs(width / (viewBox.xMax - viewBox.xMin));
     const magnificationY = Math.abs(height / (viewBox.yMax - viewBox.yMin));
     return Math.min(magnificationX, magnificationY);

--- a/src-js/fontra-core/src/rectangle.js
+++ b/src-js/fontra-core/src/rectangle.js
@@ -196,3 +196,20 @@ export function rectRound(rect) {
     yMax: Math.round(rect.yMax),
   };
 }
+
+function isNumber(n) {
+  return typeof n === "number";
+}
+
+export function validateRect(rect) {
+  if (
+    !isNumber(rect.xMin) ||
+    !isNumber(rect.yMin) ||
+    !isNumber(rect.xMax) ||
+    !isNumber(rect.yMax)
+  ) {
+    throw new TypeError(`Not a valid rectangle: ${JSON.stringify(rect)}`);
+  } else {
+    console.log("all good", rect);
+  }
+}

--- a/src-js/fontra-core/src/rectangle.js
+++ b/src-js/fontra-core/src/rectangle.js
@@ -209,7 +209,5 @@ export function validateRect(rect) {
     !isNumber(rect.yMax)
   ) {
     throw new TypeError(`Not a valid rectangle: ${JSON.stringify(rect)}`);
-  } else {
-    console.log("all good", rect);
   }
 }

--- a/src-js/fontra-core/src/rectangle.js
+++ b/src-js/fontra-core/src/rectangle.js
@@ -198,7 +198,7 @@ export function rectRound(rect) {
 }
 
 function isNumber(n) {
-  return !isNaN(n) && typeof n === "number";
+  return !isNaN(n) && typeof n === "number" && n !== Infinity;
 }
 
 export function validateRect(rect) {

--- a/src-js/fontra-core/src/rectangle.js
+++ b/src-js/fontra-core/src/rectangle.js
@@ -198,7 +198,7 @@ export function rectRound(rect) {
 }
 
 function isNumber(n) {
-  return typeof n === "number";
+  return !isNaN(n) && typeof n === "number";
 }
 
 export function validateRect(rect) {

--- a/src-js/fontra-core/src/rectangle.js
+++ b/src-js/fontra-core/src/rectangle.js
@@ -1,3 +1,5 @@
+import { isNumber } from "./utils.js";
+
 export function pointInRect(x, y, rect) {
   if (!rect) {
     return false;
@@ -195,10 +197,6 @@ export function rectRound(rect) {
     xMax: Math.round(rect.xMax),
     yMax: Math.round(rect.yMax),
   };
-}
-
-function isNumber(n) {
-  return !isNaN(n) && typeof n === "number" && n !== Infinity;
 }
 
 export function validateRect(rect) {

--- a/src-js/fontra-core/src/utils.js
+++ b/src-js/fontra-core/src/utils.js
@@ -770,6 +770,10 @@ export function bisect_right(a, x) {
   return lo;
 }
 
+export function isNumber(n) {
+  return !isNaN(n) && typeof n === "number" && n !== Infinity && n !== -Infinity;
+}
+
 export const friendlyHttpStatus = {
   200: "OK",
   201: "Created",

--- a/src-js/fontra-core/tests/test-rectangle.js
+++ b/src-js/fontra-core/tests/test-rectangle.js
@@ -642,6 +642,7 @@ describe("rectRound", () => {
 describe("validateRect", () => {
   const testData = [
     { rect: { xMin: 0.2, yMin: 0.3, xMax: 10.1, yMax: 10.0000001 }, good: true },
+    { rect: { xMin: NaN, yMin: 0.3, xMax: 10.1, yMax: 10.0000001 }, good: false },
     { rect: { xMin: "0.2", yMin: 0.3, xMax: 10.1, yMax: 10.0000001 }, good: false },
     { rect: { xMin: null, yMin: 0.3, xMax: 10.1, yMax: 10.0000001 }, good: false },
     { rect: {}, good: false },

--- a/src-js/fontra-core/tests/test-rectangle.js
+++ b/src-js/fontra-core/tests/test-rectangle.js
@@ -21,6 +21,7 @@ import {
   sectRect,
   unionRect,
   updateRect,
+  validateRect,
 } from "@fontra/core/rectangle.js";
 import { parametrize } from "./test-support.js";
 
@@ -636,4 +637,21 @@ describe("rectRound", () => {
       expect(result).deep.equals(expectedResult);
     }
   );
+});
+
+describe("validateRect", () => {
+  const testData = [
+    { rect: { xMin: 0.2, yMin: 0.3, xMax: 10.1, yMax: 10.0000001 }, good: true },
+    { rect: { xMin: "0.2", yMin: 0.3, xMax: 10.1, yMax: 10.0000001 }, good: false },
+    { rect: { xMin: null, yMin: 0.3, xMax: 10.1, yMax: 10.0000001 }, good: false },
+    { rect: {}, good: false },
+    { rect: { xMin: 12 }, good: false },
+  ];
+  parametrize("Validate rectangle", testData, (testItem) => {
+    if (testItem.good) {
+      expect(validateRect(testItem.rect)).equals(undefined);
+    } else {
+      expect(() => validateRect(testItem.rect)).to.throw("Not a valid rectangle");
+    }
+  });
 });

--- a/src-js/fontra-core/tests/test-rectangle.js
+++ b/src-js/fontra-core/tests/test-rectangle.js
@@ -643,6 +643,7 @@ describe("validateRect", () => {
   const testData = [
     { rect: { xMin: 0.2, yMin: 0.3, xMax: 10.1, yMax: 10.0000001 }, good: true },
     { rect: { xMin: NaN, yMin: 0.3, xMax: 10.1, yMax: 10.0000001 }, good: false },
+    { rect: { xMin: Infinity, yMin: 0.3, xMax: 10.1, yMax: 10.0000001 }, good: false },
     { rect: { xMin: "0.2", yMin: 0.3, xMax: 10.1, yMax: 10.0000001 }, good: false },
     { rect: { xMin: null, yMin: 0.3, xMax: 10.1, yMax: 10.0000001 }, good: false },
     { rect: {}, good: false },

--- a/src-js/fontra-core/tests/test-utils.js
+++ b/src-js/fontra-core/tests/test-utils.js
@@ -15,6 +15,7 @@ import {
   hexToRgba,
   hyphenatedToCamelCase,
   hyphenatedToLabel,
+  isNumber,
   loadURLFragment,
   makeUPlusStringFromCodePoint,
   mapObjectValues,
@@ -742,5 +743,24 @@ describe("bisect_right", () => {
 
   parametrize("bisect_right test", testData, (testCase) => {
     expect(bisect_right(testCase.a, testCase.x)).to.equal(testCase.i);
+  });
+});
+
+describe("isNumber", () => {
+  const testData = [
+    { n: 0, isNumber: true },
+    { n: 0.5, isNumber: true },
+    { n: -100, isNumber: true },
+    { n: undefined, isNumber: false },
+    { n: NaN, isNumber: false },
+    { n: Infinity, isNumber: false },
+    { n: -Infinity, isNumber: false },
+    { n: null, isNumber: false },
+    { n: "1", isNumber: false },
+    { n: "1.5", isNumber: false },
+  ];
+
+  parametrize("isNumber test", testData, (testCase) => {
+    expect(isNumber(testCase.n)).to.equal(testCase.isNumber);
   });
 });


### PR DESCRIPTION
We're occasionally running into a big where the view box seemed to be messed up (with NaN, undefined, or other invalid numbers). This validates the view box on setting and getting, so we hopefully get a better error once this happens.

Also, do sanity checking on canvas magnification and origin values.