### PR TITLE
Prevent arrow up/down navigation in UIList to take over short cuts

### DIFF
--- a/src-js/fontra-webcomponents/src/ui-list.js
+++ b/src-js/fontra-webcomponents/src/ui-list.js
@@ -545,7 +545,13 @@ export class UIList extends UnlitElement {
       }
       return;
     }
-    if (event.key !== "ArrowUp" && event.key !== "ArrowDown") {
+    if (
+      (event.key !== "ArrowUp" && event.key !== "ArrowDown") ||
+      event.altKey ||
+      event.ctrlKey ||
+      event.metaKey ||
+      event.shiftKey
+    ) {
       return;
     }
     event.preventDefault();


### PR DESCRIPTION
Problem:
- we have command-alt-arrow up/down shortcuts to switch source layers
- when the sources list has focus, doing command-alt-arrow will just navigate the sources list, and not the source layers list as expected

Fix this by ensuring no modifier keys are pressed in the UIList arrow key handler.