### PR TITLE
Attempt to fix Safari web worker

### DIFF
--- a/src-js/fontra-core/src/opfs.js
+++ b/src-js/fontra-core/src/opfs.js
@@ -147,8 +147,12 @@ let worker;
 
 function getWriteWorker() {
   if (!worker) {
-    const path = "/core/opfs-write-worker.js"; // + `?${Math.random()}`;
-    worker = new Worker(path);
+    worker = new Worker(
+      /* webpackChunkName: "opfs-write-worker" */ new URL(
+        "./opfs-write-worker.js",
+        import.meta.url
+      )
+    );
   }
   return worker;
 }

--- a/src-js/fontra-core/src/opfs.js
+++ b/src-js/fontra-core/src/opfs.js
@@ -168,6 +168,14 @@ async function writeFileToOPFSInWorker(path, file) {
           resolve(event.data.returnValue);
         }
       };
+      worker.onmessageerror = (event) => {
+        console.log("message error from web worker:", event);
+        reject(event.message);
+      };
+      worker.onerror = (event) => {
+        console.log("error from web worker:", event);
+        reject(event.message);
+      };
       worker.postMessage({ path, file });
     }),
     5000


### PR DESCRIPTION
Attempting to fix #2156.

- Changed creation of web worker according to https://webpack.js.org/guides/web-workers/
- Added onerror/onmessageerror handlers to worker

It is still not working:
- in Safari, go to a fontra glyph editor
- go to the reference font panel
- drop any ttf onto the font list

I get this in the console:

```
[Error] Failed to load resource: the server responded with a status of 404 (Not Found) (fontra-core.e894e05f.js, line 0)
[Error] Failed to load resource: the server responded with a status of 404 (Not Found) (fontra-core.e894e05f.js, line 0)
[Log] error from web worker: – ErrorEvent {isTrusted: true, message: "NetworkError: Load failed", filename: "http://localhost:8000/js/opfs-write-worker.chunk.js", …}
ErrorEvent {isTrusted: true, message: "NetworkError: Load failed", filename: "http://localhost:8000/js/opfs-write-worker.chunk.js", lineno: 263, colno: 28, …}ErrorEvent
[Error] NetworkError: Load failed (opfs-write-worker.chunk.js, line 263)
[Error] Unhandled Promise Rejection: NetworkError: Load failed
```
As a screen grab:
<img width="1172" alt="image" src="https://github.com/user-attachments/assets/25ab6415-1e66-4b4c-b32b-2a6d0e3d05da" />

The file `http://localhost:8000/js/opfs-write-worker.chunk.js` aka. `src/fontra/client/js/opfs-write-worker.chunk.js` exists.
However, it tries to load `http://localhost:8000/js/js/fontra-core.e894e05f.js` which does not: it has one `js/` too many in the URL. It almost sounds like a webpack bug.

The code in `src/fontra/client/js/opfs-write-worker.chunk.js` is quite incomprehensible (it's internal webpack helper code), and I can't see why it uses the wrong URL to load the chunk.

@simoncozens, any help would be greatly appreciated.