### PR TITLE
Make ufomerge happy by providing an info object with a unitsPerEm attr

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ cattrs==24.1.3
 fonttools[ufo,unicode]==4.56.0
 pillow==11.2.1
 pyyaml==6.0.2
-ufomerge==1.8.2
+ufomerge==1.9.1
 watchfiles==1.0.4
 skia-pathops==0.8.0.post2

--- a/src/fontra/workflow/features.py
+++ b/src/fontra/workflow/features.py
@@ -74,8 +74,14 @@ class MinimalGlyph:
 
 
 @dataclass(kw_only=True)
+class MinimalUFOInfo:
+    unitsPerEm: int = 1000
+
+
+@dataclass(kw_only=True)
 class MinimalUFO:
     glyphMap: dict[str, list[int]] = field(default_factory=dict)
+    info: MinimalUFOInfo = field(default_factory=MinimalUFOInfo)
     features: OpenTypeFeatures = field(default_factory=OpenTypeFeatures)
     layers: dict = field(init=False, repr=False, default_factory=dict)
     groups: dict = field(init=False, repr=False, default_factory=dict)


### PR DESCRIPTION
ufomerge now can scale a UFO when merging, and for that it looks at ufo.info.unitsPerEm.

I'm not 100% we even need that functionality, since we have explicit scale tools in fontra-workflow, so for now it's fine to just hard-code that value to 1000.