### PR TITLE
[feature editor] Fix undo confusion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@babel/preset-typescript": "^7.26.0",
         "@codemirror/autocomplete": "^6.18.6",
         "@codemirror/highlight": "^0.19.8",
+        "@codemirror/history": "^0.19.2",
         "@codemirror/language": "^6.11.0",
         "babel-loader": "^9.2.1",
         "codemirror": "^6.0.1"
@@ -1441,6 +1442,39 @@
         "@lezer/common": "^0.15.0"
       }
     },
+    "node_modules/@codemirror/history": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/history/-/history-0.19.2.tgz",
+      "integrity": "sha512-unhP4t3N2smzmHoo/Yio6ueWi+il8gm9VKrvi6wlcdGH5fOfVDNkmjHQ495SiR+EdOG35+3iNebSPYww0vN7ow==",
+      "deprecated": "As of 0.20.0, this package has been merged into @codemirror/commands",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^0.19.2",
+        "@codemirror/view": "^0.19.0"
+      }
+    },
+    "node_modules/@codemirror/history/node_modules/@codemirror/state": {
+      "version": "0.19.9",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-0.19.9.tgz",
+      "integrity": "sha512-psOzDolKTZkx4CgUqhBQ8T8gBc0xN5z4gzed109aF6x7D7umpDRoimacI/O6d9UGuyl4eYuDCZmDFr2Rq7aGOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/text": "^0.19.0"
+      }
+    },
+    "node_modules/@codemirror/history/node_modules/@codemirror/view": {
+      "version": "0.19.48",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.19.48.tgz",
+      "integrity": "sha512-0eg7D2Nz4S8/caetCTz61rK0tkHI17V/d15Jy0kLOT8dTLGGNJUponDnW28h2B6bERmPlVHKh8MJIr5OCp1nGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/rangeset": "^0.19.5",
+        "@codemirror/state": "^0.19.3",
+        "@codemirror/text": "^0.19.0",
+        "style-mod": "^4.0.0",
+        "w3c-keyname": "^2.2.4"
+      }
+    },
     "node_modules/@codemirror/language": {
       "version": "6.11.0",
       "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.11.0.tgz",
@@ -1495,6 +1529,7 @@
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.2.tgz",
       "integrity": "sha512-FVqsPqtPWKVVL3dPSxy8wEF/ymIEuVzF1PK3VbUgrxXpJUSHQWWZz4JMToquRxnkw+36LTamCZG2iua2Ptq0fA==",
+      "license": "MIT",
       "dependencies": {
         "@marijn/find-cluster-break": "^1.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@babel/preset-typescript": "^7.26.0",
     "@codemirror/autocomplete": "^6.18.6",
     "@codemirror/highlight": "^0.19.8",
+    "@codemirror/history": "^0.19.2",
     "@codemirror/language": "^6.11.0",
     "babel-loader": "^9.2.1",
     "codemirror": "^6.0.1"

--- a/src-js/views-fontinfo/src/panel-opentype-feature-code.js
+++ b/src-js/views-fontinfo/src/panel-opentype-feature-code.js
@@ -106,7 +106,7 @@ export class OpenTypeFeatureCodePanel extends BaseInfoPanel {
   }
 
   getUndoRedoLabel(isRedo) {
-    return isRedo ? "Redo" : "Undo";
+    return isRedo ? "action.redo" : "action.undo";
   }
 
   canUndoRedo(isRedo) {


### PR DESCRIPTION
CodeMirror has its own undo, so we shouldn't use our undo mechanism, but we can hook up our undo/redo menus.