### PR TITLE
[Kerning tool] Reverse alt-key behavior with kerning delete key

### DIFF
--- a/src-js/views-editor/src/edit-tools-metrics.js
+++ b/src-js/views-editor/src/edit-tools-metrics.js
@@ -1198,7 +1198,7 @@ class KerningTool extends MetricsBaseTool {
   }
 
   async doDelete(event) {
-    const deepDelete = event.altKey;
+    const deepDelete = !event.altKey;
 
     const { editContext, values } = this.getEditContext(!deepDelete);
     if (!editContext) {


### PR DESCRIPTION
When selecting one or more kerning pairs, hitting the delete key should delete the selected pairs across the entire designspace.

New behavior:
- delete: "deep delete": delete the selected pairs across the entire designspace
- alt-delete: only delete the selected pairs in the currently active designspace location

(The old behavior was the opposite.)