### PR TITLE
Show a dialog when the one or more of the selected glyphs do not have a source at the current location

### DIFF
--- a/src-js/fontra-core/assets/lang/de.js
+++ b/src-js/fontra-core/assets/lang/de.js
@@ -142,6 +142,8 @@ export const strings = {
   "dialog.cant-edit-glyph.content": "Der Font ist schreibgeschützt.",
   "dialog.cant-edit-glyph.content.location-not-at-source":
     "Die Location ist nicht bei einer Source.",
+  "dialog.cant-edit-glyph.content.location-not-at-source-for-glyphs":
+    "The location is not at a source for the following glyphs: %0",
   "dialog.cant-edit-glyph.content.locked-glyph": "Der Glyph ist gesperrt.",
   "dialog.cant-edit-glyph.title": "Kann Glyphen “%0” nicht bearbeiten",
   "dialog.cant-edit-kerning.title": "Can’t edit kerning",

--- a/src-js/fontra-core/assets/lang/de.js
+++ b/src-js/fontra-core/assets/lang/de.js
@@ -145,6 +145,7 @@ export const strings = {
   "dialog.cant-edit-glyph.content.locked-glyph": "Der Glyph ist gesperrt.",
   "dialog.cant-edit-glyph.title": "Kann Glyphen “%0” nicht bearbeiten",
   "dialog.cant-edit-kerning.title": "Can’t edit kerning",
+  "dialog.cant-edit-sidebearings.title": "Can’t edit sidebearings",
   "dialog.create": "Erstellen",
   "dialog.create-new-glyph.body":
     'Klicke "Erstellen" um einen neuen Glyphen hinzuzufügen mit dem Namen "%0"%1.',

--- a/src-js/fontra-core/assets/lang/en.js
+++ b/src-js/fontra-core/assets/lang/en.js
@@ -141,6 +141,8 @@ export const strings = {
   "dialog.cant-edit-glyph.content": "The font is read-only.",
   "dialog.cant-edit-glyph.content.location-not-at-source":
     "The location is not at a source.",
+  "dialog.cant-edit-glyph.content.location-not-at-source-for-glyphs":
+    "The location is not at a source for the following glyphs: %0",
   "dialog.cant-edit-glyph.content.locked-glyph": "The glyph is locked.",
   "dialog.cant-edit-glyph.title": "Can’t edit glyph “%0”",
   "dialog.cant-edit-kerning.title": "Can’t edit kerning",

--- a/src-js/fontra-core/assets/lang/en.js
+++ b/src-js/fontra-core/assets/lang/en.js
@@ -144,6 +144,7 @@ export const strings = {
   "dialog.cant-edit-glyph.content.locked-glyph": "The glyph is locked.",
   "dialog.cant-edit-glyph.title": "Can’t edit glyph “%0”",
   "dialog.cant-edit-kerning.title": "Can’t edit kerning",
+  "dialog.cant-edit-sidebearings.title": "Can’t edit sidebearings",
   "dialog.create": "Create",
   "dialog.create-new-glyph.body":
     'Click "Create" if you want to create a new glyph named "%0"%1.',

--- a/src-js/fontra-core/assets/lang/fr.js
+++ b/src-js/fontra-core/assets/lang/fr.js
@@ -143,6 +143,7 @@ export const strings = {
   "dialog.cant-edit-glyph.content.locked-glyph": "Le glyphe est vérouillé",
   "dialog.cant-edit-glyph.title": "Ne peut pas éditer le glyphe «%0»",
   "dialog.cant-edit-kerning.title": "Can’t edit kerning",
+  "dialog.cant-edit-sidebearings.title": "Can’t edit sidebearings",
   "dialog.create": "Créer",
   "dialog.create-new-glyph.body":
     'Cliquez «Créer» si vous voulez créer un nouveau glyphe nommé  "%0"%1.',

--- a/src-js/fontra-core/assets/lang/fr.js
+++ b/src-js/fontra-core/assets/lang/fr.js
@@ -140,6 +140,8 @@ export const strings = {
   "dialog.cant-edit-glyph.content": "La fonte est en lecture seule",
   "dialog.cant-edit-glyph.content.location-not-at-source":
     "La localisation n'est pas sur une source",
+  "dialog.cant-edit-glyph.content.location-not-at-source-for-glyphs":
+    "The location is not at a source for the following glyphs: %0",
   "dialog.cant-edit-glyph.content.locked-glyph": "Le glyphe est vérouillé",
   "dialog.cant-edit-glyph.title": "Ne peut pas éditer le glyphe «%0»",
   "dialog.cant-edit-kerning.title": "Can’t edit kerning",

--- a/src-js/fontra-core/assets/lang/ja.js
+++ b/src-js/fontra-core/assets/lang/ja.js
@@ -141,6 +141,8 @@ export const strings = {
   "dialog.cant-edit-glyph.content": "このフォントは読み取り専用です。",
   "dialog.cant-edit-glyph.content.location-not-at-source":
     "現在の補完軸の値はソースと異なります。",
+  "dialog.cant-edit-glyph.content.location-not-at-source-for-glyphs":
+    "The location is not at a source for the following glyphs: %0",
   "dialog.cant-edit-glyph.content.locked-glyph": "このグリフはロックされています。",
   "dialog.cant-edit-glyph.title": "グリフ“%0”を編集できませんでした。",
   "dialog.cant-edit-kerning.title": "Can’t edit kerning",

--- a/src-js/fontra-core/assets/lang/ja.js
+++ b/src-js/fontra-core/assets/lang/ja.js
@@ -144,6 +144,7 @@ export const strings = {
   "dialog.cant-edit-glyph.content.locked-glyph": "このグリフはロックされています。",
   "dialog.cant-edit-glyph.title": "グリフ“%0”を編集できませんでした。",
   "dialog.cant-edit-kerning.title": "Can’t edit kerning",
+  "dialog.cant-edit-sidebearings.title": "Can’t edit sidebearings",
   "dialog.create": "作成",
   "dialog.create-new-glyph.body":
     "グリフ名“%0”%1を作成する場合、“作成”をクリックしてください。",

--- a/src-js/fontra-core/assets/lang/nl.js
+++ b/src-js/fontra-core/assets/lang/nl.js
@@ -145,6 +145,7 @@ export const strings = {
   "dialog.cant-edit-glyph.content.locked-glyph": "The glyph is locked.",
   "dialog.cant-edit-glyph.title": "Can’t edit glyph “%0”",
   "dialog.cant-edit-kerning.title": "Can’t edit kerning",
+  "dialog.cant-edit-sidebearings.title": "Can’t edit sidebearings",
   "dialog.create": "Creëer",
   "dialog.create-new-glyph.body": 'Klik "Creëer" om een nieuwe glyph "%0" te maken%1.',
   "dialog.create-new-glyph.body.2": ' voor karakter "%0" (%1)',

--- a/src-js/fontra-core/assets/lang/nl.js
+++ b/src-js/fontra-core/assets/lang/nl.js
@@ -142,6 +142,8 @@ export const strings = {
   "dialog.cant-edit-glyph.content": "The font is read-only.",
   "dialog.cant-edit-glyph.content.location-not-at-source":
     "The location is not at a source.",
+  "dialog.cant-edit-glyph.content.location-not-at-source-for-glyphs":
+    "The location is not at a source for the following glyphs: %0",
   "dialog.cant-edit-glyph.content.locked-glyph": "The glyph is locked.",
   "dialog.cant-edit-glyph.title": "Can’t edit glyph “%0”",
   "dialog.cant-edit-kerning.title": "Can’t edit kerning",

--- a/src-js/fontra-core/assets/lang/zh-CN.js
+++ b/src-js/fontra-core/assets/lang/zh-CN.js
@@ -139,6 +139,7 @@ export const strings = {
   "dialog.cant-edit-glyph.content.locked-glyph": "该字形已被锁定。",
   "dialog.cant-edit-glyph.title": "无法编辑字形 “%0”",
   "dialog.cant-edit-kerning.title": "Can’t edit kerning",
+  "dialog.cant-edit-sidebearings.title": "Can’t edit sidebearings",
   "dialog.create": "创建",
   "dialog.create-new-glyph.body": '如果你想创建一个新的字形 "%0"%1，请点击 "创建"。',
   "dialog.create-new-glyph.body.2": '为字符 "%0" (%1)',

--- a/src-js/fontra-core/assets/lang/zh-CN.js
+++ b/src-js/fontra-core/assets/lang/zh-CN.js
@@ -136,6 +136,8 @@ export const strings = {
   "dialog.cant-create-glyph.title": "无法添加字形 “%0”",
   "dialog.cant-edit-glyph.content": "该字体为只读文件",
   "dialog.cant-edit-glyph.content.location-not-at-source": "当前位置不是一个源。",
+  "dialog.cant-edit-glyph.content.location-not-at-source-for-glyphs":
+    "The location is not at a source for the following glyphs: %0",
   "dialog.cant-edit-glyph.content.locked-glyph": "该字形已被锁定。",
   "dialog.cant-edit-glyph.title": "无法编辑字形 “%0”",
   "dialog.cant-edit-kerning.title": "Can’t edit kerning",

--- a/src-js/views-editor/src/edit-tools-metrics.js
+++ b/src-js/views-editor/src/edit-tools-metrics.js
@@ -599,8 +599,7 @@ class SidebearingTool extends MetricsBaseTool {
     }
 
     if (notAtSourceGlyphs.size) {
-      // TODO: dialog
-      console.log("some glyphs not at source location", [...notAtSourceGlyphs]);
+      this.showDialogLocationNotAtSource([...notAtSourceGlyphs].sort());
       return;
     }
 
@@ -633,6 +632,31 @@ class SidebearingTool extends MetricsBaseTool {
           metric: direction === 1 ? "left" : "right",
         };
       }
+    }
+  }
+
+  async showDialogLocationNotAtSource(glyphNames) {
+    const glyphName = this.sceneSettings.selectedGlyphName;
+    const result = await dialog(
+      translate("dialog.cant-edit-sidebearings.title"),
+      translate("dialog.cant-edit-glyph.content.location-not-at-source") +
+        "\n" +
+        glyphNames.join(", "),
+      [
+        {
+          title: translate("dialog.cancel"),
+          resultValue: "cancel",
+          isCancelButton: true,
+        },
+        {
+          title: translate("sources.button.go-to-nearest-source"),
+          resultValue: "goToNearestSource",
+          isDefaultButton: true,
+        },
+      ]
+    );
+    if (result === "goToNearestSource") {
+      this.editor.goToNearestSource();
     }
   }
 }

--- a/src-js/views-editor/src/edit-tools-metrics.js
+++ b/src-js/views-editor/src/edit-tools-metrics.js
@@ -639,9 +639,10 @@ class SidebearingTool extends MetricsBaseTool {
     const glyphName = this.sceneSettings.selectedGlyphName;
     const result = await dialog(
       translate("dialog.cant-edit-sidebearings.title"),
-      translate("dialog.cant-edit-glyph.content.location-not-at-source") +
-        "\n" +
-        glyphNames.join(", "),
+      translate(
+        "dialog.cant-edit-glyph.content.location-not-at-source-for-glyphs",
+        glyphNames.join(", ")
+      ),
       [
         {
           title: translate("dialog.cancel"),


### PR DESCRIPTION
This fixes #2217.