### PR TITLE
Don't share mutable objects into change objects, and from change objects

### DIFF
--- a/src-js/fontra-core/src/changes.js
+++ b/src-js/fontra-core/src/changes.js
@@ -1,3 +1,5 @@
+import { deepCopyObject } from "./utils.js";
+
 export class ChangeCollector {
   constructor(parentCollector, path) {
     this._parentCollector = parentCollector;
@@ -73,12 +75,12 @@ export class ChangeCollector {
 
   addChange(func, ...args) {
     this._ensureForwardChanges();
-    this._forwardChanges.push({ f: func, a: args });
+    this._forwardChanges.push({ f: func, a: deepCopyObject(args) });
   }
 
   addRollbackChange(func, ...args) {
     this._ensureRollbackChanges();
-    this._rollbackChanges.splice(0, 0, { f: func, a: args });
+    this._rollbackChanges.splice(0, 0, { f: func, a: deepCopyObject(args) });
   }
 
   subCollector(...path) {
@@ -310,7 +312,7 @@ export function applyChange(subject, change, subjectClassDef) {
         itemCast = classDef.cast.bind(classDef);
       }
     }
-    changeFunc(subject, itemCast || noopItemCast, ...args);
+    changeFunc(subject, itemCast || noopItemCast, ...deepCopyObject(args));
   }
 
   for (const subChange of children) {

--- a/src-js/fontra-core/tests/test-change-recorder.js
+++ b/src-js/fontra-core/tests/test-change-recorder.js
@@ -266,6 +266,30 @@ const testData = [
       a: [2],
     },
   },
+  {
+    testName: "new path then append to it",
+    subject: {},
+    operation: (subject) => {
+      subject.list = [];
+      subject.list.push(123);
+    },
+    expectedSubject: {
+      list: [123],
+    },
+    expectedChange: {
+      c: [
+        {
+          a: ["list", [123]],
+          f: "=",
+        },
+        {
+          a: [0, 123],
+          f: "+",
+          p: ["list"],
+        },
+      ],
+    },
+  },
 ];
 
 describe("recordChanges tests", () => {
@@ -292,6 +316,11 @@ describe("recordChanges tests", () => {
         expect(subject).to.deep.equal(testCase.subject);
         applyChange(subject, changes.change);
         expect(subject).to.deep.equal(testCase.expectedSubject);
+
+        // Apply the change to the subject from scratch
+        const subject2 = copyObject(testCase.subject);
+        applyChange(subject2, changes.change);
+        expect(subject2).to.deep.equal(testCase.expectedSubject);
       }
     });
   }

--- a/src-js/fontra-core/tests/test-change-recorder.js
+++ b/src-js/fontra-core/tests/test-change-recorder.js
@@ -279,7 +279,7 @@ const testData = [
     expectedChange: {
       c: [
         {
-          a: ["list", [123]],
+          a: ["list", []],
           f: "=",
         },
         {

--- a/src-js/fontra-core/tests/test-changes.js
+++ b/src-js/fontra-core/tests/test-changes.js
@@ -1,4 +1,3 @@
-import { deepCopyObject } from "@fontra/core/utils.js";
 import { expect } from "chai";
 
 import {
@@ -10,6 +9,7 @@ import {
   matchChangePath,
   matchChangePattern,
 } from "@fontra/core/changes.js";
+import { deepCopyObject } from "@fontra/core/utils.js";
 import { getTestData } from "./test-support.js";
 
 describe("applyChange Tests", () => {
@@ -25,8 +25,11 @@ describe("applyChange Tests", () => {
 
     const subject = deepCopyObject(inputData[inputDataName]);
     it(`applyChange Test #${i} -- ${testName}`, () => {
-      applyChange(subject, test["change"]);
+      const change = deepCopyObject(test["change"]);
+      applyChange(subject, change);
       expect(subject).to.deep.equal(expectedData);
+      // ensure the change object wasn't modified itself
+      expect(change).to.deep.equal(test["change"]);
     });
   }
 });

--- a/src/fontra/core/changes.py
+++ b/src/fontra/core/changes.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from typing import (
     Any,
     Callable,
@@ -113,7 +114,7 @@ def _applyChange(subject: Any, change: dict[str, Any], *, itemCast=None) -> None
 
     if functionName is not None:
         changeFunc: Callable[..., None] = changeFunctions[functionName]
-        args = change.get("a", [])
+        args = deepcopy(change.get("a", []))
         if functionName in baseChangeFunctions:
             if itemCast is None and args:
                 itemCast = getItemCast(subject, args[0], "type")

--- a/test-common/apply-change-test-data.json
+++ b/test-common/apply-change-test-data.json
@@ -40,6 +40,24 @@
         ]
       },
       "expectedData": [1, [222, 22, 444], 3]
+    },
+    {
+      "testName": "add mutable item, then modify",
+      "inputDataName": "simpleArray",
+      "change": {
+        "c": [
+          {
+            "a": [2, []],
+            "f": "="
+          },
+          {
+            "a": [0, 123],
+            "f": "+",
+            "p": [2]
+          }
+        ]
+      },
+      "expectedData": [1, 2, [123]]
     }
   ]
 }

--- a/test-py/test_changes.py
+++ b/test-py/test_changes.py
@@ -40,9 +40,11 @@ applyChangeTestData = [
     "testName, inputDataName, change, expectedData", applyChangeTestData
 )
 def test_applyChange(testName, inputDataName, change, expectedData):
+    change2 = deepcopy(change)
     subject = deepcopy(applyChangeTestInputData[inputDataName])
     applyChange(subject, change)
     assert subject == expectedData
+    assert change == change2
 
 
 @pytest.mark.parametrize(

--- a/test-py/test_changes.py
+++ b/test-py/test_changes.py
@@ -44,6 +44,7 @@ def test_applyChange(testName, inputDataName, change, expectedData):
     subject = deepcopy(applyChangeTestInputData[inputDataName])
     applyChange(subject, change)
     assert subject == expectedData
+    # ensure the change object wasn't modified itself
     assert change == change2
 
 


### PR DESCRIPTION
This fixes #2241.

The root cause was confusion regarding mutable objects that got shared in/via change objects that should not have been shared. The fix should be thorough and watertight, but might come at the expense of some performance, although I doubt this will be noticable in most common cases.