### PR TITLE
Do 403 if we don't have access to the requested project, or if it doesn't exist

### DIFF
--- a/src/fontra/core/server.py
+++ b/src/fontra/core/server.py
@@ -243,6 +243,10 @@ class FontraServer:
             qs = quote(request.path_qs, safe="")
             raise web.HTTPFound(f"/?ref={qs}")
 
+        project = request.query.get("project")
+        if not await self.projectManager.projectAvailable(project, authToken):
+            raise web.HTTPNotFound()
+
         return await self.staticContentHandler(packageName, request)
 
     async def staticContentHandler(

--- a/src/fontra/core/server.py
+++ b/src/fontra/core/server.py
@@ -244,8 +244,10 @@ class FontraServer:
             raise web.HTTPFound(f"/?ref={qs}")
 
         project = request.query.get("project")
-        if not await self.projectManager.projectAvailable(project, authToken):
-            raise web.HTTPNotFound()
+        if not project or not await self.projectManager.projectAvailable(
+            project, authToken
+        ):
+            raise web.HTTPForbidden()
 
         return await self.staticContentHandler(packageName, request)
 


### PR DESCRIPTION
This fixes #2121.