### PR TITLE
Fix subscriptions on reconnect

### DIFF
--- a/src-js/fontra-core/src/font-controller.js
+++ b/src-js/fontra-core/src/font-controller.js
@@ -100,6 +100,10 @@ export class FontController {
     return Object.keys(this._rootObject);
   }
 
+  getRootSubscriptionPattern() {
+    return Object.fromEntries(this.getRootKeys().map((key) => [key, null]));
+  }
+
   get glyphMap() {
     return this._rootObject.glyphMap;
   }

--- a/src-js/fontra-core/src/remote.js
+++ b/src-js/fontra-core/src/remote.js
@@ -41,6 +41,7 @@ export class RemoteObject {
       messageFromServer: undefined,
       externalChange: undefined,
       reloadData: undefined,
+      reconnect: undefined,
     };
 
     const g = _genNextClientCallID();
@@ -54,6 +55,7 @@ export class RemoteObject {
         if (document.visibilityState === "visible" && this.websocket.readyState > 1) {
           // console.log("wake reconnect");
           this._connect();
+          this._trigger("reconnect");
         }
       },
       false
@@ -159,6 +161,7 @@ export class RemoteObject {
     if (this.websocket.readyState !== 1) {
       // console.log("waiting for reconnect");
       await this._connect();
+      this._trigger("reconnect");
     }
     this.websocket.send(JSON.stringify(message));
 

--- a/src-js/fontra-core/src/view-controller.js
+++ b/src-js/fontra-core/src/view-controller.js
@@ -45,6 +45,7 @@ export class ViewController {
     remoteFontEngine.on("reloadData", (reloadPattern) =>
       controller.reloadData(reloadPattern)
     );
+    remoteFontEngine.on("reconnect", () => controller.onReconnect());
 
     await controller.start();
     controller.afterStart();
@@ -141,6 +142,23 @@ export class ViewController {
   /* called by reloadData */
   async reloadGlyphs(glyphNames) {
     await this.fontController.reloadGlyphs(glyphNames);
+  }
+
+  /* this is called when a connection has been established again, after a disconnect */
+  async onReconnect() {
+    const { subscriptionPattern, liveSubscriptionPattern } =
+      this.getSubscriptionPatterns();
+    if (subscriptionPattern) {
+      await this.fontController.subscribeChanges(subscriptionPattern, false);
+    }
+    if (liveSubscriptionPattern) {
+      await this.fontController.subscribeChanges(liveSubscriptionPattern, true);
+    }
+  }
+
+  /* gets called from onReconnect(), can be overridden by subclass */
+  getSubscriptionPatterns() {
+    return {};
   }
 
   /**

--- a/src-js/views-editor/src/editor.js
+++ b/src-js/views-editor/src/editor.js
@@ -757,11 +757,11 @@ export class EditorController extends ViewController {
 
   async _start() {
     await super.start();
-    const rootSubscriptionPattern = {};
-    for (const rootKey of this.fontController.getRootKeys()) {
-      rootSubscriptionPattern[rootKey] = null;
-    }
-    await this.fontController.subscribeChanges(rootSubscriptionPattern, false);
+
+    await this.fontController.subscribeChanges(
+      this.fontController.getRootSubscriptionPattern(),
+      false
+    );
 
     const blankFont = new FontFace("AdobeBlank", `url("/fonts/AdobeBlank.woff2")`, {});
     document.fonts.add(blankFont);
@@ -780,6 +780,16 @@ export class EditorController extends ViewController {
     // Delay a tiny amount to account for a delay in the sidebars being set up,
     // which affects the available viewBox
     setTimeout(() => this.setupFromWindowLocation(), 20);
+  }
+
+  getSubscriptionPatterns() {
+    const { subscriptionPattern, liveSubscriptionPattern } =
+      this.sceneModel.getGlyphSubscriptionPatterns();
+    const rootSubscriptionPattern = this.fontController.getRootSubscriptionPattern();
+    return {
+      subscriptionPattern: { ...rootSubscriptionPattern, ...subscriptionPattern },
+      liveSubscriptionPattern,
+    };
   }
 
   async showDialogNewGlyph() {

--- a/src-js/views-editor/src/scene-model.js
+++ b/src-js/views-editor/src/scene-model.js
@@ -367,6 +367,20 @@ export class SceneModel {
     }
   }
 
+  getGlyphSubscriptionPatterns() {
+    const subscriptionPattern = {
+      glyphs: Object.fromEntries(
+        [...this.cachedGlyphNames].map((glyphName) => [glyphName, null])
+      ),
+    };
+    const liveSubscriptionPattern = {
+      glyphs: Object.fromEntries(
+        [...this.usedGlyphNames].map((glyphName) => [glyphName, null])
+      ),
+    };
+    return { subscriptionPattern, liveSubscriptionPattern };
+  }
+
   async buildScene(cancelSignal) {
     const fontController = this.fontController;
     const kerningInstance = this.sceneSettings.applyKerning

--- a/src-js/views-editor/src/scene-model.js
+++ b/src-js/views-editor/src/scene-model.js
@@ -368,17 +368,10 @@ export class SceneModel {
   }
 
   getGlyphSubscriptionPatterns() {
-    const subscriptionPattern = {
-      glyphs: Object.fromEntries(
-        [...this.cachedGlyphNames].map((glyphName) => [glyphName, null])
-      ),
+    return {
+      subscriptionPattern: makeGlyphNamesPattern(this.cachedGlyphNames),
+      liveSubscriptionPattern: makeGlyphNamesPattern(this.usedGlyphNames),
     };
-    const liveSubscriptionPattern = {
-      glyphs: Object.fromEntries(
-        [...this.usedGlyphNames].map((glyphName) => [glyphName, null])
-      ),
-    };
-    return { subscriptionPattern, liveSubscriptionPattern };
   }
 
   async buildScene(cancelSignal) {

--- a/src-js/views-fontinfo/src/fontinfo.js
+++ b/src-js/views-fontinfo/src/fontinfo.js
@@ -10,6 +10,15 @@ import { FontInfoPanel } from "./panel-font-info.js";
 import { OpenTypeFeatureCodePanel } from "./panel-opentype-feature-code.js";
 import { SourcesPanel } from "./panel-sources.js";
 
+const panelClasses = [
+  FontInfoPanel,
+  AxesPanel,
+  CrossAxisMappingPanel,
+  SourcesPanel,
+  OpenTypeFeatureCodePanel,
+  DevelopmentStatusDefinitionsPanel,
+];
+
 export class FontInfoController extends ViewController {
   static titlePattern(displayPath) {
     return `Fontra Font Info — ${decodeURI(displayPath)}`;
@@ -32,20 +41,7 @@ export class FontInfoController extends ViewController {
     this.panels = {};
     const observer = setupIntersectionObserver(panelContainer, this.panels);
 
-    const subscribePattern = {};
-
-    for (const panelClass of [
-      FontInfoPanel,
-      AxesPanel,
-      CrossAxisMappingPanel,
-      SourcesPanel,
-      OpenTypeFeatureCodePanel,
-      DevelopmentStatusDefinitionsPanel,
-    ]) {
-      panelClass.fontAttributes.forEach((fontAttr) => {
-        subscribePattern[fontAttr] = null;
-      });
-
+    for (const panelClass of panelClasses) {
       const headerElement = html.div(
         {
           class: "header",
@@ -86,9 +82,20 @@ export class FontInfoController extends ViewController {
       observer.observe(panelElement);
     }
 
-    await this.fontController.subscribeChanges(subscribePattern, false);
+    const { subscriptionPattern } = this.getSubscriptionPatterns();
+    await this.fontController.subscribeChanges(subscriptionPattern, false);
 
     window.addEventListener("keydown", (event) => this.handleKeyDown(event));
+  }
+
+  getSubscriptionPatterns() {
+    const subscriptionPattern = {};
+    for (const panelClass of panelClasses) {
+      panelClass.fontAttributes.forEach((fontAttr) => {
+        subscriptionPattern[fontAttr] = null;
+      });
+    }
+    return { subscriptionPattern };
   }
 
   handleKeyDown(event) {

--- a/src-js/views-fontoverview/src/fontoverview.js
+++ b/src-js/views-fontoverview/src/fontoverview.js
@@ -161,12 +161,8 @@ export class FontOverviewController extends ViewController {
     this.glyphOrganizer.setSearchString(this.fontOverviewSettings.searchString);
     this.glyphOrganizer.setGroupByKeys(this.fontOverviewSettings.groupByKeys);
 
-    const rootSubscriptionPattern = {};
-    for (const rootKey of this.fontController.getRootKeys()) {
-      rootSubscriptionPattern[rootKey] = null;
-    }
-    rootSubscriptionPattern["glyphs"] = null;
-    await this.fontController.subscribeChanges(rootSubscriptionPattern, false);
+    const { subscriptionPattern } = this.getSubscriptionPatterns();
+    await this.fontController.subscribeChanges(subscriptionPattern, false);
 
     const sidebarContainer = document.querySelector("#sidebar-container");
     const glyphCellViewContainer = document.querySelector("#glyph-cell-view-container");
@@ -584,6 +580,12 @@ export class FontOverviewController extends ViewController {
 
     registerActionCallbacks("action.zoom-in", () => this.zoomIn());
     registerActionCallbacks("action.zoom-out", () => this.zoomOut());
+  }
+
+  getSubscriptionPatterns() {
+    const subscriptionPattern = this.fontController.getRootSubscriptionPattern();
+    subscriptionPattern["glyphs"] = null;
+    return { subscriptionPattern };
   }
 
   canUndoRedo(isRedo) {


### PR DESCRIPTION
This fixes a long standing bug with multiple views: after disconnect/reconnect (for example after the computer went to sleep and woke up again) the views would no longer respond to external changes. This is because server dropped the FontHandler, and subscription info was lost. Solve this by resubscribing to the relevant objects once we reconnect.