### PR TITLE
[metrics tools] Instead of zapping the selection, keep valid selectors

### DIFF
--- a/src-js/views-editor/src/edit-tools-metrics.js
+++ b/src-js/views-editor/src/edit-tools-metrics.js
@@ -29,7 +29,10 @@ class MetricsBaseTool extends BaseTool {
 
     this.sceneSettingsController.addKeyListener("glyphLines", (event) => {
       if (event.senderInfo?.senderID !== this) {
-        this.handles.forEach((handle) => handle.remove());
+        const positionedLines = this.sceneSettings.positionedLines;
+        this.metricSelection = this.metricSelection.filter(
+          (selector) => positionedLines[selector.lineIndex]?.glyphs[selector.glyphIndex]
+        );
       }
     });
 


### PR DESCRIPTION
When the text/glyph canvas contents changes, do not reset the metrics (sidebearing/kerning) selection, but filter out the invalid ones. This is especially nice together with the `/?` placeholder feature, as it allows the user to cycle through the font (command arrow L/R) and edit sidebearings without leaving the keyboard.