### PR TITLE
[kerning] Edit kern group info

### DIFF
--- a/src-js/fontra-core/assets/lang/de.js
+++ b/src-js/fontra-core/assets/lang/de.js
@@ -380,6 +380,7 @@ export const strings = {
     "Glyph ist schreibgeschützt",
   "sidebar.selection-info.glyph-locking.tooltip.unlock": "Glyph entsperren",
   "sidebar.selection-info.glyph-name": "Glyph-Name",
+  "sidebar.selection-info.kern-group-l-r": "Kern group L/R",
   "sidebar.selection-info.multi-source": "Multi-Source-Werteänderungen sind absolut",
   "sidebar.selection-info.sidebearings": "Glyph-Rand",
   "sidebar.selection-info.title": "Glyph-Info",

--- a/src-js/fontra-core/assets/lang/en.js
+++ b/src-js/fontra-core/assets/lang/en.js
@@ -368,6 +368,7 @@ export const strings = {
   "sidebar.selection-info.glyph-locking.tooltip.read-only": "Glyph is read-only",
   "sidebar.selection-info.glyph-locking.tooltip.unlock": "Unlock glyph",
   "sidebar.selection-info.glyph-name": "Glyph name",
+  "sidebar.selection-info.kern-group-l-r": "Kern group L/R",
   "sidebar.selection-info.multi-source": "Multi-source value changes are absolute",
   "sidebar.selection-info.sidebearings": "Sidebearings",
   "sidebar.selection-info.title": "Glyph info",

--- a/src-js/fontra-core/assets/lang/fr.js
+++ b/src-js/fontra-core/assets/lang/fr.js
@@ -383,6 +383,7 @@ export const strings = {
     "Le glyph est en lecture seule",
   "sidebar.selection-info.glyph-locking.tooltip.unlock": "Dévérouiller le glyphe",
   "sidebar.selection-info.glyph-name": "Nom du glyphe",
+  "sidebar.selection-info.kern-group-l-r": "Kern group L/R",
   "sidebar.selection-info.multi-source":
     "Valeurs absolues pour l'édition multiple de sources",
   "sidebar.selection-info.sidebearings": "Approches",

--- a/src-js/fontra-core/assets/lang/ja.js
+++ b/src-js/fontra-core/assets/lang/ja.js
@@ -370,6 +370,7 @@ export const strings = {
   "sidebar.selection-info.glyph-locking.tooltip.read-only": "読み取り専用グリフ",
   "sidebar.selection-info.glyph-locking.tooltip.unlock": "グリフをロック解除",
   "sidebar.selection-info.glyph-name": "グリフ名",
+  "sidebar.selection-info.kern-group-l-r": "Kern group L/R",
   "sidebar.selection-info.multi-source": "複数ソースの編集において、値を絶対値に揃える",
   "sidebar.selection-info.sidebearings": "サイドベアリング",
   "sidebar.selection-info.title": "グリフ情報",

--- a/src-js/fontra-core/assets/lang/nl.js
+++ b/src-js/fontra-core/assets/lang/nl.js
@@ -372,6 +372,7 @@ export const strings = {
   "sidebar.selection-info.glyph-locking.tooltip.read-only": "Glyph is read-only",
   "sidebar.selection-info.glyph-locking.tooltip.unlock": "Unlock glyph",
   "sidebar.selection-info.glyph-name": "Glyphnaam",
+  "sidebar.selection-info.kern-group-l-r": "Kern group L/R",
   "sidebar.selection-info.multi-source":
     "Wijzigingen in multi-source waarden zijn absoluut",
   "sidebar.selection-info.sidebearings": "Marges",

--- a/src-js/fontra-core/assets/lang/zh-CN.js
+++ b/src-js/fontra-core/assets/lang/zh-CN.js
@@ -350,6 +350,7 @@ export const strings = {
   "sidebar.selection-info.glyph-locking.tooltip.read-only": "字形为只读",
   "sidebar.selection-info.glyph-locking.tooltip.unlock": "解锁字形",
   "sidebar.selection-info.glyph-name": "字形名称",
+  "sidebar.selection-info.kern-group-l-r": "Kern group L/R",
   "sidebar.selection-info.multi-source": "多源编辑参数轴值时使用绝对值",
   "sidebar.selection-info.sidebearings": "边距",
   "sidebar.selection-info.title": "字形信息",

--- a/src-js/fontra-webcomponents/src/ui-form.js
+++ b/src-js/fontra-webcomponents/src/ui-form.js
@@ -97,9 +97,11 @@ export class Form extends SimpleElement {
     }
 
     .ui-form-value.edit-number-x-y,
+    .ui-form-value.edit-text-double,
     .ui-form-value.universal-row {
       display: flex;
       gap: 0.3rem;
+      width: 100%;
     }
 
     .ui-form-icon {
@@ -243,6 +245,11 @@ export class Form extends SimpleElement {
     this._fieldGetters[fieldItem.key] = () => inputElement.value;
     this._fieldSetters[fieldItem.key] = (value) => (inputElement.value = value);
     valueElement.appendChild(inputElement);
+  }
+
+  _addEditTextDouble(valueElement, fieldItem) {
+    this._addEditText(valueElement, fieldItem.field1);
+    this._addEditText(valueElement, fieldItem.field2);
   }
 
   _addEditNumberXY(valueElement, fieldItem) {

--- a/src-js/fontra-webcomponents/src/ui-form.js
+++ b/src-js/fontra-webcomponents/src/ui-form.js
@@ -101,7 +101,6 @@ export class Form extends SimpleElement {
     .ui-form-value.universal-row {
       display: flex;
       gap: 0.3rem;
-      width: 100%;
     }
 
     .ui-form-icon {

--- a/src-js/views-editor/src/editor.js
+++ b/src-js/views-editor/src/editor.js
@@ -894,7 +894,7 @@ export class EditorController extends ViewController {
       PenTool,
       KnifeTool,
       ShapeTool,
-      // KerningTool,
+      KerningTool,
       PowerRulerTool,
       HandTool,
     ];


### PR DESCRIPTION
Towards #1501.

This implements kern group editing in the selection info sidebar.

It also activates the Kerning tool.

<img width="928" alt="image" src="https://github.com/user-attachments/assets/1132d07d-902a-4ddd-8f83-52645c09bc0a" />

<img width="639" alt="image" src="https://github.com/user-attachments/assets/05d495f2-cb56-445f-8539-e3782825997b" />
