### PR TITLE
Misc glyph source edit bugfixes

### DIFF
--- a/src-js/fontra-core/src/font-controller.js
+++ b/src-js/fontra-core/src/font-controller.js
@@ -431,7 +431,7 @@ export class FontController {
   }
 
   makeVariableGlyphController(glyph) {
-    return new VariableGlyphController(glyph, this.fontAxesSourceSpace, this.sources);
+    return new VariableGlyphController(glyph, this);
   }
 
   updateGlyphDependencies(glyph) {

--- a/src-js/fontra-core/src/glyph-controller.js
+++ b/src-js/fontra-core/src/glyph-controller.js
@@ -48,10 +48,9 @@ import { VarPackedPath, joinPaths } from "./var-path.js";
 export const BACKGROUND_LAYER_SEPARATOR = "^";
 
 export class VariableGlyphController {
-  constructor(glyph, fontAxesSourceSpace, fontSources) {
+  constructor(glyph, fontController) {
     this.glyph = glyph;
-    this.fontAxesSourceSpace = fontAxesSourceSpace;
-    this._fontSources = fontSources;
+    this._fontController = fontController;
     this._locationToSourceIndex = {};
     this._layerGlyphControllers = {};
     this._layerNameToSourceIndex = {};
@@ -75,6 +74,14 @@ export class VariableGlyphController {
     return this.glyph.layers;
   }
 
+  get fontAxesSourceSpace() {
+    return this._fontController.fontAxesSourceSpace;
+  }
+
+  get fontSources() {
+    return this._fontController.sources;
+  }
+
   get combinedAxes() {
     if (this._combinedAxes === undefined) {
       this._setupAxisMapping();
@@ -95,11 +102,11 @@ export class VariableGlyphController {
   }
 
   getSourceName(source) {
-    return source.name || this._fontSources[source.locationBase]?.name;
+    return source.name || this.fontSources[source.locationBase]?.name;
   }
 
   getSourceLocation(source) {
-    return { ...this._fontSources[source.locationBase]?.location, ...source.location };
+    return { ...this.fontSources[source.locationBase]?.location, ...source.location };
   }
 
   _setupAxisMapping() {
@@ -523,6 +530,9 @@ export class VariableGlyphController {
 
     if (!sourceLayerNames) {
       const source = this.sources[sourceIndex];
+      if (!source) {
+        return []; // Hmm
+      }
       this._layerNameToSourceIndex[source.layerName] = sourceIndex;
 
       const layerNamePrefix = source.layerName + BACKGROUND_LAYER_SEPARATOR;

--- a/src-js/fontra-core/src/glyph-controller.js
+++ b/src-js/fontra-core/src/glyph-controller.js
@@ -39,6 +39,7 @@ import { addItemwise } from "./var-funcs.js";
 import { StaticGlyph, copyComponent } from "./var-glyph.js";
 import {
   locationToString,
+  makeDefaultLocation,
   makeSparseLocation,
   makeSparseNormalizedLocation,
   normalizeLocation,
@@ -1183,10 +1184,6 @@ function makeEmptyComponentPlaceholderGlyph() {
   }
 
   return StaticGlyph.fromObject({ path: path });
-}
-
-function makeDefaultLocation(axes) {
-  return Object.fromEntries(axes.map((axis) => [axis.name, axis.defaultValue]));
 }
 
 function ensureGlyphCompatibility(layerGlyphs, glyphDependencies) {

--- a/src-js/fontra-core/src/var-model.js
+++ b/src-js/fontra-core/src/var-model.js
@@ -576,3 +576,7 @@ export function isLocationAtDefault(location, axes) {
   }
   return true;
 }
+
+export function makeDefaultLocation(axes) {
+  return Object.fromEntries(axes.map((axis) => [axis.name, axis.defaultValue]));
+}

--- a/src-js/views-editor/src/panel-designspace-navigation.js
+++ b/src-js/views-editor/src/panel-designspace-navigation.js
@@ -1471,9 +1471,14 @@ export default class DesignspaceNavigationPanel extends Panel {
     });
 
     nameController.addKeyListener("sourceName", (event) => {
+      const glyphLocation = filterObject(locationController.model, (name, value) =>
+        glyphAxisNames.has(name)
+      );
+      const hasGlyphLocation = !isLocationAtDefault(glyphLocation, glyph.axes);
+
       nameController.model.suggestedLayerName =
         event.newValue ||
-        nameController.model.locationBase ||
+        (hasGlyphLocation ? "" : nameController.model.locationBase) ||
         nameController.model.suggestedSourceName;
       validateInput();
     });
@@ -1499,8 +1504,19 @@ export default class DesignspaceNavigationPanel extends Panel {
         locationController.setItem(name, value, { sentByLocationBase: true });
       }
       nameController.model.sourceName = "";
-      nameController.model.suggestedSourceName = fontSource.name;
-      nameController.model.suggestedLayerName = sourceIdentifier;
+
+      const suggestedSourceName = suggestedSourceNameFromLocation(
+        makeSparseLocation(locationController.model, locationAxes)
+      );
+
+      const hasGlyphLocation = !isLocationAtDefault(glyphLocation, glyph.axes);
+
+      nameController.model.suggestedSourceName = hasGlyphLocation
+        ? suggestedSourceName
+        : fontSource.name;
+      nameController.model.suggestedLayerName = hasGlyphLocation
+        ? suggestedSourceName
+        : sourceIdentifier;
     });
 
     locationController.addListener((event) => {

--- a/src-js/views-editor/src/panel-designspace-navigation.js
+++ b/src-js/views-editor/src/panel-designspace-navigation.js
@@ -1541,11 +1541,13 @@ export default class DesignspaceNavigationPanel extends Panel {
         )
       )
     );
-    // Remove our original source location from the set, as that's obviously an
-    // allowed location.
-    sourceLocations.delete(
-      locationToString(makeSparseLocation(location, locationAxes))
-    );
+    // If we are editing an existing source, remove our original source location from the set,
+    // as that's obviously an allowed location.
+    if (layerName) {
+      sourceLocations.delete(
+        locationToString(makeSparseLocation(location, locationAxes))
+      );
+    }
 
     const fontSourceMenuItems = [
       { value: "", label: "None" },

--- a/src-js/views-editor/src/panel-designspace-navigation.js
+++ b/src-js/views-editor/src/panel-designspace-navigation.js
@@ -1443,22 +1443,30 @@ export default class DesignspaceNavigationPanel extends Panel {
       dialog.defaultButton.classList.toggle("disabled", warnings.length);
     };
 
+    const { glyphLocation } = glyphController.splitLocation(location);
+    const hasGlyphLocation = !isLocationAtDefault(glyphLocation, glyph.axes);
+    const fontSourceName = this.fontController.sources[locationBase]?.name;
+
     const locationAxes = this._sourcePropertiesLocationAxes(glyph);
     const locationController = new ObservableController({ ...location });
     const layerNames = Object.keys(glyph.layers);
+
     const suggestedSourceName =
-      this.fontController.sources[locationBase]?.name ||
-      suggestedSourceNameFromLocation(makeSparseLocation(location, locationAxes));
+      fontSourceName && !hasGlyphLocation
+        ? fontSourceName
+        : suggestedSourceNameFromLocation(makeSparseLocation(location, locationAxes));
+    const suggestedLayerName =
+      locationBase && !hasGlyphLocation
+        ? locationBase
+        : sourceName || suggestedSourceName;
 
     const nameController = new ObservableController({
       sourceName: sourceName || (locationBase ? "" : suggestedSourceName),
       layerName: (locationBase ? layerName === locationBase : layerName === sourceName)
         ? ""
         : layerName,
-      suggestedSourceName: suggestedSourceName,
-      suggestedLayerName: locationBase
-        ? locationBase
-        : sourceName || suggestedSourceName,
+      suggestedSourceName,
+      suggestedLayerName,
       locationBase: locationBase || "",
     });
 

--- a/src-js/views-editor/src/panel-designspace-navigation.js
+++ b/src-js/views-editor/src/panel-designspace-navigation.js
@@ -1487,10 +1487,6 @@ export default class DesignspaceNavigationPanel extends Panel {
       const sourceIdentifier = event.newValue;
       const fontSource = this.fontController.sources[sourceIdentifier];
       const sourceLocation = fontSource.location;
-      const fontLocation = filterObject(
-        sourceLocation,
-        (name, value) => !glyphAxisNames.has(name)
-      );
       const glyphLocation = filterObject(locationController.model, (name, value) =>
         glyphAxisNames.has(name)
       );

--- a/src-js/views-editor/src/panel-designspace-navigation.js
+++ b/src-js/views-editor/src/panel-designspace-navigation.js
@@ -1541,6 +1541,8 @@ export default class DesignspaceNavigationPanel extends Panel {
         )
       )
     );
+    // layerName === "" if we're adding a new source, and layerName !== "" if we're editing
+    // an existing source.
     // If we are editing an existing source, remove our original source location from the set,
     // as that's obviously an allowed location.
     if (layerName) {

--- a/src-js/views-editor/src/panel-designspace-navigation.js
+++ b/src-js/views-editor/src/panel-designspace-navigation.js
@@ -1508,11 +1508,12 @@ export default class DesignspaceNavigationPanel extends Panel {
     });
 
     locationController.addListener((event) => {
-      if (!event.senderInfo?.sentByLocationBase) {
+      const isGlyphAxisChange = glyphAxisNames.has(event.key);
+      if (!event.senderInfo?.sentByLocationBase && !isGlyphAxisChange) {
         nameController.model.locationBase = "";
       }
 
-      if (!nameController.model.locationBase) {
+      if (!nameController.model.locationBase || isGlyphAxisChange) {
         const suggestedSourceName = suggestedSourceNameFromLocation(
           makeSparseLocation(locationController.model, locationAxes)
         );

--- a/src-js/views-editor/src/scene-controller.js
+++ b/src-js/views-editor/src/scene-controller.js
@@ -43,6 +43,7 @@ import {
   zip,
 } from "@fontra/core/utils.js";
 import { GlyphSource, Layer } from "@fontra/core/var-glyph.js";
+import { isLocationAtDefault } from "@fontra/core/var-model.js";
 import { VarPackedPath, packContour } from "@fontra/core/var-path.js";
 import * as vector from "@fontra/core/vector.js";
 import { dialog, message } from "@fontra/web-components/modal-dialog.js";
@@ -1166,6 +1167,10 @@ export class SceneController {
   }
 
   _insertGlyphSourceIfAtFontSource(varGlyph, glyphController) {
+    if (!isLocationAtDefault(this.sceneSettings.glyphLocation, varGlyph.axes)) {
+      return undefined;
+    }
+
     const sourceIdentifier =
       this.fontController.fontSourcesInstancer.getSourceIdentifierForLocation(
         this.sceneSettings.fontLocationSourceMapped
@@ -1173,6 +1178,7 @@ export class SceneController {
     if (!sourceIdentifier) {
       return undefined;
     }
+
     const instance = glyphController.instance.copy();
     // Round coordinates and component positions
     instance.path = instance.path.roundCoordinates();


### PR DESCRIPTION
This fixes three things:
- Don't misbehave when creating a new glyph source from a font source immediately after font axis/sources were edited
- Don't misbehave when trying to edit a glyph off-source, when a glyph axis is involved
- Fix default source/layer name fields in Add Source and Edit Source Properties dialog