### PR TITLE
Adjust custom data ui width of key column

### DIFF
--- a/src-js/fontra-webcomponents/src/custom-data-list.js
+++ b/src-js/fontra-webcomponents/src/custom-data-list.js
@@ -95,12 +95,12 @@ export class CustomDataList extends SimpleElement {
       {
         key: "key",
         title: "Key", // TODO: translation
-        width: "14em",
+        width: "17.5em",
       },
       {
         key: "value",
         title: "Value", // TODO: translation
-        width: "14em",
+        width: "10em",
         editable: true,
       },
     ];


### PR DESCRIPTION
Fixes #2103

Because of `openTypeNamePreferredSubfamilyName` the width change is quite big.

Family level:
<img width="464" alt="Screenshot 2025-03-20 at 16 39 54" src="https://github.com/user-attachments/assets/b6ce1633-a7e3-462c-8931-586e326ba6a4" />

Font Source level:
<img width="611" alt="Screenshot 2025-03-20 at 16 39 45" src="https://github.com/user-attachments/assets/7f2704d0-9329-4776-b981-dbd39a93a2db" />

And the total width is now 0.5em smaller then before, because I notices a small unneeded horizontal scroll.
