### PR TITLE
Fix URL manipulation for Edit font axes button

### DIFF
--- a/src-js/views-editor/src/panel-designspace-navigation.js
+++ b/src-js/views-editor/src/panel-designspace-navigation.js
@@ -158,7 +158,7 @@ export default class DesignspaceNavigationPanel extends Panel {
             tooltip: translate("sidebar.designspace-navigation.font-axes.edit"),
             onclick: (event) => {
               const url = new URL(window.location);
-              url.pathname = url.pathname.replace("/editor/", "/fontinfo/");
+              url.pathname = url.pathname.replace("/editor.html", "/fontinfo.html");
               url.hash = "#axes-panel";
               window.open(url.toString());
             },


### PR DESCRIPTION
This fixes #2123.

(This is still some fallout of the js-split operation.)