### PR TITLE
Make glyph search list selection respond to selected glyph changes in the editor

### DIFF
--- a/src-js/fontra-webcomponents/src/glyph-search-list.js
+++ b/src-js/fontra-webcomponents/src/glyph-search-list.js
@@ -120,6 +120,13 @@ export class GlyphSearchList extends SimpleElement {
     return this.glyphNamesList.items[this.glyphNamesList.selectedItemIndex]?.glyphName;
   }
 
+  setSelectedGlyphName(glyphName) {
+    const index = this.glyphNamesList.items.findIndex(
+      (item) => item.glyphName === glyphName
+    );
+    this.glyphNamesList.setSelectedItemIndex(index >= 0 ? index : undefined);
+  }
+
   getFilteredGlyphNames() {
     return this.glyphNamesList.items.map((item) => item.glyphName);
   }

--- a/src-js/views-editor/src/panel-glyph-search.js
+++ b/src-js/views-editor/src/panel-glyph-search.js
@@ -18,7 +18,10 @@ export default class GlyphSearchPanel extends Panel {
     super(editorController);
     this.glyphSearch = this.contentElement.querySelector("#glyph-search-list");
     this.glyphSearch.addEventListener("selectedGlyphNameChanged", (event) =>
-      this.glyphNameChangedCallback(event.detail)
+      this.glyphNameChangedCallback(event.detail, false)
+    );
+    this.glyphSearch.addEventListener("selectedGlyphNameDoubleClicked", (event) =>
+      this.glyphNameChangedCallback(event.detail, true)
     );
     this.editorController.fontController.addChangeListener({ glyphMap: null }, () => {
       this.glyphSearch.updateGlyphNamesListContent();
@@ -37,7 +40,7 @@ export default class GlyphSearchPanel extends Panel {
     );
   }
 
-  glyphNameChangedCallback(glyphName) {
+  glyphNameChangedCallback(glyphName, isDoubleClick) {
     if (!glyphName) {
       return;
     }
@@ -45,11 +48,11 @@ export default class GlyphSearchPanel extends Panel {
       this.editorController.fontController.glyphInfoFromGlyphName(glyphName);
     let selectedGlyphState = this.editorController.sceneSettings.selectedGlyph;
     const glyphLines = [...this.editorController.sceneSettings.glyphLines];
-    if (selectedGlyphState) {
+    if (selectedGlyphState && !isDoubleClick) {
       glyphLines[selectedGlyphState.lineIndex][selectedGlyphState.glyphIndex] =
         glyphInfo;
       this.editorController.sceneSettings.glyphLines = glyphLines;
-    } else {
+    } else if (!selectedGlyphState && isDoubleClick) {
       if (!glyphLines.length) {
         glyphLines.push([]);
       }

--- a/src-js/views-editor/src/panel-glyph-search.js
+++ b/src-js/views-editor/src/panel-glyph-search.js
@@ -26,6 +26,15 @@ export default class GlyphSearchPanel extends Panel {
     this.editorController.fontController.ensureInitialized.then(() => {
       this.glyphSearch.glyphMap = this.editorController.fontController.glyphMap;
     });
+
+    this.editorController.sceneSettingsController.addKeyListener(
+      "selectedGlyphName",
+      (event) => {
+        if (event.newValue !== this.glyphSearch.getSelectedGlyphName()) {
+          this.glyphSearch.setSelectedGlyphName(event.newValue);
+        }
+      }
+    );
   }
 
   glyphNameChangedCallback(glyphName) {


### PR DESCRIPTION
With this PR, the glyph search list will show the currently selected glyph in the canvas as the selected item. Prep-work for #2198.