### PR TITLE
Add guideline between 2 points

### DIFF
--- a/src-js/fontra-core/assets/lang/en.js
+++ b/src-js/fontra-core/assets/lang/en.js
@@ -14,6 +14,7 @@ export const strings = {
   "action.add-anchor": "Add Anchor",
   "action.add-component": "Add Component",
   "action.add-guideline": "Add Guideline",
+  "action.add-guideline-between-points": "Add Guideline Between Points",
   "action.break-contour": "Break Contour",
   "action.break-contour.plural": "Break Contours",
   "action.close-contour": "Close %0 Contour",


### PR DESCRIPTION
When 2 points are selected, a new context menu item is enabled to create a guideline between them. This resolves the more important half of #2219.

Hopefully the way I'm getting the currently selected points is reasonable; I had some trouble navigating the codebase so maybe there's a better method hiding somewhere.

Besides translations, is anything else needed in order to consider this change complete?