### PR TITLE
Add expression evaluation to numeric metrics fields in selection info

### DIFF
--- a/src-js/fontra-core/src/simple-compute.js
+++ b/src-js/fontra-core/src/simple-compute.js
@@ -350,3 +350,23 @@ export function compute(expression, functions, variables) {
 
   return Number(result);
 }
+
+export function nameCapture(namesObject, getter = null) {
+  if (!getter) {
+    getter = (namesObject, prop) => namesObject[prop];
+  }
+  const names = new Set();
+  const namespace = new Proxy(
+    {},
+    {
+      get(subject, prop) {
+        if (namesObject[prop] !== undefined) {
+          names.add(prop);
+          return getter(namesObject, prop);
+        }
+      },
+    }
+  );
+
+  return { names, namespace };
+}

--- a/src-js/fontra-core/src/simple-compute.js
+++ b/src-js/fontra-core/src/simple-compute.js
@@ -1,0 +1,352 @@
+/**
+ * Adapted from
+ * The expression calculator
+ * from https://github.com/malikzh/computejs
+ *
+ * @author Malik Zharykov <cmalikz.h@gmail.com>
+ * @license MIT
+ *
+ * Original Lincense:
+ *
+ * MIT License
+ *
+ * Copyright (c) 2019 Malik Zharykov
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+export class SimpleComputeError extends Error {}
+
+export function compute(expression, functions, variables) {
+  functions = functions || {};
+  variables = variables || {};
+
+  if (typeof expression !== "string") {
+    throw new TypeError("compute `expression` argument not a string");
+  }
+
+  if (!expression) {
+    throw new SimpleComputeError("Empty expression given");
+  }
+
+  // We perform lexical analysis
+  let tokens = [];
+  let i = 0;
+  let tmp = "";
+  let binaryOperators = ["SUM", "SUB", "MUL", "DIV", "MOD", "POW"];
+
+  for (;;) {
+    tmp = "";
+
+    if (expression.charAt(i) == "") break;
+
+    switch (expression.charAt(i)) {
+      case "*":
+        tokens.push({ token: "MUL" });
+        ++i;
+        break;
+      case "/":
+        tokens.push({ token: "DIV" });
+        ++i;
+        break;
+      case "+":
+        tokens.push({ token: "SUM" });
+        ++i;
+        break;
+      case "-":
+        tokens.push({ token: "SUB" });
+        ++i;
+        break;
+      case "%":
+        tokens.push({ token: "MOD" });
+        ++i;
+        break;
+      case "^":
+        tokens.push({ token: "POW" });
+        ++i;
+        break;
+      case "(":
+        tokens.push({ token: "LBR" });
+        ++i;
+        break;
+      case ")":
+        tokens.push({ token: "RBR" });
+        ++i;
+        break;
+      case ",":
+        tokens.push({ token: "COMMA" });
+        ++i;
+        break;
+
+      case " ":
+      case "\r":
+      case "\n":
+        ++i;
+        continue;
+
+      default:
+        // Processing number + number with a dot
+        while (
+          /^\d$/.test(expression.charAt(i)) ||
+          (tmp.length > 0 && expression.charAt(i) == "." && tmp.indexOf(".") == -1) ||
+          (tmp.length > 0 && expression.charAt(i) == "," && tmp.indexOf(",") == -1)
+        ) {
+          tmp += expression.charAt(i);
+          ++i;
+        }
+
+        // If tmp is not empty, then we got a number
+        if (tmp.length > 0) {
+          tokens.push({ token: "NUMBER", value: tmp });
+          continue;
+        }
+
+        // Execution will only get here if the symbol is not an operator or a number, let's check if it is a variable
+
+        for (const allowHyphen of [true, false]) {
+          // The first time we allow hyphens in the variable name, but if the variable
+          // does not exist, we fall back to not allowing hyphens. This way we can
+          // both match glyph names containing hyphens, as well as do `a-b` where a and
+          // b are distinct variables or constants.
+          const nonFirstRegex = allowHyphen ? /^[\d\-]$/i : /^[\d]$/i;
+          let tmptmp = tmp;
+          let tmp_i = i;
+          while (
+            /^[a-z_\.]$/i.test(expression.charAt(tmp_i)) ||
+            (tmptmp.length > 0 && nonFirstRegex.test(expression.charAt(tmp_i)))
+          ) {
+            tmptmp += expression.charAt(tmp_i);
+            ++tmp_i;
+          }
+          if (!allowHyphen || (tmptmp.length > 0 && variables[tmptmp] !== undefined)) {
+            tmp = tmptmp;
+            i = tmp_i;
+            break;
+          }
+        }
+
+        if (tmp.length > 0) {
+          tokens.push({ token: "VARIABLE", value: tmp });
+          continue;
+        }
+
+        // If it is neither this nor that, we give an error
+        throw new SimpleComputeError('Invalid symbol: "' + expression.charAt(i) + '"');
+    }
+  }
+
+  // Next, after tokenization, we perform syntactic analysis and immediately calculate
+  // The analysis is implemented by a simple LL parser
+  const Parser = {
+    BinaryOperator: function (operators, ValueFunc, CalcFunc, right_assoc) {
+      let result = ValueFunc();
+
+      if (result === false) {
+        return false;
+      }
+
+      if (!right_assoc) {
+        // Left-associative computation
+        while (i < tokens.length) {
+          if (operators.indexOf(tokens[i].token) == -1) {
+            return result;
+          }
+
+          let op = tokens[i++].token;
+
+          let right = this.MulDivModValue();
+
+          if (right === false || right === null) {
+            return right;
+          }
+
+          result = Number(CalcFunc(op, result, right));
+        }
+      } else {
+        // Right-associative computation
+        if (operators.indexOf(tokens[i].token) == -1) {
+          return result;
+        }
+
+        let op = tokens[i++].token;
+
+        let right = this.BinaryOperator(ValueFunc(), CalcFunc(), right_assoc);
+
+        if (right === false || right === null) {
+          return right;
+        }
+
+        result = Number(CalcFunc(op, result, right));
+      }
+
+      return result;
+    },
+
+    ScalarValue: function () {
+      let va = false;
+
+      if (tokens[i].token === "NUMBER") {
+        return Number(tokens[i++].value.replace(",", "."));
+      } else if (tokens[i].token === "SUM") {
+        ++i;
+        return this.BracketValue();
+      } else if (tokens[i].token === "SUB") {
+        ++i;
+        va = this.BracketValue();
+
+        if (va === false || va === null) {
+          return va;
+        }
+
+        return -va;
+      } else if (tokens[i].token === "VARIABLE") {
+        if (variables[tokens[i].value] === undefined) {
+          throw new SimpleComputeError(`Undefined name: '${tokens[i].value}'`);
+        }
+        return Number(variables[tokens[i++].value]);
+      } else {
+        return false;
+      }
+    },
+
+    FuncValue: function () {
+      if (
+        !(
+          i + 1 < tokens.length &&
+          tokens[i].token === "VARIABLE" &&
+          tokens[i + 1].token === "LBR"
+        )
+      ) {
+        return this.ScalarValue();
+      }
+
+      let funcname = tokens[i].value;
+
+      i += 2; // skip funcname(
+
+      let args = [];
+
+      while (true) {
+        if (tokens[i].token === "RBR") {
+          ++i;
+          break;
+        }
+
+        let arg = this.SumSubValue();
+
+        if (arg === false || arg === null) {
+          return arg;
+        }
+
+        args.push(arg);
+
+        if (i >= tokens.length) {
+          return false;
+        }
+
+        if (tokens[i].token === "COMMA") {
+          ++i;
+          continue;
+        }
+      }
+
+      if (functions[funcname] === undefined) {
+        throw new SimpleComputeError("Undefined function call: " + funcname + "()");
+      }
+
+      return Number(functions[funcname](args));
+    },
+
+    BracketValue: function () {
+      if (i >= tokens.length) {
+        return false;
+      }
+
+      if (tokens[i].token !== "LBR") {
+        return this.FuncValue();
+      }
+
+      ++i;
+
+      let result = this.SumSubValue();
+
+      if (i >= tokens.length || tokens[i].token !== "RBR") {
+        return false;
+      }
+
+      ++i;
+
+      return result;
+    },
+
+    PowValue: function () {
+      return this.BinaryOperator(
+        ["POW"],
+        () => this.BracketValue(),
+        function (op, result, right) {
+          return op === "POW" ? Math.pow(result, right) : 0;
+        },
+        false
+      );
+    },
+
+    MulDivModValue: function () {
+      return this.BinaryOperator(
+        ["MUL", "DIV", "MOD"],
+        () => this.PowValue(),
+        function (op, result, right) {
+          return op === "MUL"
+            ? result * right
+            : op === "DIV"
+            ? result / right
+            : op === "MOD"
+            ? result % right
+            : 0;
+        },
+        false
+      );
+    },
+
+    SumSubValue: function () {
+      return this.BinaryOperator(
+        ["SUM", "SUB"],
+        () => this.MulDivModValue(),
+        function (op, result, right) {
+          return op === "SUM" ? result + right : op === "SUB" ? result - right : 0;
+        },
+        false
+      );
+    },
+  };
+
+  i = 0;
+  const result = Parser.SumSubValue();
+
+  if (i !== tokens.length && result !== null) {
+    throw new SimpleComputeError(
+      "Unexpected token: " + (i >= tokens.length ? "END" : tokens[i].token)
+    );
+  }
+
+  if (result === false || result === null) {
+    throw new SimpleComputeError("unknown error");
+  }
+
+  return Number(result);
+}

--- a/src-js/fontra-core/src/simple-compute.js
+++ b/src-js/fontra-core/src/simple-compute.js
@@ -128,7 +128,7 @@ export function compute(expression, functions, variables) {
           let tmptmp = tmp;
           let tmp_i = i;
           while (
-            /^[a-z_\.]$/i.test(expression.charAt(tmp_i)) ||
+            /^[a-z_\.!]$/i.test(expression.charAt(tmp_i)) ||
             (tmptmp.length > 0 && nonFirstRegex.test(expression.charAt(tmp_i)))
           ) {
             tmptmp += expression.charAt(tmp_i);
@@ -360,9 +360,10 @@ export function nameCapture(namesObject, getter = null) {
     {},
     {
       get(subject, prop) {
-        if (namesObject[prop] !== undefined) {
+        const name = getter(namesObject, prop);
+        if (name !== undefined) {
           names.add(prop);
-          return getter(namesObject, prop);
+          return name;
         }
       },
     }

--- a/src-js/fontra-core/tests/test-simple-compute.js
+++ b/src-js/fontra-core/tests/test-simple-compute.js
@@ -66,13 +66,13 @@ describe("simple-compute", () => {
     },
     {
       expression: "a + b",
-      variables: { a: 12, b: 1 },
+      variables: { a: 12, b: 1, c: 4, d: 43 },
       expectedResult: 13,
       expectedNames: new Set(["a", "b"]),
     },
     {
       expression: "a + b",
-      variables: { a: 12, b: 1 },
+      variables: { a: [1, 2, 3], b: [4, 5, 6] },
       expectedResult: 2,
       expectedNames: new Set(["a", "b"]),
       getter: (namesObject, prop) => 1,

--- a/src-js/fontra-core/tests/test-simple-compute.js
+++ b/src-js/fontra-core/tests/test-simple-compute.js
@@ -1,4 +1,4 @@
-import { compute } from "@fontra/core/simple-compute.js";
+import { compute, nameCapture } from "@fontra/core/simple-compute.js";
 import { expect } from "chai";
 import { parametrize } from "./test-support.js";
 
@@ -49,6 +49,47 @@ describe("simple-compute", () => {
       expect(compute(testItem.expression, undefined, testItem.variables)).to.equal(
         testItem.expectedResult
       );
+    }
+  });
+
+  const nameCaptureTestData = [
+    {
+      expression: "a",
+      variables: { a: 12 },
+      expectedResult: 12,
+      expectedNames: new Set(["a"]),
+    },
+    {
+      expression: "a",
+      variables: {},
+      expectedException: "Undefined name: 'a'",
+    },
+    {
+      expression: "a + b",
+      variables: { a: 12, b: 1 },
+      expectedResult: 13,
+      expectedNames: new Set(["a", "b"]),
+    },
+    {
+      expression: "a + b",
+      variables: { a: 12, b: 1 },
+      expectedResult: 2,
+      expectedNames: new Set(["a", "b"]),
+      getter: (namesObject, prop) => 1,
+    },
+  ];
+
+  parametrize("compute + nameCapture", nameCaptureTestData, (testItem) => {
+    const { names, namespace } = nameCapture(testItem.variables, testItem.getter);
+    if (testItem.expectedException) {
+      expect(() => compute(testItem.expression, undefined, namespace)).to.throw(
+        testItem.expectedException
+      );
+    } else {
+      expect(compute(testItem.expression, undefined, namespace)).to.equal(
+        testItem.expectedResult
+      );
+      expect(names).to.deep.equal(testItem.expectedNames);
     }
   });
 });

--- a/src-js/fontra-core/tests/test-simple-compute.js
+++ b/src-js/fontra-core/tests/test-simple-compute.js
@@ -1,0 +1,54 @@
+import { compute } from "@fontra/core/simple-compute.js";
+import { expect } from "chai";
+import { parametrize } from "./test-support.js";
+
+describe("simple-compute", () => {
+  const computeTestData = [
+    { expression: 12, expectedException: "compute `expression` argument not a string" },
+    { expression: "", expectedException: "Empty expression given" },
+    { expression: "a", variables: {}, expectedException: "Undefined name: 'a'" },
+    { expression: "12", expectedResult: 12 },
+    { expression: "1.2", expectedResult: 1.2 },
+    { expression: "1,2", expectedResult: 1.2 },
+    { expression: "1,2+4", expectedResult: 5.2 },
+    { expression: "-12", expectedResult: -12 },
+    { expression: "0 - -12", expectedResult: 12 },
+    { expression: "12*3", expectedResult: 36 },
+    { expression: "12 * 3", expectedResult: 36 },
+    { expression: "2 * (3 + 1)", expectedResult: 8 },
+    { expression: "2 * 3 + 1", expectedResult: 7 },
+    { expression: "a", variables: { a: 3 }, expectedResult: 3 },
+    { expression: "-a", variables: { a: 3 }, expectedResult: -3 },
+    { expression: "aa23", variables: { aa23: 4 }, expectedResult: 4 },
+    { expression: "a.alt", variables: { "a.alt": 4 }, expectedResult: 4 },
+    { expression: "a-b.2", variables: { "a-b.2": 4 }, expectedResult: 4 },
+    { expression: "a-2", variables: { a: 4 }, expectedResult: 2 },
+    { expression: "a-b", variables: { "a-b": 4 }, expectedResult: 4 },
+    { expression: "a-b", variables: { a: 4, b: 1 }, expectedResult: 3 },
+    { expression: "a/2", variables: { a: 3 }, expectedResult: 1.5 },
+    { expression: "((a))", variables: { a: 3 }, expectedResult: 3 },
+    { expression: "(a)", variables: { a: 3 }, expectedResult: 3 },
+    { expression: "(a", variables: { a: 3 }, expectedException: "unknown error" },
+    {
+      expression: "*",
+      variables: { a: 3 },
+      expectedException: "Unexpected token: MUL",
+    },
+    {
+      expression: "1 *",
+      expectedException: "unknown error",
+    },
+  ];
+
+  parametrize("compute", computeTestData, (testItem) => {
+    if (testItem.expectedException) {
+      expect(() =>
+        compute(testItem.expression, undefined, testItem.variables)
+      ).to.throw(testItem.expectedException);
+    } else {
+      expect(compute(testItem.expression, undefined, testItem.variables)).to.equal(
+        testItem.expectedResult
+      );
+    }
+  });
+});

--- a/src-js/fontra-core/tests/test-simple-compute.js
+++ b/src-js/fontra-core/tests/test-simple-compute.js
@@ -18,6 +18,7 @@ describe("simple-compute", () => {
     { expression: "2 * (3 + 1)", expectedResult: 8 },
     { expression: "2 * 3 + 1", expectedResult: 7 },
     { expression: "a", variables: { a: 3 }, expectedResult: 3 },
+    { expression: "a!", variables: { "a!": 3 }, expectedResult: 3 },
     { expression: "-a", variables: { a: 3 }, expectedResult: -3 },
     { expression: "aa23", variables: { aa23: 4 }, expectedResult: 4 },
     { expression: "a.alt", variables: { "a.alt": 4 }, expectedResult: 4 },

--- a/src-js/views-editor/src/panel-selection-info.js
+++ b/src-js/views-editor/src/panel-selection-info.js
@@ -2,6 +2,7 @@ import { recordChanges } from "@fontra/core/change-recorder.js";
 import * as html from "@fontra/core/html-utils.js";
 import { translate } from "@fontra/core/localization.js";
 import { rectFromPoints, rectSize, unionRect } from "@fontra/core/rectangle.js";
+import { compute, nameCapture } from "@fontra/core/simple-compute.js";
 import { getDecomposedIdentity } from "@fontra/core/transform.js";
 import {
   assert,
@@ -787,31 +788,51 @@ export default class SelectionInfoPanel extends Panel {
       return value;
     }
 
-    const referencedGlyphName = expression.trim();
-    if (!this.fontController.hasGlyph(referencedGlyphName)) {
-      return { error: `glyph ${referencedGlyphName} not found` };
+    const { names, namespace } = nameCapture(
+      this.fontController.glyphMap,
+      (nameObject, glyphName) => (nameObject[glyphName] ? 1 : undefined)
+    );
+
+    try {
+      const dummyResult = compute(expression, undefined, namespace);
+    } catch (e) {
+      return { error: e.message };
     }
 
     const { mainLayerName, locations } = this._getEditingLocations(varGlyphController);
-    const metrics = {};
-    const referencedGlyph = await this.fontController.getGlyph(referencedGlyphName);
-    for (const [layerName, location] of Object.entries(locations)) {
-      const getGlyphFunc = this.fontController.getGlyph.bind(this.fontController);
-      const instanceController = await referencedGlyph.instantiateController(
-        location,
-        layerName,
-        getGlyphFunc
-      );
-      metrics[layerName] = {
-        xAdvance: instanceController.xAdvance,
-        leftMargin: instanceController.leftMargin,
-        rightMargin: instanceController.rightMargin,
-      };
+
+    const layerVariables = {};
+    for (const referencedGlyphName of names) {
+      const referencedGlyph = await this.fontController.getGlyph(referencedGlyphName);
+      for (const [layerName, location] of Object.entries(locations)) {
+        const getGlyphFunc = this.fontController.getGlyph.bind(this.fontController);
+        const instanceController = await referencedGlyph.instantiateController(
+          location,
+          layerName,
+          getGlyphFunc
+        );
+        if (!layerVariables[layerName]) {
+          layerVariables[layerName] = {};
+        }
+        layerVariables[layerName][referencedGlyphName] =
+          instanceController[metricProperty];
+      }
     }
 
     return {
-      getValue: (layerName) => metrics[layerName][metricProperty],
-      value: metrics[mainLayerName][metricProperty],
+      getValue: (layerName) => {
+        try {
+          return ensureFiniteNumber(
+            compute(expression, undefined, layerVariables[layerName])
+          );
+        } catch (e) {
+          console.error(e);
+        }
+        return 0;
+      },
+      value: ensureFiniteNumber(
+        compute(expression, undefined, layerVariables[mainLayerName])
+      ),
     };
   }
 
@@ -966,6 +987,14 @@ function makeCodePointsString(codePoints) {
         `${makeUPlusStringFromCodePoint(code)}\u00A0(${getCharFromCodePoint(code)})`
     )
     .join(" ");
+}
+
+function ensureFiniteNumber(value, fallback = 0) {
+  if (isNaN(value) || Math.abs(value) === Infinity) {
+    console.log(`bad expression result: ${value}, fall back to 0`);
+    value = fallback;
+  }
+  return value;
 }
 
 customElements.define("panel-selection-info", SelectionInfoPanel);


### PR DESCRIPTION
This fixes #2236.

This introduces an inline calculator in the metrics fields in the selection info panel. It evaluates to a concrete value once you type enter or leave the field.

It supports most common operators and parentheses. 

Additionally it allows to use glyph names as variable names, to refer to the metrics value for that glyph. For example, if you type `E` in the advance width field, it will take the advance width of the `E` glyph and put that in the field. Likewise, if you type `E` in the left sidebearing field, it will put the left sidebearing value from the `E` glyph in the field. But glyph names can also be used as part of an expression, for example `E + 10`.

There is a special notation for the *opposite* sidebearing, by adding a `!` to the glyph name: if in the _left_ sidebearing field you use `E!` in the expression, it will take the _right_ sidebearing from `E`.