### PR TITLE
Fix guessGlyphPlaceholderString() args: codePoints is an array of code points, not a single code point

### DIFF
--- a/src-js/views-editor/src/visualization-layer-definitions.js
+++ b/src-js/views-editor/src/visualization-layer-definitions.js
@@ -154,8 +154,9 @@ registerVisualizationLayerDefinition({
         -lineDistance * glyphNameFontSize
       );
     }
+    const codePoint = positionedGlyph.character?.codePointAt(0);
     const { glyphString, direction } = guessGlyphPlaceholderString(
-      positionedGlyph.character?.codePointAt(0),
+      codePoint ? [codePoint] : [],
       positionedGlyph.glyphName
     );
     if (glyphString) {


### PR DESCRIPTION
This fixes #2192.