### PR TITLE
[designspace] make font source identifiers deterministic

### DIFF
--- a/src/fontra/backends/designspace.py
+++ b/src/fontra/backends/designspace.py
@@ -4,7 +4,6 @@ import asyncio
 import logging
 import os
 import pathlib
-import secrets
 import shutil
 import uuid
 from collections import defaultdict
@@ -2217,12 +2216,16 @@ def makeDSSourceIdentifier(
         else usedSourceNames
     )
 
-    sourceName = None
+    if originalSourceName is None:
+        originalSourceName = ""
+
+    sourceName = originalSourceName
+    counter = 0
 
     while not sourceName or sourceName in usedSourceNames:
-        sourceName = (
-            originalSourceName or ""
-        ) + f"::fontra{sourceIndex:03}-{secrets.token_hex(4)}"
+        counterString = f"#{counter}" if counter else ""
+        sourceName = originalSourceName + f"::fontra{sourceIndex:03}{counterString}"
+        counter += 1
 
     return sourceName
 

--- a/test-py/test_backends_designspace.py
+++ b/test-py/test_backends_designspace.py
@@ -1197,6 +1197,21 @@ async def test_deterministicFontSourceIdentifiers(writableTestFont):
     assert firstSources == secondSources
 
 
+async def test_uniqueFontSourceIdentifiers(writableTestFont):
+    dsDoc = writableTestFont.dsDoc
+    dsPath = dsDoc.path
+    for source in dsDoc.sources:
+        source.name = "non-unique-name"
+    dsDoc.write(dsPath)
+
+    firstBackend = getFileSystemBackend(dsPath)
+    firstSources = await firstBackend.getSources()
+    secondBackend = getFileSystemBackend(dsPath)
+    secondSources = await secondBackend.getSources()
+
+    assert firstSources == secondSources
+
+
 def fileNamesFromDir(path):
     return sorted(p.name for p in path.iterdir())
 

--- a/test-py/test_backends_designspace.py
+++ b/test-py/test_backends_designspace.py
@@ -1182,6 +1182,21 @@ async def test_sparse_master_background_layers(writableTestFont):
     assert glyph == reopenedGlyph
 
 
+async def test_deterministicFontSourceIdentifiers(writableTestFont):
+    dsDoc = writableTestFont.dsDoc
+    dsPath = dsDoc.path
+    for source in dsDoc.sources:
+        source.name = None
+    dsDoc.write(dsPath)
+
+    firstBackend = getFileSystemBackend(dsPath)
+    firstSources = await firstBackend.getSources()
+    secondBackend = getFileSystemBackend(dsPath)
+    secondSources = await secondBackend.getSources()
+
+    assert firstSources == secondSources
+
+
 def fileNamesFromDir(path):
     return sorted(p.name for p in path.iterdir())
 

--- a/test-py/test_backends_designspace.py
+++ b/test-py/test_backends_designspace.py
@@ -1204,12 +1204,9 @@ async def test_uniqueFontSourceIdentifiers(writableTestFont):
         source.name = "non-unique-name"
     dsDoc.write(dsPath)
 
-    firstBackend = getFileSystemBackend(dsPath)
-    firstSources = await firstBackend.getSources()
-    secondBackend = getFileSystemBackend(dsPath)
-    secondSources = await secondBackend.getSources()
-
-    assert firstSources == secondSources
+    backend = getFileSystemBackend(dsPath)
+    sources = await backend.getSources()
+    assert len(sources) == len(dsDoc.sources)
 
 
 def fileNamesFromDir(path):


### PR DESCRIPTION
This fixes #2164.

This is important now that font source identifiers are also used as glyph layer identifiers, and we need the exact same identifiers if the backend gets reloaded, say after a computer sleep.