### PR TITLE
[chore] Move DefaultFormatter, NumberFormatter and OptionalNumberFormatter

### DIFF
--- a/src-js/fontra-core/src/font-info-data.js
+++ b/src-js/fontra-core/src/font-info-data.js
@@ -1,4 +1,3 @@
-import { NumberFormatter } from "@fontra/core/ui-utils.js";
 import {
   ArrayFormatter,
   BooleanFormatter,
@@ -6,6 +5,7 @@ import {
   FixedLengthArrayFormatter,
   IntegerFormatter,
   IntegerFormatterMinMax,
+  NumberFormatter,
   UnsignedIntegerFormatter,
   UnsignedNumberFormatter,
 } from "./formatters.js";

--- a/src-js/fontra-core/src/formatters.js
+++ b/src-js/fontra-core/src/formatters.js
@@ -3,6 +3,42 @@ export function isString(value) {
   return typeof value === "string" || value instanceof String;
 }
 
+export const DefaultFormatter = {
+  toString: (value) => (value !== undefined && value !== null ? value.toString() : ""),
+  fromString: (value) => {
+    return {
+      value: value,
+    };
+  },
+};
+
+export const NumberFormatter = {
+  toString: (value) => value.toString(),
+  fromString: (value) => {
+    const number = Number(value);
+    if (isNaN(number) || !value) {
+      return { error: "not a number" };
+    } else {
+      return { value: number };
+    }
+  },
+};
+
+export const OptionalNumberFormatter = {
+  toString: (value) => (value != undefined ? value.toString() : ""),
+  fromString: (value) => {
+    if (!value) {
+      return { value: null };
+    }
+    const number = Number(value);
+    if (isNaN(number)) {
+      return { error: "not a number" };
+    } else {
+      return { value: number };
+    }
+  },
+};
+
 export const IntegerFormatter = {
   toString: (value) => value.toString(),
   fromString: (

--- a/src-js/fontra-core/src/ui-utils.js
+++ b/src-js/fontra-core/src/ui-utils.js
@@ -1,4 +1,5 @@
 import { PopupMenu } from "@fontra/web-components/popup-menu.js";
+import { DefaultFormatter } from "./formatters.js";
 import * as html from "./html-utils.js";
 import { uniqueID, zip } from "./utils.js";
 
@@ -234,44 +235,6 @@ export function labeledPopupSelect(label, controller, key, popupItems, options) 
   const inputElement = popupSelect(controller, key, popupItems, options);
   return [labelForElement(label, inputElement, options), inputElement];
 }
-
-export const DefaultFormatter = {
-  toString: (value) => (value !== undefined && value !== null ? value.toString() : ""),
-  fromString: (value) => {
-    return {
-      value: value,
-    };
-  },
-};
-
-// TODO: Move to formatters.js
-// (As a follow up, because of lots of dependencies)
-export const NumberFormatter = {
-  toString: (value) => value.toString(),
-  fromString: (value) => {
-    const number = Number(value);
-    if (isNaN(number) || !value) {
-      return { error: "not a number" };
-    } else {
-      return { value: number };
-    }
-  },
-};
-
-export const OptionalNumberFormatter = {
-  toString: (value) => (value != undefined ? value.toString() : ""),
-  fromString: (value) => {
-    if (!value) {
-      return { value: null };
-    }
-    const number = Number(value);
-    if (isNaN(number)) {
-      return { error: "not a number" };
-    } else {
-      return { value: number };
-    }
-  },
-};
 
 export function checkboxListCell(item, colDesc) {
   const value = item[colDesc.key];

--- a/src-js/fontra-webcomponents/src/custom-data-list.js
+++ b/src-js/fontra-webcomponents/src/custom-data-list.js
@@ -1,8 +1,9 @@
+import { DefaultFormatter } from "@fontra/core/formatters.js";
 import * as html from "@fontra/core/html-utils.js";
 import { SimpleElement } from "@fontra/core/html-utils.js";
 import { translate } from "@fontra/core/localization.js";
 import { ObservableController } from "@fontra/core/observable-object.js";
-import { DefaultFormatter, labeledTextInput } from "@fontra/core/ui-utils.js";
+import { labeledTextInput } from "@fontra/core/ui-utils.js";
 import { zip } from "@fontra/core/utils.js";
 import { dialogSetup } from "@fontra/web-components/modal-dialog.js";
 import { UIList } from "@fontra/web-components/ui-list.js";

--- a/src-js/fontra-webcomponents/src/ui-list.js
+++ b/src-js/fontra-webcomponents/src/ui-list.js
@@ -1,6 +1,6 @@
+import { DefaultFormatter } from "@fontra/core/formatters.js";
 import * as html from "@fontra/core/html-utils.js";
 import { UnlitElement } from "@fontra/core/html-utils.js";
-import { DefaultFormatter } from "@fontra/core/ui-utils.js";
 import { message } from "@fontra/web-components/modal-dialog.js";
 import { themeColorCSS } from "./theme-support.js";
 

--- a/src-js/views-editor/src/panel-designspace-navigation.js
+++ b/src-js/views-editor/src/panel-designspace-navigation.js
@@ -47,7 +47,7 @@ import { showMenu } from "@fontra/web-components/menu-panel.js";
 import { dialog, dialogSetup, message } from "@fontra/web-components/modal-dialog.js";
 import { Accordion } from "@fontra/web-components/ui-accordion.js";
 
-import { NumberFormatter } from "@fontra/core/ui-utils.js";
+import { NumberFormatter } from "@fontra/core/formatters.js";
 import Panel from "./panel.js";
 
 const FONTRA_STATUS_KEY = "fontra.development.status";

--- a/src-js/views-fontinfo/src/panel-axes.js
+++ b/src-js/views-fontinfo/src/panel-axes.js
@@ -1,12 +1,11 @@
 import { recordChanges } from "@fontra/core/change-recorder.js";
+import { NumberFormatter, OptionalNumberFormatter } from "@fontra/core/formatters.js";
 import * as html from "@fontra/core/html-utils.js";
 import { addStyleSheet } from "@fontra/core/html-utils.js";
 import { translate } from "@fontra/core/localization.js";
 import { ObservableController } from "@fontra/core/observable-object.js";
 import * as svg from "@fontra/core/svg-utils.js";
 import {
-  NumberFormatter,
-  OptionalNumberFormatter,
   checkboxListCell,
   labeledTextInput,
   setupSortableList,

--- a/src-js/views-fontinfo/src/panel-sources.js
+++ b/src-js/views-fontinfo/src/panel-sources.js
@@ -5,13 +5,12 @@ import {
 import { recordChanges } from "@fontra/core/change-recorder.js";
 import { ensureDenseSource } from "@fontra/core/font-controller.js";
 import { openTypeSettingsFontSourcesLevel } from "@fontra/core/font-info-data.js";
+import { NumberFormatter, OptionalNumberFormatter } from "@fontra/core/formatters.js";
 import * as html from "@fontra/core/html-utils.js";
 import { addStyleSheet } from "@fontra/core/html-utils.js";
 import { translate } from "@fontra/core/localization.js";
 import { ObservableController } from "@fontra/core/observable-object.js";
 import {
-  NumberFormatter,
-  OptionalNumberFormatter,
   labelForElement,
   labeledCheckbox,
   labeledTextInput,


### PR DESCRIPTION
Move `DefaultFormatter`, `NumberFormatter` and `OptionalNumberFormatter` to formatters.js, where they belong.