### PR TITLE
Enhance OpenType feature code editor 2nd attempt

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,8 @@
         "@codemirror/highlight": "^0.19.8",
         "@codemirror/history": "^0.19.2",
         "@codemirror/language": "^6.11.2",
+        "@codemirror/legacy-modes": "^6.5.1",
+        "@lezer/highlight": "^1.2.1",
         "babel-loader": "^10.0.0",
         "codemirror": "^6.0.2"
       },
@@ -1640,6 +1642,15 @@
         "style-mod": "^4.0.0"
       }
     },
+    "node_modules/@codemirror/legacy-modes": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/legacy-modes/-/legacy-modes-6.5.1.tgz",
+      "integrity": "sha512-DJYQQ00N1/KdESpZV7jg9hafof/iBNp9h7TYo1SLMk86TWl9uDsVdho2dzd81K+v4retmK6mdC7WpuOQDytQqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0"
+      }
+    },
     "node_modules/@codemirror/lint": {
       "version": "6.8.4",
       "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.8.4.tgz",
@@ -1884,6 +1895,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.1.tgz",
       "integrity": "sha512-Z5duk4RN/3zuVO7Jq0pGLJ3qynpxUVsh7IbUbGj88+uV2ApSAn6kWg2au3iJb+0Zi7kKtqffIESgNcRXWZWmSA==",
+      "license": "MIT",
       "dependencies": {
         "@lezer/common": "^1.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
     "@codemirror/highlight": "^0.19.8",
     "@codemirror/history": "^0.19.2",
     "@codemirror/language": "^6.11.2",
+    "@codemirror/legacy-modes": "^6.5.1",
+    "@lezer/highlight": "^1.2.1",
     "babel-loader": "^10.0.0",
     "codemirror": "^6.0.2"
   }

--- a/src-js/views-fontinfo/src/panel-opentype-feature-code.js
+++ b/src-js/views-fontinfo/src/panel-opentype-feature-code.js
@@ -1,12 +1,43 @@
 import { autocompletion } from "@codemirror/autocomplete";
-import { history, redo, redoDepth, undo, undoDepth } from "@codemirror/history";
+import {
+  history,
+  indentWithTab,
+  redo,
+  redoDepth,
+  undo,
+  undoDepth,
+} from "@codemirror/commands";
+import {
+  HighlightStyle,
+  LanguageSupport,
+  StreamLanguage,
+  syntaxHighlighting,
+} from "@codemirror/language";
+import { simpleMode } from "@codemirror/legacy-modes/mode/simple-mode";
+import { EditorView, keymap } from "@codemirror/view";
 import * as html from "@fontra/core/html-utils.js";
 import { addStyleSheet } from "@fontra/core/html-utils.js";
 import { scheduleCalls } from "@fontra/core/utils.js";
-import { basicSetup, EditorView } from "codemirror";
+import { Tag } from "@lezer/highlight";
+import { basicSetup } from "codemirror";
 import { BaseInfoPanel } from "./panel-base.js";
 
 addStyleSheet(`
+:root {
+  --comment-color-light: var(--fontra-theme-marker) #676e78;
+  --comment-color-dark: #a2a2a2;
+  --keyword-color-light: var(--fontra-theme-marker) #0b57d0;
+  --keyword-color-dark: #75bfff;
+  --glyph-class-color-light: var(--fontra-theme-marker) #b90063;
+  --glyph-class-color-dark: #ff7de9;
+  --named-glyph-class-color-light: var(--fontra-theme-marker) #198639;
+  --named-glyph-class-color-dark: #86de74;
+
+  --comment-color: var(--comment-color-light, var(--comment-color-dark));
+  --keyword-color: var(--keyword-color-light, var(--keyword-color-dark));
+  --glyph-class-color: var(--glyph-class-color-light, var(--glyph-class-color-dark));
+  --named-glyph-class-color: var(--named-glyph-class-color-light, var(--named-glyph-class-color-dark));
+}
 
 #opentype-feature-code-panel.font-info-panel {
   height: 100%;
@@ -26,15 +57,77 @@ addStyleSheet(`
 
 #font-info-opentype-feature-code-text-entry-textarea {
   font-size: 1.1em;
-  overflow: scroll;
-  height: calc(100% - 2em);
+  height: calc(100% - 2.4em);
 }
 
 #font-info-opentype-feature-code-text-entry-textarea > .cm-editor {
   height: 100%;
 }
 
+#font-info-opentype-feature-code-text-entry-textarea > .cm-scroller {
+  overflow: auto;
+}
+
+#font-info-opentype-feature-code-text-entry-textarea > .cm-editor.cm-focused {
+  outline: none;
+}
+
 `);
+
+const openTypeFeatureCodeSimpleMode = simpleMode({
+  start: [
+    { regex: /#.*/, token: "comment" },
+    {
+      regex:
+        /\b(?:anchor|anchorDef|anon|anonymous|by|contourpoint|cursive|device|enum|enumerate|exclude_dflt|feature|from|ignore|IgnoreBaseGlyphs|IgnoreLigatures|IgnoreMarks|include|include_dflt|language|languagesystem|lookup|lookupflag|mark|MarkAttachmentType|markClass|nameid|NULL|parameters|pos|position|required|reversesub|RightToLeft|rsub|script|sub|substitute|subtable|table|useExtension|useMarkFilteringSet|valueRecordDef|excludeDFLT|includeDFLT)\b/,
+      token: "keyword",
+    },
+    {
+      regex: /\[\s*(?:[a-zA-Z0-9_.]+(?:\s*-\s*[a-zA-Z0-9_.]+)?\s*)*\]/,
+      token: "glyphClass",
+    },
+    { regex: /@[a-zA-Z0-9_.]+/, token: "namedGlyphClass" },
+  ],
+  languageData: {
+    commentTokens: { line: "#" },
+  },
+});
+
+openTypeFeatureCodeSimpleMode.tokenTable = {
+  comment: Tag.define(),
+  keyword: Tag.define(),
+  glyphClass: Tag.define(),
+  namedGlyphClass: Tag.define(),
+};
+
+const openTypeFeatureCodeStreamLanguage = StreamLanguage.define(
+  openTypeFeatureCodeSimpleMode
+);
+
+const openTypeFeatureCodeHighlighter = syntaxHighlighting(
+  HighlightStyle.define([
+    {
+      tag: openTypeFeatureCodeSimpleMode.tokenTable.comment,
+      color: "var(--comment-color)",
+    },
+    {
+      tag: openTypeFeatureCodeSimpleMode.tokenTable.keyword,
+      color: "var(--keyword-color)",
+    },
+    {
+      tag: openTypeFeatureCodeSimpleMode.tokenTable.glyphClass,
+      color: "var(--glyph-class-color)",
+    },
+    {
+      tag: openTypeFeatureCodeSimpleMode.tokenTable.namedGlyphClass,
+      color: "var(--named-glyph-class-color)",
+    },
+  ])
+);
+
+const openTypeFeatureLanguage = new LanguageSupport(openTypeFeatureCodeStreamLanguage, [
+  openTypeFeatureCodeHighlighter,
+]);
 
 const customTheme = EditorView.theme({
   ".cm-cursor": {
@@ -44,6 +137,34 @@ const customTheme = EditorView.theme({
     backgroundColor: "var(--ui-element-background-color)",
     color: "var(--horizontal-rule-color)",
     borderRight: "1px solid var(--horizontal-rule-color)",
+  },
+  ".cm-activeLine": {
+    backgroundColor: "#8D8D8D10",
+  },
+  ".cm-activeLineGutter": {
+    backgroundColor: "transparent",
+    color: "var(--ui-element-foreground-color)",
+  },
+  "&.cm-focused > .cm-scroller > .cm-selectionLayer .cm-selectionBackground": {
+    backgroundColor: "#D3E3FD",
+  },
+  ".cm-tooltip": {
+    backgroundColor: "var(--background-color)",
+    border: "0.5px solid gray",
+    borderRadius: "4px",
+    boxShadow: "2px 3px 10px #00000020",
+    padding: "0.5em 0",
+    fontFamily: "monospace",
+    fontSize: "1.1em",
+  },
+  ".cm-tooltip-autocomplete": {
+    "& > ul > li[aria-selected]": {
+      backgroundColor: "var(--fontra-red-color)",
+    },
+  },
+  ".cm-tooltip.cm-completionInfo": {
+    fontSize: "1em",
+    padding: "0.5em 0.8em 0.7em 0.8em",
   },
 });
 
@@ -76,6 +197,8 @@ export class OpenTypeFeatureCodePanel extends BaseInfoPanel {
     this.editorView = new EditorView({
       doc: features.text,
       extensions: [
+        openTypeFeatureLanguage,
+        keymap.of([indentWithTab]),
         basicSetup,
         customTheme,
         autocompletion({ override: [myCompletions] }),
@@ -132,10 +255,10 @@ const completions = [
     type: "keyword",
     info: `Example:
     feature case {
-        # lookups and rules
+      # lookups and rules
     } case;`,
     apply: `feature xxxx {
-    # lookups and rules
+  # lookups and rules
 } xxxx;`,
   },
   {
@@ -143,10 +266,10 @@ const completions = [
     type: "keyword",
     info: `Example:
     lookup LookupName {
-        # rules
+      # rules
     } LookupName;`,
     apply: `lookup LookupName {
-    # rules
+  # rules
 } LookupName`,
   },
   {

--- a/src-js/views-fontinfo/src/panel-opentype-feature-code.js
+++ b/src-js/views-fontinfo/src/panel-opentype-feature-code.js
@@ -54,12 +54,15 @@ addStyleSheet(`
   --keyword-color-dark: #75bfff;
   --glyph-class-color-light: var(--fontra-theme-marker) #b90063;
   --glyph-class-color-dark: #ff7de9;
+  --glyph-range-color-light: var(--fontra-theme-marker) #b95a00;
+  --glyph-range-color-dark: #ffbe7d;
   --named-glyph-class-color-light: var(--fontra-theme-marker) #198639;
   --named-glyph-class-color-dark: #86de74;
 
   --comment-color: var(--comment-color-light, var(--comment-color-dark));
   --keyword-color: var(--keyword-color-light, var(--keyword-color-dark));
   --glyph-class-color: var(--glyph-class-color-light, var(--glyph-class-color-dark));
+  --glyph-range-color: var(--glyph-range-color-light, var(--glyph-range-color-dark));
   --named-glyph-class-color: var(--named-glyph-class-color-light, var(--named-glyph-class-color-dark));
 }
 
@@ -107,8 +110,12 @@ const openTypeFeatureCodeSimpleMode = simpleMode({
       token: "keyword",
     },
     {
-      regex: /\[\s*(?:[a-zA-Z0-9_.]+(?:\s*-\s*[a-zA-Z0-9_.]+)?\s*)*\]/,
+      regex: /\[\s*\\?[a-zA-Z0-9_.]+(?:\s+\\?[a-zA-Z0-9_.]+)*\s*\]/,
       token: "glyphClass",
+    },
+    {
+      regex: /\[\s*(\\?[a-zA-Z0-9_.]+)\s*-\s*(\\?[a-zA-Z0-9_.]+)\s*\]/,
+      token: "glyphRange",
     },
     { regex: /@[a-zA-Z0-9_.]+/, token: "namedGlyphClass" },
   ],
@@ -122,6 +129,7 @@ openTypeFeatureCodeSimpleMode.tokenTable = {
   comment: Tag.define(),
   keyword: Tag.define(),
   glyphClass: Tag.define(),
+  glyphRange: Tag.define(),
   namedGlyphClass: Tag.define(),
 };
 
@@ -142,6 +150,10 @@ const openTypeFeatureCodeHighlighter = syntaxHighlighting(
     {
       tag: openTypeFeatureCodeSimpleMode.tokenTable.glyphClass,
       color: "var(--glyph-class-color)",
+    },
+    {
+      tag: openTypeFeatureCodeSimpleMode.tokenTable.glyphRange,
+      color: "var(--glyph-range-color)",
     },
     {
       tag: openTypeFeatureCodeSimpleMode.tokenTable.namedGlyphClass,


### PR DESCRIPTION
Fixes #2186 #2101  and add indent with tab support

For color coding/syntax highlighting is using CodeMirror 5-style [stream parser](https://codemirror.net/docs/ref/#language.StreamParser) which may need to be upgraded for more advanced needs. But I think it works for now.

Undo/redo and toggle comment shortcuts still use codemirror keymaps.