### PR TITLE
Add the ability to zoom to a specific font size

### DIFF
--- a/src-js/fontra-webcomponents/src/ui-form.js
+++ b/src-js/fontra-webcomponents/src/ui-form.js
@@ -416,6 +416,9 @@ export class Form extends SimpleElement {
       };
     }
 
+    this._fieldGetters[fieldItem.key] = () => rangeElement.value;
+    this._fieldSetters[fieldItem.key] = (value) => (rangeElement.value = value);
+
     valueElement.appendChild(rangeElement);
   }
 

--- a/src-js/fontra-webcomponents/src/ui-form.js
+++ b/src-js/fontra-webcomponents/src/ui-form.js
@@ -389,6 +389,7 @@ export class Form extends SimpleElement {
     rangeElement.minValue = fieldItem.minValue;
     rangeElement.defaultValue = fieldItem.defaultValue;
     rangeElement.maxValue = fieldItem.maxValue;
+    rangeElement.step = fieldItem.step;
 
     {
       // Slider change closure

--- a/src-js/views-editor/src/editor.js
+++ b/src-js/views-editor/src/editor.js
@@ -21,6 +21,7 @@ import {
 } from "@fontra/core/path-functions.js";
 import {
   centeredRect,
+  pointInRect,
   rectAddMargin,
   rectCenter,
   rectFromArray,
@@ -3369,7 +3370,11 @@ export class EditorController extends ViewController {
     const desiredHeight = canvasHeight / pixel_size;
 
     const selBox = this.sceneController.getSelectionBounds();
-    const center = rectCenter(selBox || viewBox);
+    let center = rectCenter(selBox || viewBox);
+    // avoid going completely off-screen when zoomed in very close
+    if (currentHeight < 1.0 || !pointInRect(center.x, center.y, viewBox)) {
+      center = rectCenter(viewBox);
+    }
     viewBox = rectScaleAroundCenter(viewBox, desiredHeight / currentHeight, center);
     if (animate) {
       this.animateToViewBox(viewBox);

--- a/src-js/views-editor/src/editor.js
+++ b/src-js/views-editor/src/editor.js
@@ -3351,6 +3351,7 @@ export class EditorController extends ViewController {
   }
 
   zoomToFontSize(size, animate = true) {
+    // TODO: does this function need modifications to work with vertical layout?
     let viewBox = this.sceneSettings.viewBox;
     const upm = this.fontController.unitsPerEm;
     const canvasHeight = this.canvasController.canvasHeight;
@@ -3359,7 +3360,8 @@ export class EditorController extends ViewController {
     const currentHeight = (viewBox.yMax - viewBox.yMin) / upm;
     const desiredHeight = canvasHeight / pixel_size;
 
-    const center = rectCenter(viewBox);
+    const selBox = this.sceneController.getSelectionBounds();
+    const center = rectCenter(selBox || viewBox);
     viewBox = rectScaleAroundCenter(viewBox, desiredHeight / currentHeight, center);
     if (animate) {
       this.animateToViewBox(viewBox);

--- a/src-js/views-editor/src/editor.js
+++ b/src-js/views-editor/src/editor.js
@@ -148,6 +148,7 @@ export class EditorController extends ViewController {
       [
         "align",
         "applyKerning",
+        "cleanViewSizePreview",
         "editLayerName",
         "editingLayers",
         "fontLocationUser",
@@ -3068,6 +3069,11 @@ export class EditorController extends ViewController {
   }
 
   enterCleanViewAndHandTool(event) {
+    if (this.sceneSettings.cleanViewSizePreview) {
+      this.savedViewBox = this.sceneSettings.viewBox;
+      const pixels = (4 / 3) * this.sceneSettings.textSize;
+      this.zoomToFontSize(pixels, false);
+    }
     this.canvasController.sceneView = this.cleanSceneView;
     this.canvasController.requestUpdate();
     for (const overlay of document.querySelectorAll(".cleanable-overlay")) {
@@ -3089,6 +3095,15 @@ export class EditorController extends ViewController {
     }
     this.setSelectedTool(this.savedSelectedToolIdentifier);
     delete this.savedSelectedToolIdentifier;
+    if (this.savedViewBox) {
+      // wait one frame so that the canvas size has settled back to normal
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          this.sceneSettings.viewBox = this.savedViewBox;
+          delete this.savedViewBox;
+        });
+      });
+    }
   }
 
   buildContextMenuItems(event) {
@@ -3177,6 +3192,8 @@ export class EditorController extends ViewController {
     }
     this.sceneSettings.align = viewInfo["align"] || "center";
     this.sceneSettings.applyKerning = viewInfo["applyKerning"] === false ? false : true;
+    this.sceneSettings.cleanViewSizePreview =
+      viewInfo["cleanViewSizePreview"] === true ? true : false;
     if (viewInfo["viewBox"]) {
       this.sceneController.autoViewBox = false;
       const viewBox = viewInfo["viewBox"];
@@ -3310,6 +3327,9 @@ export class EditorController extends ViewController {
     if (!this.sceneSettings.applyKerning) {
       viewInfo["applyKerning"] = this.sceneSettings.applyKerning;
     }
+    if (this.sceneSettings.cleanViewSizePreview) {
+      viewInfo["cleanViewSizePreview"] = this.sceneSettings.cleanViewSizePreview;
+    }
 
     const url = new URL(window.location);
     clearSearchParams(url.searchParams); /* clear legacy URL format */
@@ -3331,17 +3351,24 @@ export class EditorController extends ViewController {
     this._zoom(Math.sqrt(2));
   }
 
-  zoomToFontSize(size) {
+  zoomToFontSize(size, animate = true) {
     // `size` is in pixels
 
-    const viewBox = this.sceneSettings.viewBox;
+    let viewBox = this.sceneSettings.viewBox;
     const upm = this.fontController.unitsPerEm;
     const canvasHeight = this.canvasController.canvasHeight;
 
     const currentHeight = (viewBox.yMax - viewBox.yMin) / upm;
     const desiredHeight = canvasHeight / size;
 
-    this._zoom(desiredHeight / currentHeight);
+    const center = rectCenter(viewBox);
+    viewBox = rectScaleAroundCenter(viewBox, desiredHeight / currentHeight, center);
+    if (animate) {
+      this.animateToViewBox(viewBox);
+    } else {
+      this.sceneSettings.viewBox = viewBox;
+    }
+    this.sceneController.autoViewBox = false;
   }
 
   _zoom(factor) {

--- a/src-js/views-editor/src/editor.js
+++ b/src-js/views-editor/src/editor.js
@@ -3331,6 +3331,19 @@ export class EditorController extends ViewController {
     this._zoom(Math.sqrt(2));
   }
 
+  zoomToFontSize(size) {
+    // `size` is in pixels
+
+    const viewBox = this.sceneSettings.viewBox;
+    const upm = this.fontController.unitsPerEm;
+    const canvasHeight = this.canvasController.canvasHeight;
+
+    const currentHeight = (viewBox.yMax - viewBox.yMin) / upm;
+    const desiredHeight = canvasHeight / size;
+
+    this._zoom(desiredHeight / currentHeight);
+  }
+
   _zoom(factor) {
     let viewBox = this.sceneSettings.viewBox;
     const selBox = this.sceneController.getSelectionBounds();

--- a/src-js/views-editor/src/editor.js
+++ b/src-js/views-editor/src/editor.js
@@ -161,6 +161,7 @@ export class EditorController extends ViewController {
         "selection",
         "substituteGlyphName",
         "text",
+        "textSize",
         "viewBox",
       ],
       (event) => {
@@ -3209,6 +3210,10 @@ export class EditorController extends ViewController {
     }
     this._previousURLText = viewInfo["text"];
 
+    if (viewInfo["textSize"]) {
+      this.sceneSettings.textSize = viewInfo["textSize"];
+    }
+
     this.sceneModel.setGlyphLocations(viewInfo["glyphLocations"]);
 
     if (viewInfo["fontAxesUseSourceCoordinates"]) {
@@ -3280,6 +3285,9 @@ export class EditorController extends ViewController {
     }
     if (this.sceneSettings.text?.length) {
       viewInfo["text"] = this.sceneSettings.text;
+    }
+    if (this.sceneSettings.textSize) {
+      viewInfo["textSize"] = this.sceneSettings.textSize;
     }
     if (this.sceneSettings.selectedGlyph) {
       viewInfo["selectedGlyph"] = this.sceneSettings.selectedGlyph;

--- a/src-js/views-editor/src/editor.js
+++ b/src-js/views-editor/src/editor.js
@@ -3071,8 +3071,7 @@ export class EditorController extends ViewController {
   enterCleanViewAndHandTool(event) {
     if (this.sceneSettings.cleanViewSizePreview) {
       this.savedViewBox = this.sceneSettings.viewBox;
-      const pixels = (4 / 3) * this.sceneSettings.textSize;
-      this.zoomToFontSize(pixels, false);
+      this.zoomToFontSize(this.sceneSettings.textSize, false);
     }
     this.canvasController.sceneView = this.cleanSceneView;
     this.canvasController.requestUpdate();
@@ -3352,14 +3351,13 @@ export class EditorController extends ViewController {
   }
 
   zoomToFontSize(size, animate = true) {
-    // `size` is in pixels
-
     let viewBox = this.sceneSettings.viewBox;
     const upm = this.fontController.unitsPerEm;
     const canvasHeight = this.canvasController.canvasHeight;
 
+    const pixel_size = (4 / 3) * size; // pt to px
     const currentHeight = (viewBox.yMax - viewBox.yMin) / upm;
-    const desiredHeight = canvasHeight / size;
+    const desiredHeight = canvasHeight / pixel_size;
 
     const center = rectCenter(viewBox);
     viewBox = rectScaleAroundCenter(viewBox, desiredHeight / currentHeight, center);

--- a/src-js/views-editor/src/panel-text-entry.js
+++ b/src-js/views-editor/src/panel-text-entry.js
@@ -174,8 +174,7 @@ export default class TextEntryPanel extends Panel {
     const buttonSet = html.createDomElement("icon-button", {
       "src": "/tabler-icons/resize.svg",
       "onclick": (event) => {
-        const pixels = (4 / 3) * this.textSettings.textSize; // pt to px
-        this.editorController.zoomToFontSize(pixels);
+        this.editorController.zoomToFontSize(this.textSettings.textSize);
       },
       "class": "ui-form-icon ui-form-icon-button",
       "data-tooltip": "Set text size", // TODO: translate

--- a/src-js/views-editor/src/panel-text-entry.js
+++ b/src-js/views-editor/src/panel-text-entry.js
@@ -193,6 +193,18 @@ export default class TextEntryPanel extends Panel {
       step: 1,
     });
 
+    const checkboxCleanPreview = labeledCheckbox(
+      "Use this size in clean view", // TODO: translate
+      this.textSettingsController,
+      "cleanViewSizePreview",
+      {}
+    );
+
+    formContents.push({
+      type: "single-icon",
+      element: checkboxCleanPreview,
+    });
+
     this.textSizeForm.setFieldDescriptions(formContents);
 
     this.textSizeForm.style.setProperty("--label-column-width", "20%");

--- a/src-js/views-editor/src/panel-text-entry.js
+++ b/src-js/views-editor/src/panel-text-entry.js
@@ -159,10 +159,6 @@ export default class TextEntryPanel extends Panel {
   }
 
   setupTextSizeForm() {
-    if (!this.textSettings.textSize) {
-      this.textSettings.textSize = 12;
-    }
-
     this.textSizeForm = new Form();
     const formContents = [];
 
@@ -213,9 +209,13 @@ export default class TextEntryPanel extends Panel {
   }
 
   setupTextSizeHandler() {
-    this.textSizeForm.addEventListener("doChange", (event) => {
+    this.textSettingsController.addKeyListener("textSize", (event) => {
+      this.textSizeForm.setValue("textSize", event.newValue);
+    });
+
+    this.textSizeForm.addEventListener("endChange", (event) => {
       if (event.detail.key == "textSize") {
-        this.textSettings.textSize = event.detail.value;
+        this.textSettings.textSize = this.textSizeForm.getValue("textSize");
       }
     });
   }

--- a/src-js/views-editor/src/panel-text-entry.js
+++ b/src-js/views-editor/src/panel-text-entry.js
@@ -1,6 +1,7 @@
 import * as html from "@fontra/core/html-utils.js";
 import { labeledCheckbox } from "@fontra/core/ui-utils.js";
 import { findNestedActiveElement } from "@fontra/core/utils.js";
+import { Form } from "@fontra/web-components/ui-form.js";
 import Panel from "./panel.js";
 
 export default class TextEntryPanel extends Panel {
@@ -72,6 +73,8 @@ export default class TextEntryPanel extends Panel {
     this.setupTextEntryElement();
     this.setupTextAlignElement();
     this.setupApplyKerningElement();
+    this.setupTextSizeForm();
+    this.setupTextSizeHandler();
     this.setupIntersectionObserver();
   }
 
@@ -112,6 +115,7 @@ export default class TextEntryPanel extends Panel {
               ]
             ),
             html.div({ id: "apply-kerning-checkbox" }),
+            html.div({ id: "text-size-form" }),
           ]
         ),
       ]
@@ -152,6 +156,57 @@ export default class TextEntryPanel extends Panel {
 
     const placeHolder = this.contentElement.querySelector("#apply-kerning-checkbox");
     placeHolder.replaceWith(this.applyKerningCheckBox);
+  }
+
+  setupTextSizeForm() {
+    if (!this.textSettings.textSize) {
+      this.textSettings.textSize = 12;
+    }
+
+    this.textSizeForm = new Form();
+    const formContents = [];
+
+    formContents.push({
+      type: "header",
+      label: "Text Size", // TODO: translate
+    });
+
+    const buttonSet = html.createDomElement("icon-button", {
+      "src": "/tabler-icons/resize.svg",
+      "onclick": (event) => {
+        const pixels = (4 / 3) * this.textSettings.textSize; // pt to px
+        this.editorController.zoomToFontSize(pixels);
+      },
+      "class": "ui-form-icon ui-form-icon-button",
+      "data-tooltip": "Set text size", // TODO: translate
+      "data-tooltipposition": "top",
+    });
+
+    formContents.push({
+      type: "edit-number-slider",
+      key: "textSize",
+      label: buttonSet,
+      value: this.textSettings.textSize,
+      defaultValue: 12,
+      minValue: 8,
+      maxValue: 96,
+      step: 1,
+    });
+
+    this.textSizeForm.setFieldDescriptions(formContents);
+
+    this.textSizeForm.style.setProperty("--label-column-width", "20%");
+
+    const placeHolder = this.contentElement.querySelector("#text-size-form");
+    placeHolder.replaceWith(this.textSizeForm);
+  }
+
+  setupTextSizeHandler() {
+    this.textSizeForm.addEventListener("doChange", (event) => {
+      if (event.detail.key == "textSize") {
+        this.textSettings.textSize = event.detail.value;
+      }
+    });
   }
 
   setupTextEntryElement() {

--- a/src-js/views-editor/src/scene-controller.js
+++ b/src-js/views-editor/src/scene-controller.js
@@ -92,6 +92,7 @@ export class SceneController {
       text: "",
       align: "center",
       applyKerning: true,
+      cleanViewSizePreview: false,
       editLayerName: null,
       glyphLines: [],
       fontLocationUser: {},

--- a/src-js/views-editor/src/scene-controller.js
+++ b/src-js/views-editor/src/scene-controller.js
@@ -90,6 +90,7 @@ export class SceneController {
   setupSceneSettings() {
     this.sceneSettingsController = new ObservableController({
       text: "",
+      textSize: 12,
       align: "center",
       applyKerning: true,
       cleanViewSizePreview: false,


### PR DESCRIPTION
This adds a slider in the text entry panel to pick a font size, and a button that zooms to match that size. There is also a checkbox to automatically apply that font size in clean view.

<img width="313" height="222" alt="image" src="https://github.com/user-attachments/assets/238d78d4-dadb-49c6-8ee1-c77b339eb996" />

I currently have some issues and questions about the UI:
- Even though there is a tooltip set for the button, it doesn't appear when hovering.
- The slider can't be adjusted by keyboard input until after interacting with its text input.
- The unit of the input (pt) needs to be communicated to the user somehow.
- The apply button feels too far right, even with a modified `--label-column-width`.
- I used a ui-form, since I'm trying to match the "set then apply" pattern found in the transform panel, and that uses ui-form. Is this the right approach here, or should it use a bespoke setup instead?
- Thoughts on the icon? For now I'm using `resize` as a placeholder, but other possibilities include `text-size`, `zoom-scan`, `ruler-measure-2`, and `eye`. I'm also happy to draw a new icon if needed.

Right now the UI strings are hardcoded with `// TODO: translate` comments, similar to surrounding code. Would it be better to use the translations framework, even though I can't provide translated text for other languages?

Closes #105, contributes towards #2215.