### PR TITLE
Select (local) guidelines along line

### DIFF
--- a/src-js/views-editor/src/scene-model.js
+++ b/src-js/views-editor/src/scene-model.js
@@ -789,7 +789,7 @@ export class SceneModel {
       const distance = Math.abs(
         Math.cos(angle) * (guideline.y - y) - Math.sin(angle) * (guideline.x - x)
       );
-      if (distance < size) {
+      if (distance < size / 2) {
         return new Set([`guideline/${i}`]);
       }
     }

--- a/src-js/views-editor/src/scene-model.js
+++ b/src-js/views-editor/src/scene-model.js
@@ -777,13 +777,19 @@ export class SceneModel {
     const guidelines = positionedGlyph.glyph.guidelines;
     const x = point.x - positionedGlyph.x;
     const y = point.y - positionedGlyph.y;
-    const selRect = centeredRect(x, y, size);
     const indices = parsedCurrentSelection
       ? parsedCurrentSelection.guideline || []
       : [...range(guidelines.length)];
     for (const i of reversed(indices)) {
       const guideline = guidelines[i];
-      if (guideline && pointInRect(guideline.x, guideline.y, selRect)) {
+      if (!guideline) {
+        continue;
+      }
+      const angle = (guideline.angle * Math.PI) / 180;
+      const distance = Math.abs(
+        Math.cos(angle) * (guideline.y - y) - Math.sin(angle) * (guideline.x - x)
+      );
+      if (distance < size) {
         return new Set([`guideline/${i}`]);
       }
     }


### PR DESCRIPTION
Currently, guidlines can only be selected at their anchor point. This PR allows clicking anywhere on the guideline.